### PR TITLE
Implement uniform buffers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
 after_success: |
     [ $TRAVIS_BRANCH = master ] &&
     [ $TRAVIS_PULL_REQUEST = false ] &&
-    cargo doc &&
+    cargo doc --features "headless gl_read_buffer gl_uniform_blocks" &&
     echo '<meta http-equiv=refresh content=0;url=glium/index.html>' > target/doc/index.html &&
     sudo pip install ghp-import &&
     ghp-import -n target/doc &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ build = "build/main.rs"
 [features]
 default = ["image", "cgmath", "nalgebra", "gl_read_buffer"]
 gl_read_buffer = []
+gl_uniform_blocks = []
 headless = ["glutin/headless"]
 
 [dependencies.compile_msg]

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Glium has four Cargo features:
 In addition to this, it has the following OpenGL-related features:
 
  - `gl_read_buffer` (read the content of a buffer)
+ - `gl_uniform_blocks` (bind buffers to uniform blocks)
 
 Enabling each of these features adds more restrictions towards the backend and increases the
 likehood that `build_glium` will return an `Err`. However, it also gives you access to more

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -69,6 +69,21 @@ impl BufferType for PixelUnpackBuffer {
     }
 }
 
+/// Used for uniform buffers.
+pub struct UniformBuffer;
+
+impl BufferType for UniformBuffer {
+    fn get_storage_point(_: Option<UniformBuffer>, state: &mut context::GLState)
+        -> &mut gl::types::GLuint
+    {
+        &mut state.uniform_buffer_binding
+    }
+
+    fn get_bind_point(_: Option<UniformBuffer>) -> gl::types::GLenum {
+        gl::UNIFORM_BUFFER
+    }
+}
+
 impl Buffer {
     pub fn new<T, D>(display: &super::Display, data: Vec<D>, usage: gl::types::GLenum)
         -> Buffer where T: BufferType, D: Send + Copy
@@ -109,7 +124,8 @@ impl Buffer {
                 ctxt.gl.GetBufferParameteriv(bind, gl::BUFFER_SIZE, &mut obtained_size);
                 if buffer_size != obtained_size as usize {
                     ctxt.gl.DeleteBuffers(1, [id].as_ptr());
-                    panic!("Not enough available memory for buffer");
+                    panic!("Not enough available memory for buffer (required: {} bytes, \
+                            obtained: {})", buffer_size, obtained_size);
                 }
             }
         });

--- a/src/context.rs
+++ b/src/context.rs
@@ -99,6 +99,9 @@ pub struct GLState {
     /// The latest buffer bound to `GL_PIXEL_UNPACK_BUFFER`.
     pub pixel_unpack_buffer_binding: gl::types::GLuint,
 
+    /// The latest buffer bound to `GL_UNIFORM_BUFFER`.
+    pub uniform_buffer_binding: gl::types::GLuint,
+
     /// The latest buffer bound to `GL_READ_FRAMEBUFFER`.
     pub read_framebuffer: gl::types::GLuint,
 
@@ -170,6 +173,7 @@ impl GLState {
             array_buffer_binding: 0,
             pixel_pack_buffer_binding: 0,
             pixel_unpack_buffer_binding: 0,
+            uniform_buffer_binding: 0,
             read_framebuffer: 0,
             draw_framebuffer: 0,
             default_framebuffer_read: None,
@@ -234,6 +238,8 @@ pub struct ExtensionsList {
     pub gl_arb_texture_storage: bool,
     /// GL_ARB_buffer_storage
     pub gl_arb_buffer_storage: bool,
+    /// GL_ARB_uniform_buffer_object
+    pub gl_arb_uniform_buffer_object: bool,
 }
 
 /// Represents the capabilities of the context.
@@ -529,6 +535,12 @@ fn check_gl_compatibility(ctxt: CommandContext) -> Result<(), GliumCreationError
                 result.push("OpenGL implementation doesn't support sampler objects");
             }
         }
