### PR TITLE
Remove gl_extensions restriction for reading textures

### DIFF
--- a/build/textures.rs
+++ b/build/textures.rs
@@ -425,36 +425,22 @@ fn build_texture<W: Writer>(mut dest: &mut W, ty: TextureType, dimensions: Textu
     }
 
     // writing the `read` function
-    // TODO: implement for arrays too
-    if dimensions != TextureDimensions::Texture1dArray && dimensions != TextureDimensions::Texture2dArray {
-        let (data_type, constructor) = match dimensions {
-            TextureDimensions::Texture1d | TextureDimensions::Texture1dArray => (
-                    "Texture1dData",
-                    "Texture1dData::from_vec(data)"
-                ),
-            TextureDimensions::Texture2d | TextureDimensions::Texture2dArray => (
-                    "Texture2dData",
-                    "Texture2dData::from_vec(data, self.get_width() as u32)"
-                ),
-            TextureDimensions::Texture3d => (
-                    "Texture3dData",
-                    "Texture3dData::from_vec(data, self.get_width() as u32, \
-                                             self.get_height().unwrap() as u32)"
-                ),
-        };
+    // TODO: implement for other types too
+    if dimensions == TextureDimensions::Texture2d &&
+       (ty == TextureType::Regular || ty == TextureType::Compressed)
+    {
+        /*let data_type = match dimensions {
+            TextureDimensions::Texture1d | TextureDimensions::Texture1dArray => "Texture1dData",
+            TextureDimensions::Texture2d | TextureDimensions::Texture2dArray => "Texture2dData",
+            TextureDimensions::Texture3d => "Texture3dData",
+        };*/
 
         (write!(dest, r#"
                 /// Reads the content of the texture.
-                ///
-                /// # Features
-                ///
-                /// This method is always only if the `gl_extensions` feature is enabled.
-                #[cfg(feature = "gl_extensions")]
-                pub fn read<P, T>(&self) -> T where T: {data_type}<Data = P>, P: PixelValue {{
-                    let data = self.0.read::<P>(0);
-                    {constructor}
+                pub fn read<P, T>(&self) -> T where T: Texture2dData<Data = P>, P: PixelValue + Clone {{    // TODO: remove Clone
+                    self.0.read(0)
                 }}
-            "#, data_type = data_type, constructor = constructor)).unwrap();
+            "#)).unwrap();
     }
 
     // closing `impl Texture` block

--- a/src/context.rs
+++ b/src/context.rs
@@ -131,6 +131,9 @@ pub struct GLState {
 
     /// The latest value passed to `glPixelStore` with `GL_UNPACK_ALIGNMENT`.
     pub pixel_store_unpack_alignment: gl::types::GLint,
+
+    /// The latest value passed to `glPixelStore` with `GL_PACK_ALIGNMENT`.
+    pub pixel_store_pack_alignment: gl::types::GLint,
 }
 
 impl GLState {
@@ -172,6 +175,7 @@ impl GLState {
             cull_face: gl::BACK,
             polygon_mode: gl::FILL,
             pixel_store_unpack_alignment: 4,
+            pixel_store_pack_alignment: 4,
         }
     }
 }

--- a/src/fbo.rs
+++ b/src/fbo.rs
@@ -102,6 +102,27 @@ impl FramebuffersContainer {
         }
     }
 
+    pub fn get_framebuffer_for_reading(&self, attachment: &Attachment, context: &context::Context)
+                                       -> (gl::types::GLuint, gl::types::GLenum)
+    {
+        for (attachments, fbo) in self.framebuffers.lock().unwrap().iter() {
+            for &(key, ref atc) in attachments.colors.iter() {
+                if atc == attachment {
+                    return (fbo.get_id(), gl::COLOR_ATTACHMENT0 + key);
+                }
+            }
+        }
+
+        let attachments = FramebufferAttachments {
+            colors: vec![(0, attachment.clone())],
+            depth: None,
+            stencil: None,
+        };
+
+        let framebuffer = self.get_framebuffer_for_drawing(Some(&attachments), context);
+        (framebuffer, gl::COLOR_ATTACHMENT0)
+    }
+
     fn get_framebuffer(&self, framebuffer: &FramebufferAttachments,
                        context: &context::Context) -> gl::types::GLuint
     {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,3 +1,4 @@
+use libc;
 use std::sync::Arc;
 use std::sync::mpsc::channel;
 
@@ -9,6 +10,7 @@ use uniforms::{Uniforms, UniformValue, SamplerBehavior};
 use {DisplayImpl, Program, DrawParameters, Rect, Surface, GlObject, ToGlEnum};
 use index_buffer::IndicesSource;
 use vertex_buffer::VerticesSource;
+use texture;
 
 use {program, vertex_array_object};
 use {gl, context};
@@ -274,6 +276,67 @@ pub fn blit<S1: Surface, S2: Surface>(source: &S1, target: &S2, mask: gl::types:
             }
         }
     });
+}
+
+pub fn read_attachment<P, T>(attachment: &fbo::Attachment, dimensions: (u32, u32),
+                             display: &Display) -> T          // TODO: remove Clone for P
+                             where P: texture::PixelValue + Clone + Send,
+                             T: texture::Texture2dData<Data = P>
+{
+    let (fbo, atch) = display.context.framebuffer_objects.as_ref().unwrap()
+                             .get_framebuffer_for_reading(attachment, &display.context.context);
+    read_impl(fbo, atch, dimensions, &display.context.context)
+}
+
+pub fn read_from_default_fb<P, T>(attachment: gl::types::GLenum, display: &Display) -> T          // TODO: remove Clone for P
+                                  where P: texture::PixelValue + Clone + Send,
+                                  T: texture::Texture2dData<Data = P>
+{
+    let (w, h) = display.get_framebuffer_dimensions();
+    let (w, h) = (w as u32, h as u32);      // TODO: remove this conversion
+    read_impl(0, attachment, (w, h), &display.context.context)
+}
+
+fn read_impl<P, T>(fbo: gl::types::GLuint, readbuffer: gl::types::GLenum,
+                   dimensions: (u32, u32), context: &context::Context) -> T          // TODO: remove Clone for P
+                   where P: texture::PixelValue + Clone + Send,
+                   T: texture::Texture2dData<Data = P>
+{
+    use std::mem;
+
+    let pixels_count = dimensions.0 * dimensions.1;
+
+    let pixels_size = texture::Texture2dData::get_format(None::<T>).get_size();
+    let (format, gltype) = texture::Texture2dData::get_format(None::<T>).to_gl_enum();
+
+    let (tx, rx) = channel();
+    context.exec(move |: mut ctxt| {
+        unsafe {
+            // binding framebuffer
+            fbo::bind_framebuffer(&mut ctxt, fbo, false, true);
+
+            // adjusting glReadBuffer
+            ctxt.gl.ReadBuffer(readbuffer);
+
+            // adjusting data alignement
+            if ctxt.state.pixel_store_pack_alignment != 1 {
+                ctxt.state.pixel_store_pack_alignment = 1;
+                ctxt.gl.PixelStorei(gl::PACK_ALIGNMENT, 1);
+            }
+
+            // reading
+            let total_data_size = pixels_count  as usize * pixels_size / mem::size_of::<P>();
+            let mut data: Vec<P> = Vec::with_capacity(total_data_size);
+            ctxt.gl.ReadPixels(0, 0, dimensions.0 as gl::types::GLint,
+                               dimensions.1 as gl::types::GLint, format, gltype,
+                               data.as_mut_ptr() as *mut libc::c_void);
+            data.set_len(total_data_size);
+            tx.send(data).ok();
+        }
+    });
+
+    let data = rx.recv().unwrap();
+    texture::Texture2dData::from_vec(data, dimensions.0 as u32)
 }
 
 // TODO: we use a `Fn` instead of `FnOnce` because of that "std::thunk" issue

--- a/tests/framebuffer.rs
+++ b/tests/framebuffer.rs
@@ -45,7 +45,6 @@ fn simple_dimensions() {
 }
 
 #[test]
-#[cfg(feature = "gl_extensions")]       // TODO: remove
 fn simple_render_to_texture() {
     use std::default::Default;
 
@@ -69,7 +68,6 @@ fn simple_render_to_texture() {
 }
 
 #[test]
-#[cfg(feature = "gl_extensions")]       // TODO: remove
 fn depth_texture2d() {
     use std::iter;
 

--- a/tests/texture.rs
+++ b/tests/texture.rs
@@ -75,7 +75,6 @@ fn texture_3d_creation() {
 }
 
 #[test]
-#[cfg(feature = "gl_extensions")]
 fn texture_2d_read() {
     let display = support::build_display();
 


### PR DESCRIPTION
Instead of calling `glGetTexture`, binds a framebuffer and use `glReadPixels`.

Introduces a potential, rare, race condition when destroying a texture that has been bound to the same FBO as the texture you are reading simultaneously. Will open an issue about it.