### PR TITLE
Remove gl(es)_extensions and add gl_read_buffer feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,8 @@ license = "Apache"
 build = "build/main.rs"
 
 [features]
-default = ["image", "gl_extensions", "cgmath", "nalgebra"]
-gl_extensions = []
-gles_extensions = []
+default = ["image", "cgmath", "nalgebra", "gl_read_buffer"]
+gl_read_buffer = []
 headless = ["glutin/headless"]
 
 [dependencies.compile_msg]

--- a/README.md
+++ b/README.md
@@ -99,16 +99,16 @@ Performances:
 
 ## Features
 
-Glium has six features:
+Glium has four Cargo features:
 
  - `image` allows support for the `image` library, which allows easy creation of textures from different image formats.
  - `cgmath` and `nalgebra` add support for these libraries' matrices and vectors.
  - `headless`, which enables headless building and testing.
- - `gl_extensions`
- - `gles_extensions`
 
-If you disable both `gl_extensions` and `gles_extensions`, then only the functionality that
-is available in both OpenGL 3 and OpenGL ES 2 will be available at compile-time.
+In addition to this, it has the following OpenGL-related features:
 
-Enabling either `gl_extensions` or `gles_extensions` will unlock this functionality, but will
-trigger a `panic!` if used when not available on the target hardware.
+ - `gl_read_buffer` (read the content of a buffer)
+
+Enabling each of these features adds more restrictions towards the backend and increases the
+likehood that `build_glium` will return an `Err`. However, it also gives you access to more
+functions with different signatures.

--- a/src/context.rs
+++ b/src/context.rs
@@ -482,6 +482,10 @@ fn check_gl_compatibility(ctxt: CommandContext) -> Result<(), GliumCreationError
             result.push("OpenGL ES version inferior to 3.0");
         }
 