+
+        if cfg!(feature = "gl_uniform_blocks") && ctxt.version < &GlVersion(3, 1) &&
+            !ctxt.extensions.gl_arb_uniform_buffer_object
+        {
+            result.push("OpenGL implementation doesn't support uniform blocks");
+        }
     }
 
     if result.len() == 0 {
@@ -593,6 +605,7 @@ fn get_extensions(gl: &gl::Gl) -> ExtensionsList {
         gl_ext_texture_filter_anisotropic: false,
         gl_arb_texture_storage: false,
         gl_arb_buffer_storage: false,
+        gl_arb_uniform_buffer_object: false,
     };
 
     for extension in strings.into_iter() {
@@ -609,6 +622,7 @@ fn get_extensions(gl: &gl::Gl) -> ExtensionsList {
             "GL_EXT_texture_filter_anisotropic" => extensions.gl_ext_texture_filter_anisotropic = true,
             "GL_ARB_texture_storage" => extensions.gl_arb_texture_storage = true,
             "GL_ARB_buffer_storage" => extensions.gl_arb_buffer_storage = true,
+            "GL_ARB_uniform_buffer_object" => extensions.gl_arb_uniform_buffer_object = true,
             _ => ()
         }
     }

--- a/src/uniforms/buffer.rs
+++ b/src/uniforms/buffer.rs
@@ -1,0 +1,94 @@
+use Display;
+use buffer::{self, Buffer};
+
+use std::ops::{Deref, DerefMut};
+
+use context;
+use gl;
+
+/// Buffer that contains a uniform block.
+pub struct UniformBuffer<T> {
+    buffer: Buffer,
+}
+
+impl<T> UniformBuffer<T> where T: Copy + Send {
+    /// Uploads data in the uniforms buffer.
+    ///
+    /// ## Features
+    ///
+    /// Only available if the `gl_uniform_blocks` feature is enabled.
+    #[cfg(feature = "gl_uniform_blocks")]
+    pub fn new(display: &Display, data: T) -> UniformBuffer<T> {
+        let buffer = Buffer::new::<buffer::UniformBuffer, _>(display, vec![data],
+                                                             gl::STATIC_DRAW);
+
+        UniformBuffer {
+            buffer: buffer,
+        }
+    }
+
+    /// Uploads data in the uniforms buffer.
+    pub fn new_if_supported(display: &Display, data: T) -> Option<UniformBuffer<T>> {
+        if display.context.context.get_version() < &context::GlVersion(3, 1) &&
+           !display.context.context.get_extensions().gl_arb_uniform_buffer_object
+        {
+            None
+
+        } else {
+            let buffer = Buffer::new::<buffer::UniformBuffer, _>(display, vec![data],
+                                                                 gl::STATIC_DRAW);
+
+            Some(UniformBuffer {
+                buffer: buffer,
+            })
+        }
+    }
+
+    /// Modifies the content of the buffer.
+    pub fn upload(&mut self, data: T) {
+        self.buffer.upload::<buffer::UniformBuffer, _>(0, vec![data])
+    }
+
+    /// Maps the buffer to allow write access to it.
+    ///
+    /// **Warning**: using this function can slow things down a lot, because it
+    /// waits for all the previous commands to be executed before returning.
+    pub fn map<'a>(&'a mut self) -> Mapping<'a, T> {
+        Mapping(self.buffer.map::<buffer::UniformBuffer, T>(0, 1))
+    }
+
+    /// Reads the content of the buffer.
+    ///
+    /// This function is usually better if are just doing one punctual read, while `map`
+    /// is better if you want to have multiple small reads.
+    ///
+    /// # Features
+    ///
+    /// Only available if the `gl_read_buffer` feature is enabled.
+    #[cfg(feature = "gl_read_buffer")]
+    pub fn read(&self) -> T {
+        self.buffer.read::<buffer::UniformBuffer, T>().into_iter().next().unwrap()
+    }
+
+    /// Reads the content of the buffer.
+    pub fn read_if_supported(&self) -> Option<T> {
+        let res = self.buffer.read_if_supported::<buffer::UniformBuffer, T>();
+        res.map(|res| res.into_iter().next().unwrap())
+    }
+}
+
+/// A mapping of a uniform buffer.
+pub struct Mapping<'a, T>(buffer::Mapping<'a, buffer::UniformBuffer, T>);
+
+impl<'a, T> Deref for Mapping<'a, T> {
+    type Target = T;
+    fn deref<'b>(&'b self) -> &'b T {
+        self.0.deref().get(0).unwrap()
+    }
+}
+
+impl<'a, T> DerefMut for Mapping<'a, T> {
+    fn deref_mut<'b>(&'b mut self) -> &'b mut T {
+        self.0.deref_mut().get_mut(0).unwrap()
+    }
+}

