### PR TITLE
Add possibility to retreive a program's binary representation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ script:
     - cargo build --verbose
     - cargo test --features "headless" --verbose
     - cargo test --no-default-features --features "headless" --verbose
-    - cargo build --features "headless gl_read_buffer gl_uniform_blocks gl_sync gl_persistent_mapping" --verbose
+    - cargo build --features "headless gl_read_buffer gl_uniform_blocks gl_sync gl_persistent_mapping gl_program_binary" --verbose
 
 after_success: |
     [ $TRAVIS_BRANCH = master ] &&
     [ $TRAVIS_PULL_REQUEST = false ] &&
-    cargo doc --features "headless gl_read_buffer gl_uniform_blocks gl_sync gl_persistent_mapping" &&
+    cargo doc --features "headless gl_read_buffer gl_uniform_blocks gl_sync gl_persistent_mapping gl_program_binary" &&
     echo '<meta http-equiv=refresh content=0;url=glium/index.html>' > target/doc/index.html &&
     sudo pip install ghp-import &&
     ghp-import -n target/doc &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ gl_read_buffer = []
 gl_uniform_blocks = []
 gl_sync = []
 gl_persistent_mapping = ["gl_sync"]
+gl_program_binary = []
 headless = ["glutin/headless"]
 
 [dependencies.compile_msg]

--- a/src/context.rs
+++ b/src/context.rs
@@ -242,6 +242,8 @@ pub struct ExtensionsList {
     pub gl_arb_uniform_buffer_object: bool,
     /// GL_ARB_sync
     pub gl_arb_sync: bool,
+    /// GL_ARB_get_program_binary
+    pub gl_arb_get_programy_binary: bool,
 }
 
 /// Represents the capabilities of the context.
@@ -555,6 +557,12 @@ fn check_gl_compatibility(ctxt: CommandContext) -> Result<(), GliumCreationError
         {
             result.push("OpenGL implementation doesn't support persistent mapping");
         }
+
+        if cfg!(feature = "gl_program_binary") && ctxt.version < &GlVersion(4, 1) &&
+            !ctxt.extensions.gl_arb_get_programy_binary
+        {
+            result.push("OpenGL implementation doesn't support program binary");
+        }
     }
 
     if result.len() == 0 {
@@ -621,6 +629,7 @@ fn get_extensions(gl: &gl::Gl) -> ExtensionsList {
         gl_arb_buffer_storage: false,
         gl_arb_uniform_buffer_object: false,
         gl_arb_sync: false,
+        gl_arb_get_programy_binary: false,
     };
 
     for extension in strings.into_iter() {
@@ -639,6 +648,7 @@ fn get_extensions(gl: &gl::Gl) -> ExtensionsList {
             "GL_ARB_buffer_storage" => extensions.gl_arb_buffer_storage = true,
             "GL_ARB_uniform_buffer_object" => extensions.gl_arb_uniform_buffer_object = true,
             "GL_ARB_sync" => extensions.gl_arb_sync = true,
+            "GL_ARB_get_program_binary" => extensions.gl_arb_get_programy_binary = true,
             _ => ()
         }
     }

--- a/tests/program.rs
+++ b/tests/program.rs
@@ -213,3 +213,43 @@ fn get_uniform_blocks() {
 
     display.assert_no_error();
 }
+
+#[test]
+fn get_program_binary() {
+    let display = support::build_display();
+
+    let program = glium::Program::from_source(&display,
+        "
+            #version 110
+
+            uniform mat4 matrix;
+
+            attribute vec2 position;
+            attribute vec3 color;
+
+            varying vec3 vColor;
+
+            void main() {
+                gl_Position = vec4(position, 0.0, 1.0) * matrix;
+                vColor = color;
+            }
+        ",
+        "
+            #version 110
+            varying vec3 vColor;
+
+            void main() {
+                gl_FragColor = vec4(vColor, 1.0);
+            }
+        ",
+        None).unwrap();
+
+    let binary = match program.get_binary_if_supported() {
+        None => return,
+        Some(bin) => bin
+    };
+
+    assert!(binary.content.len() >= 1);
+
+    display.assert_no_error();
+}


### PR DESCRIPTION
- Adds a `gl_program_binary` Cargo feature.
- Adds a `Binary` struct in the `program` module.
- Adds `program.get_binary()` and `program.get_binary_if_supported()`.
- Doesn't allow creating a program from the binary yet.
