### PR TITLE
Add macros for uniforms

### DIFF
--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -4,6 +4,8 @@
 extern crate glium_macros;
 
 extern crate glutin;
+
+#[macro_use]
 extern crate glium;
 
 use glium::Surface;
@@ -70,13 +72,6 @@ fn main() {
         // geometry shader
         None)
         .unwrap();
-
-    // creating the uniforms structure
-    #[uniforms]
-    #[derive(Copy)]
-    struct Uniforms {
-        matrix: [[f32; 4]; 4],
-    }
     
     // the main loop
     // each cycle will draw once
@@ -85,7 +80,7 @@ fn main() {
         use std::time::Duration;
 
         // building the uniforms
-        let uniforms = Uniforms {
+        let uniforms = uniform! {
             matrix: [
                 [1.0, 0.0, 0.0, 0.0],
                 [0.0, 1.0, 0.0, 0.0],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,6 +212,7 @@ pub mod debug;
 pub mod framebuffer;
 pub mod index_buffer;
 pub mod pixel_buffer;
+pub mod macros;
 pub mod render_buffer;
 pub mod uniforms;
 pub mod vertex_buffer;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,70 @@
+/// Returns an implementation-defined type which implements the `Uniform` trait.
+///
+/// ## Example
+///
+/// ```rust
+/// # #[macro_use]
+/// # extern crate glium;
+/// # fn main() {
+/// let uniforms = uniform! {
+///     color: [1.0, 1.0, 0.0, 1.0],
+///     some_value: 12i32
+/// };
+/// # }
+/// ```
+#[macro_export]
+macro_rules! uniform {
+    () => {
+        $crate::uniforms::EmptyUniforms
+    };
+
+    ($field:ident: $value:expr) => {
+        $crate::uniforms::UniformsStorage::new(stringify!($field), $value)
+    };
+
+    ($field1:ident: $value1:expr, $($field:ident: $value:expr),+) => {
+        {
+            let mut uniforms = $crate::uniforms::UniformsStorage::new(stringify!($field1), $value1);
+            $(
+                uniforms = uniforms.add(stringify!($field), $value);
+            )+
+            uniforms
+        }
+    };
+}
+
+/*
+// TODO: doesn't work
+#[macro_export]
+macro_rules! attributes {
+    ($(#[$attr:meta])* struct $struct_name:ident {
+        $($(#[$field_attr:meta])* $field:ident: $t:ty),*
+    }) => {
+        #[derive(Copy)]
+        $(#[$attr])*
+        pub struct $struct_name {
+            $(
+                $($field_attr)* pub $field: $t
+            ),+
+        }
+
+        impl $crate::vertex_buffer::Vertex for $struct_name {
+            fn build_bindings(_: Option<Self>) -> $crate::vertex_buffer::VertexFormat {
+                vec![
+                    $(
+                        (
+                            stringify!($field),
+                            {
+                                let dummy: &$struct_name = unsafe { ::std::mem::transmute(0u) };
+                                let dummy_field = &dummy.$field;
+                                let dummy_field: usize = unsafe { ::std::mem::transmute(dummy_field) };
+                                dummy_field
+                            },
+                            $crate::vertex_buffer::Attribute::get_type(None::<$t>)
+                        )
+                    )+
+                ]
+            }
+        }
+    }
+}*/


### PR DESCRIPTION
Should replace `glium_macros` for Rust 1.0 compatibility.