--- a/src/uniforms/mod.rs
+++ b/src/uniforms/mod.rs
@@ -49,6 +49,7 @@ let uniforms = glium::uniforms::UniformsStorage::new("texture",
 ```
 
 */
+pub use self::buffer::UniformBuffer;
 pub use self::sampler::{SamplerWrapFunction, MagnifySamplerFilter, MinifySamplerFilter};
 pub use self::sampler::{Sampler, SamplerBehavior};
 pub use self::uniforms::{EmptyUniforms, UniformsStorage};
@@ -57,6 +58,7 @@ pub use self::value::{UniformValue, IntoUniformValue, UniformType};
 // TODO: remove
 pub use self::sampler::{SamplerObject, get_sampler};
 
+mod buffer;
 mod sampler;
 mod uniforms;
 mod value;

--- a/tests/uniform_buffer.rs
+++ b/tests/uniform_buffer.rs
@@ -1,0 +1,94 @@
+#![feature(plugin)]
+#![feature(unboxed_closures)]
+
+#[plugin]
+extern crate glium_macros;
+
+extern crate glutin;
+extern crate glium;
+
+mod support;
+
+#[test]
+fn uniform_buffer_creation() {
+    let display = support::build_display();
+
+    glium::uniforms::UniformBuffer::new_if_supported(&display, 12);
+
+    display.assert_no_error();
+}
+
+#[test]
+fn uniform_buffer_mapping_read() {
+    let display = support::build_display();
+
+    let mut vb = match glium::uniforms::UniformBuffer::new_if_supported(&display, 12) {
+        None => return,
+        Some(b) => b
+    };
+
+    let mapping = vb.map();
+    assert_eq!(*mapping, 12);
+
+    display.assert_no_error();
+}
+
+#[test]
+fn uniform_buffer_mapping_write() {
+    let display = support::build_display();
+
+    let mut vb = match glium::uniforms::UniformBuffer::new_if_supported(&display, 6) {
+        None => return,
+        Some(b) => b
+    };
+
+    {
+        let mut mapping = vb.map();
+        *mapping = 15;
+    }
+
+    let mapping = vb.map();
+    assert_eq!(*mapping, 15);
+
+    display.assert_no_error();
+}
+
+#[test]
+fn uniform_buffer_read() {
+    let display = support::build_display();
+
+    let vb = match glium::uniforms::UniformBuffer::new_if_supported(&display, 12) {
+        None => return,
+        Some(b) => b
+    };
+
+    let data = match vb.read_if_supported() {
+        Some(d) => d,
+        None => return
+    };
+
+    assert_eq!(data, 12);
+
+    display.assert_no_error();
+}
+
+#[test]
+fn uniform_buffer_write() {
+    let display = support::build_display();
+
+    let mut vb = match glium::uniforms::UniformBuffer::new_if_supported(&display, 5) {
+        None => return,
+        Some(b) => b
+    };
+
+    vb.upload(24);
+
+    let data = match vb.read_if_supported() {
+        Some(d) => d,
+        None => return
+    };
+
+    assert_eq!(data, 24);
+
+    display.assert_no_error();
+}


### PR DESCRIPTION
Buffers that contain a single value (usually a struct) whose purpose is to be bound to a uniform block.
Not really useful for the moment as you can't bind them.