### PR TITLE
Use glBufferStorage if possible

### DIFF
--- a/build/main.rs
+++ b/build/main.rs
@@ -23,6 +23,7 @@ fn main() {
                                         "GL_NVX_gpu_memory_info".to_string(),
                                         "GL_ATI_meminfo".to_string(),
                                         "GL_EXT_texture_filter_anisotropic".to_string(),
+                                        "GL_ARB_buffer_storage".to_string(),
                                     ],
                                     "4.5", "compatibility", &mut gl_bindings).unwrap();
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -102,8 +102,16 @@ impl Buffer {
 
                 ctxt.gl.BindBuffer(bind, id);
                 *storage = id;
-                ctxt.gl.BufferData(bind, buffer_size as gl::types::GLsizeiptr,
-                                   data.as_ptr() as *const libc::c_void, usage);
+
+                if ctxt.version >= &GlVersion(4, 4) || ctxt.extensions.gl_arb_buffer_storage {
+                    ctxt.gl.BufferStorage(bind, buffer_size as gl::types::GLsizeiptr,
+                                          data.as_ptr() as *const libc::c_void,
+                                          gl::DYNAMIC_STORAGE_BIT | gl::MAP_READ_BIT |
+                                          gl::MAP_WRITE_BIT);       // TODO: more specific flags
+                } else {
+                    ctxt.gl.BufferData(bind, buffer_size as gl::types::GLsizeiptr,
+                                       data.as_ptr() as *const libc::c_void, usage);
+                }
 
                 let mut obtained_size: gl::types::GLint = mem::uninitialized();
                 ctxt.gl.GetBufferParameteriv(bind, gl::BUFFER_SIZE, &mut obtained_size);
@@ -138,7 +146,16 @@ impl Buffer {
 
                 ctxt.gl.BindBuffer(bind, id);
                 *storage = id;
-                ctxt.gl.BufferData(bind, buffer_size as gl::types::GLsizeiptr, ptr::null(), usage);
+
+                if ctxt.version >= &GlVersion(4, 4) || ctxt.extensions.gl_arb_buffer_storage {
+                    ctxt.gl.BufferStorage(bind, buffer_size as gl::types::GLsizeiptr,
+                                          ptr::null(),
+                                          gl::DYNAMIC_STORAGE_BIT | gl::MAP_READ_BIT |
+                                          gl::MAP_WRITE_BIT);       // TODO: more specific flags
+                } else {
+                    ctxt.gl.BufferData(bind, buffer_size as gl::types::GLsizeiptr,
+                                       ptr::null(), usage);
+                }
 
                 let mut obtained_size: gl::types::GLint = mem::uninitialized();
                 ctxt.gl.GetBufferParameteriv(bind, gl::BUFFER_SIZE, &mut obtained_size);

--- a/src/context.rs
+++ b/src/context.rs
@@ -214,6 +214,8 @@ pub struct ExtensionsList {
     pub gl_ext_texture_filter_anisotropic: bool,
     /// GL_ARB_texture_storage
     pub gl_arb_texture_storage: bool,
+    /// GL_ARB_buffer_storage
+    pub gl_arb_buffer_storage: bool,
 }
 
 /// Represents the capabilities of the context.
@@ -557,6 +559,7 @@ fn get_extensions(gl: &gl::Gl) -> ExtensionsList {
         gl_arb_sampler_objects: false,
         gl_ext_texture_filter_anisotropic: false,
         gl_arb_texture_storage: false,
+        gl_arb_buffer_storage: false,
     };
 
     for extension in strings.into_iter() {
@@ -572,6 +575,7 @@ fn get_extensions(gl: &gl::Gl) -> ExtensionsList {
             "GL_ARB_sampler_objects" => extensions.gl_arb_sampler_objects = true,
             "GL_EXT_texture_filter_anisotropic" => extensions.gl_ext_texture_filter_anisotropic = true,
             "GL_ARB_texture_storage" => extensions.gl_arb_texture_storage = true,
+            "GL_ARB_buffer_storage" => extensions.gl_arb_buffer_storage = false,
             _ => ()
         }
     }


### PR DESCRIPTION
On GL 4.4+ or if `GL_ARB_buffer_storage` is present, use `glBufferStorage` instead of `glBufferData`.

This is an optimization, but is also necessary for permanent mapping (#88)