### PR TITLE
Programs reform

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,6 +213,7 @@ pub mod framebuffer;
 pub mod index_buffer;
 pub mod pixel_buffer;
 pub mod macros;
+pub mod program;
 pub mod render_buffer;
 pub mod uniforms;
 pub mod vertex_buffer;
@@ -222,7 +223,6 @@ mod buffer;
 mod context;
 mod fbo;
 mod ops;
-mod program;
 mod sync;
 mod vertex_array_object;
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -322,6 +322,11 @@ impl Program {
         self.frag_data_locations.lock().unwrap().insert(name.to_string(), location);
         location
     }
+
+    /// Returns informations about a uniform variable, if it exists.
+    pub fn get_uniform(&self, name: &str) -> Option<&Uniform> {
+        self.uniforms.get(name)
+    }
 }
 
 impl fmt::Show for Program {

--- a/src/program.rs
+++ b/src/program.rs
@@ -42,6 +42,12 @@ pub enum ProgramCreationInput<'a> {
     }
 }
 
+impl<'a> IntoProgramCreationInput<'a> for ProgramCreationInput<'a> {
+    fn into_program_creation_input(self) -> ProgramCreationInput<'a> {
+        self
+    }
+}
+
 /// Traits for objects that can be turned into `ProgramCreationInput`.
 pub trait IntoProgramCreationInput<'a> {
     /// Builds the `ProgramCreationInput`.


### PR DESCRIPTION
 - [x] Make the `program` module public
 - [ ] ~~Allow passing binary representation to create a program.~~
 - [ ] ~~Allow obtaining the binary representation of a program.~~
 - [ ] ~~Make the `Attribute` struct public.~~
 - [x] Make the `Uniform` struct public. (#232)
 - [ ] ~~Allow passing informations about attributes and uniforms alongside with the source code.~~
 - [ ] ~~Add methods to `Program` to obtain informations about attributes and uniforms.~~
 - [ ] ~~Add doc-comments to the `program` module.~~

Close #35