### PR TITLE
Make MultiOutputFrameBuffer usable

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -254,6 +254,9 @@ pub struct Capabilities {
 
     /// Maximum width and height of `glViewport`.
     pub max_viewport_dims: (gl::types::GLint, gl::types::GLint),
+
+    /// Maximum number of elements that can be passed with `glDrawBuffers`.
+    pub max_draw_buffers: gl::types::GLint,
 }
 
 impl Context {
@@ -659,6 +662,12 @@ fn get_capabilities(gl: &gl::Gl, version: &GlVersion, extensions: &ExtensionsLis
             let mut val: [gl::types::GLint; 2] = [ 0, 0 ];
             gl.GetIntegerv(gl::MAX_VIEWPORT_DIMS, val.as_mut_ptr());
             (val[0], val[1])
+        },
+
+        max_draw_buffers: unsafe {
+            let mut val = 1;
+            gl.GetIntegerv(gl::MAX_DRAW_BUFFERS, &mut val);
+            val
         },
 
     }

--- a/tests/framebuffer.rs
+++ b/tests/framebuffer.rs
@@ -123,3 +123,75 @@ fn depth_texture2d() {
 
     display.assert_no_error();
 }
+
+#[test]
+fn multioutput() {
+    use std::iter;
+
+    let display = support::build_display();
+    let (vb, ib) = support::build_rectangle_vb_ib(&display);
+
+    let program = match glium::Program::from_source(&display,
+        "
+            #version 110
+
+            attribute vec2 position;
+
+            void main() {
+                gl_Position = vec4(position, 0.0, 1.0);
+            }
+        ",
+        "
+            #version 330
+
+            out vec4 color1;
+            out vec4 color2;
+
+            void main() {
+                color1 = vec4(1.0, 1.0, 1.0, 1.0);
+                color2 = vec4(1.0, 0.0, 0.0, 1.0);
+            }
+        ",
+        None)
+    {
+        Err(glium::CompilationError(_)) => return,
+        Ok(p) => p,
+        e => e.unwrap()
+    };
+
+    // building two empty color attachments
+    let color1 = glium::Texture2d::new_empty(&display,
+                                             glium::texture::UncompressedFloatFormat::U8U8U8U8,
+                                             128, 128);
+    color1.as_surface().clear_color(0.0, 0.0, 0.0, 1.0);
+
+    let color2 = glium::Texture2d::new_empty(&display,
+                                             glium::texture::UncompressedFloatFormat::U8U8U8U8,
+                                             128, 128);
+    color2.as_surface().clear_color(0.0, 0.0, 0.0, 1.0);
+
+    // building the framebuffer
+    let mut framebuffer = glium::framebuffer::MultiOutputFrameBuffer::new(&display,
+                                             &[("color1", &color1), ("color2", &color2)]);
+
+    framebuffer.draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &std::default::Default::default());
+
+    // checking color1
+    let read_back1: Vec<Vec<(f32, f32, f32, f32)>> = color1.read();
+    for row in read_back1.iter() {
+        for pixel in row.iter() {
+            assert_eq!(pixel, &(1.0, 1.0, 1.0, 1.0));
+        }
+    }
+
+    // checking color2
+    let read_back2: Vec<Vec<(f32, f32, f32, f32)>> = color2.read();
+    for row in read_back2.iter() {
+        for pixel in row.iter() {
+            assert_eq!(pixel, &(1.0, 0.0, 0.0, 1.0));
+        }
+    }
+
+
+    display.assert_no_error();
+}


### PR DESCRIPTION
- [ ] ~~Split `Surface` between `Surface` and `Framebuffer` ; everything goes in `Framebuffer` except what is related to having a single color buffer. **[breaking change]**~~
- [x] Implement ~~`Framebuffer`~~ `Surface` for `MultiOutputFrameBuffer`.
- [x] Add tests
- [ ] ~~Add restrictions as for which gl versions have access to `MultiOutputFrameBuffer`~~