### PR TITLE
Better clear_* functions

### DIFF
--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -182,16 +182,10 @@ impl<'a> SimpleFrameBuffer<'a> {
 }
 
 impl<'a> Surface for SimpleFrameBuffer<'a> {
-    fn clear_color(&mut self, red: f32, green: f32, blue: f32, alpha: f32) {
-        ops::clear_color(&self.display.context, Some(&self.attachments), red, green, blue, alpha)
-    }
-
-    fn clear_depth(&mut self, value: f32) {
-        ops::clear_depth(&self.display.context, Some(&self.attachments), value)
-    }
-
-    fn clear_stencil(&mut self, value: i32) {
-        ops::clear_stencil(&self.display.context, Some(&self.attachments), value)
+    fn clear(&mut self, color: Option<(f32, f32, f32, f32)>, depth: Option<f32>,
+             stencil: Option<i32>)
+    {
+        ops::clear(&self.display.context, Some(&self.attachments), color, depth, stencil);
     }
 
     fn get_dimensions(&self) -> (u32, u32) {
@@ -361,15 +355,9 @@ impl<'a> MultiOutputFrameBuffer<'a> {
 }
 
 impl<'a> Surface for MultiOutputFrameBuffer<'a> {
-    fn clear_color(&mut self, red: f32, green: f32, blue: f32, alpha: f32) {
-        unimplemented!()
-    }
-
-    fn clear_depth(&mut self, value: f32) {
-        unimplemented!()
-    }
-
-    fn clear_stencil(&mut self, value: i32) {
+    fn clear(&mut self, color: Option<(f32, f32, f32, f32)>, depth: Option<f32>,
+             stencil: Option<i32>)
+    {
         unimplemented!()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -933,14 +933,44 @@ pub struct Rect {
 /// Instancing and multiple viewports are also missing, as they are not supported.
 ///
 pub trait Surface: Sized {
-    /// Clears the color components of the target.
-    fn clear_color(&mut self, red: f32, green: f32, blue: f32, alpha: f32);
+    /// Clears some attachments of the target.
+    fn clear(&mut self, color: Option<(f32, f32, f32, f32)>, depth: Option<f32>,
+             stencil: Option<i32>);
 
-    /// Clears the depth component of the target.
-    fn clear_depth(&mut self, value: f32);
+    /// Clears the color attachment of the target.
+    fn clear_color(&mut self, red: f32, green: f32, blue: f32, alpha: f32) {
+        self.clear(Some((red, green, blue, alpha)), None, None);
+    }
 
-    /// Clears the stencil component of the target.
-    fn clear_stencil(&mut self, value: i32);
+    /// Clears the depth attachment of the target.
+    fn clear_depth(&mut self, value: f32) {
+        self.clear(None, Some(value), None);
+    }
+
+    /// Clears the stencil attachment of the target.
+    fn clear_stencil(&mut self, value: i32) {
+        self.clear(None, None, Some(value));
+    }
+
+    /// Clears the color and depth attachments of the target.
+    fn clear_color_and_depth(&mut self, color: (f32, f32, f32, f32), depth: f32) {
+        self.clear(Some(color), Some(depth), None);
+    }
+
+    /// Clears the color and stencil attachments of the target.
+    fn clear_color_and_stencil(&mut self, color: (f32, f32, f32, f32), stencil: i32) {
+        self.clear(Some(color), None, Some(stencil));
+    }
+
+    /// Clears the depth and stencil attachments of the target.
+    fn clear_depth_and_stencil(&mut self, depth: f32, stencil: i32) {
+        self.clear(None, Some(depth), Some(stencil));
+    }
+
+    /// Clears the color, depth and stencil attachments of the target.
+    fn clear_all(&mut self, color: (f32, f32, f32, f32), depth: f32, stencil: i32) {
+        self.clear(Some(color), Some(depth), Some(stencil));
+    }
 
     /// Returns the dimensions in pixels of the target.
     fn get_dimensions(&self) -> (u32, u32);
@@ -1046,16 +1076,10 @@ impl<'t> Frame<'t> {
 }
 
 impl<'t> Surface for Frame<'t> {
-    fn clear_color(&mut self, red: f32, green: f32, blue: f32, alpha: f32) {
-        ops::clear_color(&self.display.context, None, red, green, blue, alpha)
-    }
-
-    fn clear_depth(&mut self, value: f32) {
-        ops::clear_depth(&self.display.context, None, value)
-    }
-
-    fn clear_stencil(&mut self, value: i32) {
-        ops::clear_stencil(&self.display.context, None, value)
+    fn clear(&mut self, color: Option<(f32, f32, f32, f32)>, depth: Option<f32>,
+             stencil: Option<i32>)
+    {
+        ops::clear(&self.display.context, None, color, depth, stencil);
     }
 
     fn get_dimensions(&self) -> (u32, u32) {

--- a/src/ops/clear.rs
+++ b/src/ops/clear.rs
@@ -7,26 +7,9 @@ use Surface;
 
 use gl;
 
-pub fn clear_color(display: &Arc<DisplayImpl>, framebuffer: Option<&FramebufferAttachments>,
-                   red: f32, green: f32, blue: f32, alpha: f32)
-{
-    clear_impl(display, framebuffer, Some((red, green, blue, alpha)), None, None)
-}
 
-pub fn clear_depth(display: &Arc<DisplayImpl>, framebuffer: Option<&FramebufferAttachments>,
-                   value: f32)
-{
-    clear_impl(display, framebuffer, None, Some(value), None)
-}
-
-pub fn clear_stencil(display: &Arc<DisplayImpl>, framebuffer: Option<&FramebufferAttachments>,
-                     value: i32)
-{
-    clear_impl(display, framebuffer, None, None, Some(value))
-}
-
-fn clear_impl(display: &Arc<DisplayImpl>, framebuffer: Option<&FramebufferAttachments>,
-              color: Option<(f32, f32, f32, f32)>, depth: Option<f32>, stencil: Option<i32>)
+pub fn clear(display: &Arc<DisplayImpl>, framebuffer: Option<&FramebufferAttachments>,
+             color: Option<(f32, f32, f32, f32)>, depth: Option<f32>, stencil: Option<i32>)
 {
     let color = color.map(|(red, green, blue, alpha)| (
         red as gl::types::GLclampf,

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1,5 +1,5 @@
 pub use self::blit::blit;
-pub use self::clear::{clear_color, clear_depth, clear_stencil};
+pub use self::clear::clear;
 pub use self::draw::draw;
 pub use self::read::{read_attachment, read_from_default_fb};
 pub use self::read::{read_attachment_to_pb, read_from_default_fb_to_pb};

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -270,16 +270,10 @@ impl<P: PixelValue> Texture3dData for Vec<Vec<Vec<P>>> {
 pub struct TextureSurface<'a>(framebuffer::SimpleFrameBuffer<'a>);
 
 impl<'a> Surface for TextureSurface<'a> {
-    fn clear_color(&mut self, red: f32, green: f32, blue: f32, alpha: f32) {
-        self.0.clear_color(red, green, blue, alpha)
-    }
-
-    fn clear_depth(&mut self, value: f32) {
-        self.0.clear_depth(value)
-    }
-
-    fn clear_stencil(&mut self, value: i32) {
-        self.0.clear_stencil(value)
+    fn clear(&mut self, color: Option<(f32, f32, f32, f32)>, depth: Option<f32>,
+             stencil: Option<i32>)
+    {
+        self.0.clear(color, depth, stencil)
     }
 
     fn get_dimensions(&self) -> (u32, u32) {


### PR DESCRIPTION
Adds `clear_color_and_depth`, `clear_stencil_and_depth`, etc. and redirects everything to a single `clear` function which takes `Option`s.

Close #251 
