### PR TITLE
Add verify_shader! macro

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -7,3 +7,7 @@ authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 name = "glium_macros"
 path = "src/lib.rs"
 plugin = true
+
+[dependencies.glslang]
+git = "https://github.com/tomaka/glslang-rs"
+optional = true

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,10 +1,44 @@
+/*!
+
+# verify_shader
+
+*Only available if the `glslang` feature is enabled.*
+
+The `verify_shader!` macro checks that your shader's source code is correct and returns the
+source code as an expression.
+
+Example:
+
+```
+# #![feature(plugin)]
+# #[plugin]
+# extern crate glium_macros;
+static VERTEX_SHADER: &'static str = verify_shader!(vertex "
+    #version 110
+
+    void main() {
+        gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+    }
+");
+# fn main() {}
+```
+
+The first parameter can be `vertex`, `fragment`, `geometry`, `compute`, `tessellation_control`
+or `tessellation_evaluation`.
+
+*/
 #![feature(plugin_registrar)]
 #![feature(quote)]
 #![feature(unboxed_closures)]
 
+#[cfg(feature = "glslang")]
+extern crate glslang;
+
 extern crate rustc;
 extern crate syntax;
 
+#[cfg(feature = "glslang")]
+mod shaders;
 mod uniforms;
 mod vertex;
 
@@ -12,8 +46,19 @@ mod vertex;
 #[plugin_registrar]
 pub fn registrar(registry: &mut rustc::plugin::Registry) {
     use syntax::parse::token;
+
+    #[cfg(feature = "glslang")]
+    fn register_verify_shader(registry: &mut rustc::plugin::Registry) {
+        registry.register_macro("verify_shader", shaders::verify_shader);
+    }
+    #[cfg(not(feature = "glslang"))]
+    fn register_verify_shader(registry: &mut rustc::plugin::Registry) {
+    }
+    register_verify_shader(registry);
+
     registry.register_syntax_extension(token::intern("uniforms"),
         syntax::ext::base::Decorator(Box::new(uniforms::expand)));
     registry.register_syntax_extension(token::intern("vertex_format"),
         syntax::ext::base::Decorator(Box::new(vertex::expand)));
 }
+

--- a/macros/src/shaders.rs
+++ b/macros/src/shaders.rs
@@ -1,0 +1,54 @@
+use glslang;
+
+use syntax::ext::base::{self, MacResult, ExtCtxt};
+use syntax::ext::build::AstBuilder;
+use syntax::ast;
+use syntax::codemap::Span;
+use syntax::ptr::P;
+use syntax::parse::token::{self, Token};
+
+pub fn verify_shader<'cx>(ecx: &'cx mut ExtCtxt, span: Span, tts: &[ast::TokenTree])
+                          -> Box<MacResult + 'cx>
+{
+    if tts.len() != 2 {
+        ecx.span_err(span, "The verify_shader! macro takes two parameters");
+        return base::DummyResult::any(span);
+    }
+
+    let ident = match tts[0] {
+        ast::TokenTree::TtToken(_, Token::Ident(ref ident, _)) => ident,
+        _ => {
+            ecx.span_err(span, "Unexpected first parameter. Expected ident.");
+            return base::DummyResult::any(span);
+        }
+    };
+
+    let shader_type = match ident.as_str() {
+        "vertex" => glslang::ShaderType::Vertex,
+        "fragment" => glslang::ShaderType::Fragment,
+        "geometry" => glslang::ShaderType::Geometry,
+        "compute" => glslang::ShaderType::Compute,
+        "tessellation_control" => glslang::ShaderType::TessellationControl,
+        "tessellation_evaluation" => glslang::ShaderType::TessellationEvaluation,
+        _ => {
+            ecx.span_err(span, "Unexpected first parameter. Must be `vertex`, `fragment`, `geometry`,
+                                `compute`, `tessellation_control` or `tessellation_evaluation`.");
+            return base::DummyResult::any(span);
+        }
+    };
+
+    let source = match base::get_single_str_from_tts(ecx, span, tts.slice_from(1), "source code") {
+        Some(c) => c,
+        None => return base::DummyResult::any(span)
+    };
+
+    match glslang::test_shaders(vec![(source.as_slice(), shader_type)]) {
+        glslang::TestResult::Ok => (),
+        glslang::TestResult::Error(err_str) => {
+            ecx.span_err(span, err_str.as_slice());
+            return base::DummyResult::any(span);
+        },
+    };
+
+    base::MacExpr::new(ecx.expr_lit(span, ast::Lit_::LitStr(token::intern_and_get_ident(source.as_slice()), ast::StrStyle::CookedStr)))
+}

--- a/macros/tests/shader.rs
+++ b/macros/tests/shader.rs
@@ -1,0 +1,16 @@
+#![cfg(feature = "glslang")]
+#![feature(plugin)]
+
+#[plugin]
+extern crate glium_macros;
+
+#[test]
+fn verify_shader() {
+    static VERTEX_SHADER: &'static str = verify_shader!(vertex "
+        #version 110
+
+        void main() {
+            gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+        }
+    ");
+}


### PR DESCRIPTION
Usage:

```rust
static VERTEX_SHADER: &'static str = verify_shader!(vertex "
    #version 110

    void main() {
        gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
    }
");
```

Prints a compilation error if there is an error in the shader's source code.
The first parameter must be `vertex`, `fragment`, `geometry`, `compute`, `tessellation_control` or `tessellation_evaluation`.

For the moment, it's behind a Cargo feature named `glslang`, because the `glslang-rs` crate is difficult to setup.

Need #171 to land for further awesomeness.
