### PR TITLE
Rename the vertex_buffer module to just "vertex"

### DIFF
--- a/macros/src/vertex.rs
+++ b/macros/src/vertex.rs
@@ -85,7 +85,7 @@ fn body(ecx: &mut base::ExtCtxt, span: codemap::Span,
                 }).collect::<Vec<P<ast::Expr>>>();
 
             quote_expr!(ecx, {
-                use glium::vertex_buffer::Attribute;
+                use glium::vertex::Attribute;
                 use std::mem;
 
                 let mut bindings = Vec::new();

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -202,7 +202,7 @@ impl<'a> Surface for SimpleFrameBuffer<'a> {
 
     fn draw<'b, 'v, V, I, U>(&mut self, vb: V, ib: &I, program: &::Program,
         uniforms: U, draw_parameters: &::DrawParameters) where I: ::index_buffer::ToIndicesSource,
-        U: ::uniforms::Uniforms, V: ::vertex_buffer::IntoVerticesSource<'v>
+        U: ::uniforms::Uniforms, V: ::vertex::IntoVerticesSource<'v>
     {
         use index_buffer::ToIndicesSource;
         
@@ -379,7 +379,7 @@ impl<'a> Surface for MultiOutputFrameBuffer<'a> {
 
     fn draw<'v, V, I, U>(&mut self, vb: V, ib: &I, program: &::Program,
         uniforms: U, draw_parameters: &::DrawParameters) where I: ::index_buffer::ToIndicesSource,
-        U: ::uniforms::Uniforms, V: ::vertex_buffer::IntoVerticesSource<'v>
+        U: ::uniforms::Uniforms, V: ::vertex::IntoVerticesSource<'v>
     {
         use index_buffer::ToIndicesSource;
         

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,10 +31,10 @@ The window you are drawing on will produce events. They can be received by calli
 
 We start by creating the vertex buffer, which contains the list of all the points that make up
 our mesh. The elements that we pass to `VertexBuffer::new` must implement the
-`glium::vertex_buffer::VertexFormat` trait. We can easily do this by creating a custom struct
+`glium::vertex::VertexFormat` trait. We can easily do this by creating a custom struct
 and adding the `#[vertex_format]` attribute to it.
 
-See the `vertex_buffer` module documentation for more informations.
+See the `vertex` module documentation for more informations.
 
 ```no_run
 # #![feature(plugin)]
@@ -51,7 +51,7 @@ struct Vertex {
 }
 
 # let display: glium::Display = unsafe { std::mem::uninitialized() };
-let vertex_buffer = glium::VertexBuffer::new(&display, vec![
+let vertex = glium::VertexBuffer::new(&display, vec![
     Vertex { position: [-0.5, -0.5], color: [0.0, 1.0, 0.0] },
     Vertex { position: [ 0.0,  0.5], color: [0.0, 0.0, 1.0] },
     Vertex { position: [ 0.5, -0.5], color: [1.0, 0.0, 0.0] },
@@ -197,7 +197,7 @@ extern crate libc;
 extern crate nalgebra;
 
 pub use index_buffer::IndexBuffer;
-pub use vertex_buffer::{VertexBuffer, Vertex, VertexFormat};
+pub use vertex::{VertexBuffer, Vertex, VertexFormat};
 pub use program::{Program, ProgramCreationError};
 pub use program::ProgramCreationError::{CompilationError, LinkingError, ShaderTypeNotSupported};
 pub use sync::{LinearSyncFence, SyncFence};
@@ -216,7 +216,7 @@ pub mod macros;
 pub mod program;
 pub mod render_buffer;
 pub mod uniforms;
-pub mod vertex_buffer;
+pub mod vertex;
 pub mod texture;
 
 mod buffer;
@@ -1010,7 +1010,7 @@ pub trait Surface: Sized {
     /// - Panics if a value in the uniforms doesn't match the type requested by the program.
     ///
     fn draw<'a, 'b, V, I, U>(&mut self, V, &I, program: &Program, uniforms: U,
-        draw_parameters: &DrawParameters) where V: vertex_buffer::IntoVerticesSource<'b>,
+        draw_parameters: &DrawParameters) where V: vertex::IntoVerticesSource<'b>,
         I: index_buffer::ToIndicesSource, U: uniforms::Uniforms;
 
     /// Returns an opaque type that is used by the implementation of blit functions.
@@ -1098,7 +1098,7 @@ impl<'t> Surface for Frame<'t> {
                          index_buffer: &I, program: &Program, uniforms: U,
                          draw_parameters: &DrawParameters)
                          where I: index_buffer::ToIndicesSource, U: uniforms::Uniforms,
-                         V: vertex_buffer::IntoVerticesSource<'b>
+                         V: vertex::IntoVerticesSource<'b>
     {
         use index_buffer::ToIndicesSource;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -50,8 +50,8 @@ macro_rules! attributes {
             ),+
         }
 
-        impl $crate::vertex_buffer::Vertex for $struct_name {
-            fn build_bindings(_: Option<Self>) -> $crate::vertex_buffer::VertexFormat {
+        impl $crate::vertex::Vertex for $struct_name {
+            fn build_bindings(_: Option<Self>) -> $crate::vertex::VertexFormat {
                 vec![
                     $(
                         (
@@ -62,7 +62,7 @@ macro_rules! attributes {
                                 let dummy_field: usize = unsafe { ::std::mem::transmute(dummy_field) };
                                 dummy_field
                             },
-                            $crate::vertex_buffer::Attribute::get_type(None::<$t>)
+                            $crate::vertex::Attribute::get_type(None::<$t>)
                         )
                     )+
                 ]

--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -9,7 +9,7 @@ use sync;
 use uniforms::{Uniforms, UniformValue, SamplerBehavior};
 use {Program, DrawParameters, GlObject, ToGlEnum};
 use index_buffer::IndicesSource;
-use vertex_buffer::VerticesSource;
+use vertex::VerticesSource;
 
 use {program, vertex_array_object};
 use {gl, context};

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -291,7 +291,7 @@ impl<'a> Surface for TextureSurface<'a> {
     fn draw<'b, 'v, V, I, U>(&mut self, vb: V, ib: &I, program: &::Program,
         uniforms: U, draw_parameters: &::DrawParameters)
         where I: ::index_buffer::ToIndicesSource,
-        U: ::uniforms::Uniforms, V: ::vertex_buffer::IntoVerticesSource<'v>
+        U: ::uniforms::Uniforms, V: ::vertex::IntoVerticesSource<'v>
     {
         self.0.draw(vb, ib, program, uniforms, draw_parameters)
     }

--- a/src/vertex.rs
+++ b/src/vertex.rs
@@ -5,7 +5,7 @@ The main struct is the `VertexBuffer`, which represents a buffer in the video me
 containing a list of vertices.
 
 In order to create a vertex buffer, you must first create a struct that represents each vertex,
-and implement the `glium::vertex_buffer::Vertex` trait on it. The `#[vertex_format]` attribute
+and implement the `glium::vertex::Vertex` trait on it. The `#[vertex_format]` attribute
 located in `glium_macros` helps you with that.
 
 ```
@@ -34,8 +34,8 @@ Next, build a `Vec` of the vertices that you want to upload, and pass it to
 #     position: [f32; 3],
 #     texcoords: [f32; 2],
 # }
-# impl glium::vertex_buffer::Vertex for Vertex {
-#     fn build_bindings(_: Option<Vertex>) -> glium::vertex_buffer::VertexFormat {
+# impl glium::vertex::Vertex for Vertex {
+#     fn build_bindings(_: Option<Vertex>) -> glium::vertex::VertexFormat {
 #         unimplemented!() }
 # }
 let data = vec![
@@ -53,7 +53,7 @@ let data = vec![
     },
 ];
 
-let vertex_buffer = glium::vertex_buffer::VertexBuffer::new(&display, data);
+let vertex_buffer = glium::vertex::VertexBuffer::new(&display, data);
 ```
 
 */
@@ -202,10 +202,10 @@ impl<T: Send + Copy> VertexBuffer<T> {
     /// # fn main() {
     /// let bindings = vec![(
     ///         format!("position"), 0,
-    ///         glium::vertex_buffer::AttributeType::F32F32,
+    ///         glium::vertex::AttributeType::F32F32,
     ///     ), (
     ///         format!("color"), 2 * ::std::mem::size_of::<f32>(),
-    ///         glium::vertex_buffer::AttributeType::F32,
+    ///         glium::vertex::AttributeType::F32,
     ///     ),
     /// ];
     ///

--- a/src/vertex_array_object.rs
+++ b/src/vertex_array_object.rs
@@ -4,7 +4,7 @@ use std::mem;
 
 use program::Program;
 use index_buffer::IndicesSource;
-use vertex_buffer::{VerticesSource, AttributeType};
+use vertex::{VerticesSource, AttributeType};
 use {DisplayImpl, GlObject};
 
 use {libc, gl};

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -70,7 +70,7 @@ pub fn build_unicolor_texture2d(display: &glium::Display, red: f32, green: f32, 
 }
 
 /// Builds a vertex buffer, index buffer, and program, to draw red `(1.0, 0.0, 0.0, 1.0)` to the whole screen.
-pub fn build_fullscreen_red_pipeline(display: &glium::Display) -> (glium::vertex_buffer::VertexBufferAny,
+pub fn build_fullscreen_red_pipeline(display: &glium::Display) -> (glium::vertex::VertexBufferAny,
     glium::IndexBuffer, glium::Program)
 {
     #[vertex_format]
@@ -112,7 +112,7 @@ pub fn build_fullscreen_red_pipeline(display: &glium::Display) -> (glium::vertex
 ///
 /// The vertex buffer has the "position" attribute of type "vec2".
 pub fn build_rectangle_vb_ib(display: &glium::Display)
-    -> (glium::vertex_buffer::VertexBufferAny, glium::IndexBuffer)
+    -> (glium::vertex::VertexBufferAny, glium::IndexBuffer)
 {
     #[vertex_format]
     #[derive(Copy)]


### PR DESCRIPTION
The `vertex_buffer` module contains more than just the vertex buffer.