### PR TITLE
Rework blending to make it more flexible

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -115,6 +115,9 @@ pub struct GLState {
     /// The latest render buffer bound with `glBindRenderbuffer`.
     pub renderbuffer: gl::types::GLuint,
 
+    /// The latest values passed to `glBlendEquation`.
+    pub blend_equation: gl::types::GLenum,
+
     /// The latest values passed to `glBlendFunc`.
     pub blend_func: (gl::types::GLenum, gl::types::GLenum),
 
@@ -180,6 +183,7 @@ impl GLState {
             renderbuffer: 0,
             depth_func: gl::LESS,
             depth_range: (0.0, 1.0),
+            blend_equation: gl::FUNC_ADD,
             blend_func: (0, 0),     // no default specified
             viewport: viewport,
             scissor: viewport,

--- a/tests/blending.rs
+++ b/tests/blending.rs
@@ -1,0 +1,93 @@
+#![feature(plugin)]
+#![feature(unboxed_closures)]
+
+#[plugin]
+extern crate glium_macros;
+
+extern crate glutin;
+extern crate glium;
+
+use glium::Surface;
+
+mod support;
+
+#[test]
+fn min_blending() {
+    let display = support::build_display();
+
+    let params = glium::DrawParameters {
+        blending_function: Some(glium::BlendingFunction::Min),
+        .. std::default::Default::default()
+    };
+
+    let (vb, ib, program) = support::build_fullscreen_red_pipeline(&display);
+
+    let mut target = display.draw();
+    target.clear_color(0.0, 0.2, 0.3, 1.0);
+    target.draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params);
+    target.finish();
+
+    let data: Vec<Vec<(u8, u8, u8, u8)>> = display.read_front_buffer();
+    for row in data.iter() {
+        for pixel in row.iter() {
+            assert_eq!(pixel, &(0, 0, 0, 255));
+        }
+    }
+
+    display.assert_no_error();
+}
+
+#[test]
+fn max_blending() {
+    let display = support::build_display();
+
+    let params = glium::DrawParameters {
+        blending_function: Some(glium::BlendingFunction::Max),
+        .. std::default::Default::default()
+    };
+
+    let (vb, ib, program) = support::build_fullscreen_red_pipeline(&display);
+
+    let mut target = display.draw();
+    target.clear_color(0.4, 1.0, 1.0, 0.2);
+    target.draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params);
+    target.finish();
+
+    let data: Vec<Vec<(u8, u8, u8, u8)>> = display.read_front_buffer();
+    for row in data.iter() {
+        for pixel in row.iter() {
+            assert_eq!(pixel, &(255, 255, 255, 255));
+        }
+    }
+
+    display.assert_no_error();
+}
+
+#[test]
+fn one_plus_one() {
+    let display = support::build_display();
+
+    let params = glium::DrawParameters {
+        blending_function: Some(glium::BlendingFunction::Addition {
+            source: glium::LinearBlendingFactor::One,
+            destination: glium::LinearBlendingFactor::One,
+        }),
+        .. std::default::Default::default()
+    };
+
+    let (vb, ib, program) = support::build_fullscreen_red_pipeline(&display);
+
+    let mut target = display.draw();
+    target.clear_color(0.0, 1.0, 1.0, 0.0);
+    target.draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params);
+    target.finish();
+
+    let data: Vec<Vec<(u8, u8, u8, u8)>> = display.read_front_buffer();
+    for row in data.iter() {
+        for pixel in row.iter() {
+            assert_eq!(pixel, &(255, 255, 255, 255));
+        }
+    }
+
+    display.assert_no_error();
+}


### PR DESCRIPTION
Close #302 
cc #161 

Breaking change: removes `LerpBySourceAlpha`. Replace by `Addition { source: Alpha, destination: OneMinusSourceAlpha }`.