+        if cfg!(feature = "gl_read_buffer") {
+            result.push("OpenGL ES doesn't support gl_read_buffer");
+        }
+
     } else {
         if ctxt.version < &GlVersion(2, 0) {
             result.push("OpenGL version inferior to 2.0 is not supported");

--- a/src/index_buffer.rs
+++ b/src/index_buffer.rs
@@ -159,11 +159,7 @@ impl IndexBuffer {
     /// # Panic
     ///
     /// On OpenGL ES, attempting to draw with an index buffer that uses an index
-    /// format with adjacency information will trigger a panic .
-    ///
-    /// If you want to be compatible with all platforms, it is preferable to disable the
-    /// `gl_extensions` feature, which prevents you from accidentally using them.
-    ///
+    /// format with adjacency information will trigger a panic.
     pub fn new<T: IntoIndexBuffer>(display: &super::Display, data: T) -> IndexBuffer {
         data.into_index_buffer(display)
     }
@@ -320,16 +316,8 @@ impl<T> ToIndicesSource<T> for LinesList<T> where T: Index + Send + Copy {
 ///
 /// OpenGL ES doesn't support adjacency information. Attempting to use this type while
 /// drawing will thus panic.
-/// If you want to be compatible with all platforms, it is preferable to disable the
-/// `gl_extensions` feature.
-///
-/// # Features
-///
-/// Only available if the `gl_extensions` feature is enabled.
-#[cfg(feature = "gl_extensions")]
 pub struct LinesListAdjacency<T>(pub Vec<T>);
 
-#[cfg(feature = "gl_extensions")]
 impl<T> IntoIndexBuffer for LinesListAdjacency<T> where T: Index + Send + Copy {
     fn into_index_buffer(self, display: &super::Display) -> IndexBuffer {
         use std::mem;
@@ -343,7 +331,6 @@ impl<T> IntoIndexBuffer for LinesListAdjacency<T> where T: Index + Send + Copy {
     }
 }
 
-#[cfg(feature = "gl_extensions")]
 impl<T> ToIndicesSource<T> for LinesListAdjacency<T> where T: Index + Send + Copy {
     fn to_indices_source(&self) -> IndicesSource<T> {
         IndicesSource::Buffer {
@@ -388,16 +375,8 @@ impl<T> ToIndicesSource<T> for LineStrip<T> where T: Index + Send + Copy {
 ///
 /// OpenGL ES doesn't support adjacency information. Attempting to use this type while
 /// drawing will thus panic.
-/// If you want to be compatible with all platforms, it is preferable to disable the
-/// `gl_extensions` feature.
-///
-/// # Features
-///
-/// Only available if the `gl_extensions` feature is enabled.
-#[cfg(feature = "gl_extensions")]
 pub struct LineStripAdjacency<T>(pub Vec<T>);
 
-#[cfg(feature = "gl_extensions")]
 impl<T> IntoIndexBuffer for LineStripAdjacency<T> where T: Index + Send + Copy {
     fn into_index_buffer(self, display: &super::Display) -> IndexBuffer {
         use std::mem;
@@ -411,7 +390,6 @@ impl<T> IntoIndexBuffer for LineStripAdjacency<T> where T: Index + Send + Copy {
     }
 }
 
-#[cfg(feature = "gl_extensions")]
 impl<T> ToIndicesSource<T> for LineStripAdjacency<T> where T: Index + Send + Copy {
     fn to_indices_source(&self) -> IndicesSource<T> {
         IndicesSource::Buffer {
@@ -456,16 +434,8 @@ impl<T> ToIndicesSource<T> for TrianglesList<T> where T: Index + Send + Copy {
 ///
 /// OpenGL ES doesn't support adjacency information. Attempting to use this type while
 /// drawing will thus panic.
-/// If you want to be compatible with all platforms, it is preferable to disable the
-/// `gl_extensions` feature.
-///
-/// # Features
-///
-/// Only available if the `gl_extensions` feature is enabled.
-#[cfg(feature = "gl_extensions")]
 pub struct TrianglesListAdjacency<T>(pub Vec<T>);
 
-#[cfg(feature = "gl_extensions")]
 impl<T> IntoIndexBuffer for TrianglesListAdjacency<T> where T: Index + Send + Copy {
     fn into_index_buffer(self, display: &super::Display) -> IndexBuffer {
         use std::mem;
@@ -479,7 +449,6 @@ impl<T> IntoIndexBuffer for TrianglesListAdjacency<T> where T: Index + Send + Co
     }
 }
 
-#[cfg(feature = "gl_extensions")]
 impl<T> ToIndicesSource<T> for TrianglesListAdjacency<T> where T: Index + Send + Copy {
     fn to_indices_source(&self) -> IndicesSource<T> {
         IndicesSource::Buffer {
@@ -524,16 +493,8 @@ impl<T> ToIndicesSource<T> for TriangleStrip<T> where T: Index + Send + Copy {
 ///
 /// OpenGL ES doesn't support adjacency information. Attempting to use this type while
 /// drawing will thus panic.
-/// If you want to be compatible with all platforms, it is preferable to disable the
-/// `gl_extensions` feature.
-///
-/// # Features
-///
-/// Only available if the `gl_extensions` feature is enabled.
-#[cfg(feature = "gl_extensions")]
 pub struct TriangleStripAdjacency<T>(pub Vec<T>);
 
-#[cfg(feature = "gl_extensions")]
 impl<T> IntoIndexBuffer for TriangleStripAdjacency<T> where T: Index + Send + Copy {
     fn into_index_buffer(self, display: &super::Display) -> IndexBuffer {
         use std::mem;
@@ -547,7 +508,6 @@ impl<T> IntoIndexBuffer for TriangleStripAdjacency<T> where T: Index + Send + Co
     }
 }
 
-#[cfg(feature = "gl_extensions")]
 impl<T> ToIndicesSource<T> for TriangleStripAdjacency<T> where T: Index + Send + Copy {
     fn to_indices_source(&self) -> IndicesSource<T> {
         IndicesSource::Buffer {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1408,7 +1408,6 @@ impl Display {
     /// ```no_run
     /// # extern crate glium;
     /// # extern crate glutin;
-    /// # use glium::DisplayBuild;
     /// # fn main() {
     /// # let display: glium::Display = unsafe { ::std::mem::uninitialized() };
     /// let pixels: Vec<Vec<(u8, u8, u8)>> = display.read_front_buffer();

--- a/src/pixel_buffer.rs
+++ b/src/pixel_buffer.rs
@@ -41,10 +41,31 @@ impl<T> PixelBuffer<T> where T: Texture2dData {
     /// ## Panic
     ///
     /// Panics if the pixel buffer is empty.
-    #[cfg(feature = "gl_extensions")]       // TODO: remove
+    ///
+    /// ## Features
+    ///
+    /// This function is only available if the `gl_read_buffer` feature is enabled.
+    /// Otherwise, you should use `read_if_supported`.
+    #[cfg(feature = "gl_read_buffer")]
     pub fn read(&self) -> T {
         let data = self.buffer.read::<buffer::PixelPackBuffer, _>();
         Texture2dData::from_vec(data, self.width.expect("The pixel buffer is empty"))
+    }
+
+    /// Copies the content of the pixel buffer to RAM.
+    ///
+    /// This operation is slow and should be done outside of the rendering loop.
+    ///
+    /// ## Panic
+    ///
+    /// Panics if the pixel buffer is empty.
+    pub fn read_if_supported(&self) -> Option<T> {
+        let data = match self.buffer.read_if_supported::<buffer::PixelPackBuffer, _>() {
+            Some(d) => d,
+            None => return None
+        };
+
+        Some(Texture2dData::from_vec(data, self.width.expect("The pixel buffer is empty")))
     }
 }
 

--- a/src/vertex_buffer.rs
+++ b/src/vertex_buffer.rs
@@ -198,16 +198,6 @@ impl<T: Send + Copy> VertexBuffer<T> {
     ///
     /// **Warning**: using this function can slow things down a lot, because it
     /// waits for all the previous commands to be executed before returning.
-    ///
-    /// # Panic
-    ///
-    /// OpenGL ES doesn't support mapping buffers. Using this function will thus panic.
-    /// If you want to be compatible with all platforms, it is preferable to disable the
-    /// `gl_extensions` feature.
-    ///
-    /// # Features
-    ///
-    /// Only available if the `gl_extensions` feature is enabled.
     pub fn map<'a>(&'a mut self) -> Mapping<'a, T> {
         let len = self.buffer.buffer.get_elements_count();
         let mapping = self.buffer.buffer.map::<buffer::ArrayBuffer, T>(0, len);
@@ -219,18 +209,20 @@ impl<T: Send + Copy> VertexBuffer<T> {
     /// This function is usually better if are just doing one punctual read, while `map`
     /// is better if you want to have multiple small reads.
     ///
-    /// # Panic
-    ///
-    /// OpenGL ES doesn't support reading buffers. Using this function will thus panic.
-    /// If you want to be compatible with all platforms, it is preferable to disable the
-    /// `gl_extensions` feature.
-    ///
     /// # Features
     ///
-    /// Only available if the `gl_extensions` feature is enabled.
-    #[cfg(feature = "gl_extensions")]
+    /// Only available if the `gl_read_buffer` feature is enabled.
+    #[cfg(feature = "gl_read_buffer")]
     pub fn read(&self) -> Vec<T> {
         self.buffer.buffer.read::<buffer::ArrayBuffer, T>()
+    }
+
+    /// Reads the content of the buffer.
+    ///
+    /// This function is usually better if are just doing one punctual read, while `map`
+    /// is better if you want to have multiple small reads.
+    pub fn read_if_supported(&self) -> Option<Vec<T>> {
+        self.buffer.buffer.read_if_supported::<buffer::ArrayBuffer, T>()
     }
 
     /// Reads the content of the buffer.
@@ -244,16 +236,26 @@ impl<T: Send + Copy> VertexBuffer<T> {
     ///
     /// Panics if `offset` or `offset + size` are greated than the size of the buffer.
     ///
-    /// OpenGL ES doesn't support reading buffers. Using this function will thus panic.
-    /// If you want to be compatible with all platforms, it is preferable to disable the
-    /// `gl_extensions` feature.
-    ///
     /// # Features
     ///
-    /// Only available if the `gl_extensions` feature is enabled.
-    #[cfg(feature = "gl_extensions")]
+    /// Only available if the `gl_read_buffer` feature is enabled.
+    #[cfg(feature = "gl_read_buffer")]
     pub fn read_slice(&self, offset: usize, size: usize) -> Vec<T> {
         self.buffer.buffer.read_slice::<buffer::ArrayBuffer, T>(offset, size)
+    }
+
+    /// Reads the content of the buffer.
+    ///
+    /// This function is usually better if are just doing one punctual read, while `map`
+    /// is better if you want to have multiple small reads.
+    ///
+    /// The offset and size are expressed in number of elements.
+    ///
+    /// ## Panic
+    ///
+    /// Panics if `offset` or `offset + size` are greated than the size of the buffer.
+    pub fn read_slice_if_supported(&self, offset: usize, size: usize) -> Option<Vec<T>> {
+        self.buffer.buffer.read_slice_if_supported::<buffer::ArrayBuffer, T>(offset, size)
     }
 
     /// Writes some vertices to the buffer.
@@ -352,10 +354,6 @@ impl<'a> IntoVerticesSource<'a> for &'a VertexBufferAny {
 }
 
 /// A mapping of a buffer.
-///
-/// # Features
-///
-/// Only available if the `gl_extensions` feature is enabled.
 pub struct Mapping<'a, T>(buffer::Mapping<'a, buffer::ArrayBuffer, T>);
 
 impl<'a, T> Deref for Mapping<'a, T> {

--- a/tests/texture.rs
+++ b/tests/texture.rs
@@ -110,7 +110,6 @@ fn empty_texture2d() {
 
 #[test]
 #[ignore]  // FIXME: FAILING TEST
-#[cfg(feature = "gl_extensions")]
 fn render_to_texture2d() {
     use std::default::Default;
 

--- a/tests/texture_read.rs
+++ b/tests/texture_read.rs
@@ -33,18 +33,16 @@ fn texture_2d_read() {
 
 #[test]
 #[should_fail]
-#[cfg(feature = "gl_extensions")]       // TODO: remove
 fn empty_pixel_buffer() {
     let display = support::build_display();
 
     let pixel_buffer = glium::pixel_buffer::PixelBuffer::new_empty(&display, 128 * 128);
     display.assert_no_error();
 
-    let _: Vec<Vec<(u8, u8, u8)>> = pixel_buffer.read();
+    let _: Vec<Vec<(u8, u8, u8)>> = pixel_buffer.read_if_supported().unwrap();
 }
 
 #[test]
-#[cfg(feature = "gl_extensions")]       // TODO: remove
 fn texture_2d_read_pixelbuffer() {
     let display = support::build_display();
 
@@ -54,7 +52,11 @@ fn texture_2d_read_pixelbuffer() {
         vec![(32u8, 64u8, 128u8), (32u8, 16u8, 4u8)],
     ]);
 
-    let read_back: Vec<Vec<(u8, u8, u8)>> = texture.read_to_pixel_buffer().read();
+    let read_back: Vec<Vec<(u8, u8, u8)>> = match texture.read_to_pixel_buffer()
+                                                         .read_if_supported() {
+        Some(d) => d,
+        None => return
+    };
 
     assert_eq!(read_back[0][0], (0, 1, 2));
     assert_eq!(read_back[0][1], (4, 8, 16));

--- a/tests/vertex_buffer.rs
+++ b/tests/vertex_buffer.rs
@@ -88,7 +88,6 @@ fn vertex_buffer_mapping_write() {
 }
 
 #[test]
-#[cfg(feature = "gl_extensions")]
 fn vertex_buffer_read() {
     let display = support::build_display();
 
@@ -106,7 +105,11 @@ fn vertex_buffer_read() {
         ]
     );
 
-    let data = vb.read();
+    let data = match vb.read_if_supported() {
+        Some(d) => d,
+        None => return
+    };
+
     assert_eq!(data[0].field1.as_slice(), [2, 3].as_slice());
     assert_eq!(data[1].field2.as_slice(), [15, 17].as_slice());
 
@@ -114,7 +117,6 @@ fn vertex_buffer_read() {
 }
 
 #[test]
-#[cfg(feature = "gl_extensions")]
 fn vertex_buffer_read_slice() {
     let display = support::build_display();
 
@@ -132,7 +134,11 @@ fn vertex_buffer_read_slice() {
         ]
     );
 
-    let data = vb.read_slice(1, 1);
+    let data = match vb.read_slice_if_supported(1, 1) {
+        Some(d) => d,
+        None => return
+    };
+
     assert_eq!(data[0].field2.as_slice(), [15, 17].as_slice());
     
     display.assert_no_error();
@@ -140,7 +146,6 @@ fn vertex_buffer_read_slice() {
 
 #[test]
 #[should_fail]
-#[cfg(feature = "gl_extensions")]
 fn vertex_buffer_read_slice_out_of_bounds() {
     let display = support::build_display();
 
@@ -158,7 +163,7 @@ fn vertex_buffer_read_slice_out_of_bounds() {
         ]
     );
 
-    vb.read_slice(0, 3);
+    vb.read_slice_if_supported(0, 3).unwrap();
 }
 
 #[test]
@@ -185,7 +190,6 @@ fn vertex_buffer_any() {
 }
 
 #[test]
-#[cfg(feature = "gl_extensions")]
 fn vertex_buffer_write() {
     let display = support::build_display();
     
@@ -205,7 +209,11 @@ fn vertex_buffer_write() {
 
     vb.write(1, vec![Vertex { field1: [12, 13], field2: [15, 17] }]);
 
-    let data = vb.read();
+    let data = match vb.read_if_supported() {
+        Some(d) => d,
+        None => return
+    };
+
     assert_eq!(data[0].field1.as_slice(), [2, 3].as_slice());
     assert_eq!(data[0].field2.as_slice(), [5, 7].as_slice());
     assert_eq!(data[1].field1.as_slice(), [12, 13].as_slice());


### PR DESCRIPTION
Close #245 
Start of #252

- `read` and `read_slice` are now behind `#[cfg(feature = "gl_read_buffer")]`
- Adds `read_if_supported` and `read_slice_if_supported`
- Adjusts the tests to use these