### PR TITLE
draw() now returns a Result instead of panicking

### DIFF
--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -329,7 +329,7 @@ fn main() {
             model_matrix: *fixed_model_matrix,
             texture: &opengl_texture
         };
-        framebuffer.draw(&floor_vertex_buffer, &floor_index_buffer, &prepass_program, &uniforms, &std::default::Default::default());
+        framebuffer.draw(&floor_vertex_buffer, &floor_index_buffer, &prepass_program, &uniforms, &std::default::Default::default()).unwrap();
 
         // lighting
         let draw_params = glium::DrawParameters {
@@ -351,7 +351,7 @@ fn main() {
                 light_color: light.color,
                 light_radius: light.radius
             };
-            light_buffer.draw(&quad_vertex_buffer, &quad_index_buffer, &lighting_program, &uniforms, &draw_params);
+            light_buffer.draw(&quad_vertex_buffer, &quad_index_buffer, &lighting_program, &uniforms, &draw_params).unwrap();
         }
 
         // composition
@@ -362,7 +362,7 @@ fn main() {
         };
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 0.0, 0.0);
-        target.draw(&quad_vertex_buffer, &quad_index_buffer, &composition_program, &uniforms, &std::default::Default::default());
+        target.draw(&quad_vertex_buffer, &quad_index_buffer, &composition_program, &uniforms, &std::default::Default::default()).unwrap();
         target.finish();
 
         // sleeping for some time in order not to use up too much CPU

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -108,7 +108,7 @@ fn main() {
         // drawing a frame
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 0.0, 0.0);
-        target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &std::default::Default::default());
+        target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &std::default::Default::default()).unwrap();
         target.finish();
 
         // sleeping for some time in order not to use up too much CPU

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -103,7 +103,7 @@ fn main() {
     // drawing a frame
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
-    target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &std::default::Default::default());
+    target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &std::default::Default::default()).unwrap();
     target.finish();
 
     // reading the front buffer into an image

--- a/examples/teapot.rs
+++ b/examples/teapot.rs
@@ -97,7 +97,7 @@ fn main() {
         // drawing a frame
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 0.0, 0.0);
-        target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &params);
+        target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &params).unwrap();
         target.finish();
 
         // sleeping for some time in order not to use up too much CPU

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -92,7 +92,7 @@ fn main() {
         // drawing a frame
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 0.0, 0.0);
-        target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &std::default::Default::default());
+        target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &std::default::Default::default()).unwrap();
         target.finish();
 
         // sleeping for some time in order not to use up too much CPU

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -289,7 +289,7 @@ impl<'a> Surface for TextureSurface<'a> {
     }
 
     fn draw<'b, 'v, V, I, U>(&mut self, vb: V, ib: &I, program: &::Program,
-        uniforms: U, draw_parameters: &::DrawParameters)
+        uniforms: U, draw_parameters: &::DrawParameters) -> Result<(), ::DrawError>
         where I: ::index_buffer::ToIndicesSource,
         U: ::uniforms::Uniforms, V: ::vertex::IntoVerticesSource<'v>
     {

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -52,7 +52,7 @@ fn attribute_types_matching() {
     // drawing a frame
     let mut target = display.draw();
     target.draw(&vertex_buffer, &index_buffer, &program, &glium::uniforms::EmptyUniforms,
-                &std::default::Default::default());
+                &std::default::Default::default()).unwrap();
     target.finish();
     
     display.assert_no_error();
@@ -98,7 +98,7 @@ fn attribute_types_mismatch() {
     // drawing a frame
     let mut target = display.draw();
     target.draw(&vertex_buffer, &index_buffer, &program, &glium::uniforms::EmptyUniforms,
-                &std::default::Default::default());
+                &std::default::Default::default()).unwrap();
     target.finish();
     
     display.assert_no_error();
@@ -144,7 +144,7 @@ fn missing_attribute() {
     // drawing a frame
     let mut target = display.draw();
     target.draw(&vertex_buffer, &index_buffer, &program, &glium::uniforms::EmptyUniforms,
-                &std::default::Default::default());
+                &std::default::Default::default()).unwrap();
     target.finish();
     
     display.assert_no_error();

--- a/tests/backface-culling.rs
+++ b/tests/backface-culling.rs
@@ -61,7 +61,7 @@ fn cull_clockwise() {
         &glium::DrawParameters {
             backface_culling: glium::BackfaceCullingMode::CullClockWise,
             .. std::default::Default::default()
-        });
+        }).unwrap();
     target.finish();
 
     let read_back: Vec<Vec<(f32, f32, f32, f32)>> = display.read_front_buffer();
@@ -121,7 +121,7 @@ fn cull_counterclockwise() {
         &glium::DrawParameters {
             backface_culling: glium::BackfaceCullingMode::CullCounterClockWise,
             .. std::default::Default::default()
-        });
+        }).unwrap();
     target.finish();
 
     let read_back: Vec<Vec<(f32, f32, f32, f32)>> = display.read_front_buffer();
@@ -180,7 +180,7 @@ fn cull_clockwise_trianglestrip() {
         &glium::DrawParameters {
             backface_culling: glium::BackfaceCullingMode::CullClockWise,
             .. std::default::Default::default()
-        });
+        }).unwrap();
     target.finish();
 
     let read_back: Vec<Vec<(f32, f32, f32, f32)>> = display.read_front_buffer();
@@ -239,7 +239,7 @@ fn cull_counterclockwise_trianglestrip() {
         &glium::DrawParameters {
             backface_culling: glium::BackfaceCullingMode::CullCounterClockWise,
             .. std::default::Default::default()
-        });
+        }).unwrap();
     target.finish();
 
     let read_back: Vec<Vec<(f32, f32, f32, f32)>> = display.read_front_buffer();

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -38,7 +38,6 @@ fn release_shader_compiler() {
 }
 
 #[test]
-#[should_fail(expected = "Viewport dimensions are too large")]
 fn viewport_too_large() {
     let display = support::build_display();
 
@@ -53,7 +52,13 @@ fn viewport_too_large() {
     };
 
     let (vb, ib, program) = support::build_fullscreen_red_pipeline(&display);
-    display.draw().draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params);
+    
+    match display.draw().draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params) {
+        Err(glium::DrawError::ViewportTooLarge) => (),
+        a => panic!("{:?}", a)
+    };
+
+    display.assert_no_error();
 }
 
 #[test]
@@ -75,7 +80,6 @@ fn timestamp_query() {
 }
 
 #[test]
-#[should_fail(expected = "Depth range must be between 0 and 1")]
 fn wrong_depth_range() {
     let display = support::build_display();
 
@@ -85,7 +89,13 @@ fn wrong_depth_range() {
     };
 
     let (vb, ib, program) = support::build_fullscreen_red_pipeline(&display);
-    display.draw().draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params);
+    
+    match display.draw().draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params) {
+        Err(glium::DrawError::InvalidDepthRange) => (),
+        a => panic!("{:?}", a)
+    };
+
+    display.assert_no_error();
 }
 
 #[test]
@@ -106,7 +116,7 @@ fn scissor() {
 
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
-    target.draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params);
+    target.draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params).unwrap();
     target.finish();
 
     let data: Vec<Vec<(f32, f32, f32)>> = display.read_front_buffer();

--- a/tests/indices.rs
+++ b/tests/indices.rs
@@ -53,7 +53,7 @@ fn triangles_list_cpu() {
 
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
-    target.draw(&vb, &indices, &program, &glium::uniforms::EmptyUniforms, &Default::default());
+    target.draw(&vb, &indices, &program, &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
     target.finish();
 
     let data: Vec<Vec<(u8, u8, u8)>> = display.read_front_buffer();
@@ -78,7 +78,7 @@ fn triangle_strip_cpu() {
 
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
-    target.draw(&vb, &indices, &program, &glium::uniforms::EmptyUniforms, &Default::default());
+    target.draw(&vb, &indices, &program, &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
     target.finish();
 
     let data: Vec<Vec<(u8, u8, u8)>> = display.read_front_buffer();
@@ -104,7 +104,7 @@ fn triangle_fan_cpu() {
 
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
-    target.draw(&vb, &indices, &program, &glium::uniforms::EmptyUniforms, &Default::default());
+    target.draw(&vb, &indices, &program, &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
     target.finish();
 
     let data: Vec<Vec<(u8, u8, u8)>> = display.read_front_buffer();
@@ -130,7 +130,7 @@ fn triangles_list_gpu() {
 
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
-    target.draw(&vb, &indices, &program, &glium::uniforms::EmptyUniforms, &Default::default());
+    target.draw(&vb, &indices, &program, &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
     target.finish();
 
     let data: Vec<Vec<(u8, u8, u8)>> = display.read_front_buffer();
@@ -156,7 +156,7 @@ fn triangle_strip_gpu() {
 
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
-    target.draw(&vb, &indices, &program, &glium::uniforms::EmptyUniforms, &Default::default());
+    target.draw(&vb, &indices, &program, &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
     target.finish();
 
     let data: Vec<Vec<(u8, u8, u8)>> = display.read_front_buffer();
@@ -183,7 +183,7 @@ fn triangle_fan_gpu() {
 
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
-    target.draw(&vb, &indices, &program, &glium::uniforms::EmptyUniforms, &Default::default());
+    target.draw(&vb, &indices, &program, &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
     target.finish();
 
     let data: Vec<Vec<(u8, u8, u8)>> = display.read_front_buffer();

--- a/tests/samplers.rs
+++ b/tests/samplers.rs
@@ -55,7 +55,7 @@ fn magnify_nearest_filtering() {
 
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
-    target.draw(&vb, &ib, &program, &uniforms, &Default::default());
+    target.draw(&vb, &ib, &program, &uniforms, &Default::default()).unwrap();
     target.finish();
 
     let data: Vec<Vec<(u8, u8, u8)>> = display.read_front_buffer();

--- a/tests/texture.rs
+++ b/tests/texture.rs
@@ -120,7 +120,7 @@ fn render_to_texture2d() {
                                               glium::texture::UncompressedFloatFormat::U8U8U8U8,
                                               1024, 1024);
     let params = Default::default();
-    texture.as_surface().draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params);
+    texture.as_surface().draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params).unwrap();
 
     let read_back: Vec<Vec<(u8, u8, u8, u8)>> = texture.read();
 

--- a/tests/tmp.rs
+++ b/tests/tmp.rs
@@ -88,7 +88,7 @@ fn test() {
 
     // drawing a frame
     let mut target = display.draw();
-    target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &std::default::Default::default());
+    target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &std::default::Default::default()).unwrap();
     target.finish();
     
     display.assert_no_error();

--- a/tests/uniforms.rs
+++ b/tests/uniforms.rs
@@ -48,7 +48,7 @@ fn uniforms_storage_single_value() {
 
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
-    target.draw(&vb, &ib, &program, &uniforms, &Default::default());
+    target.draw(&vb, &ib, &program, &uniforms, &Default::default()).unwrap();
     target.finish();
 
     let data: Vec<Vec<(u8, u8, u8)>> = display.read_front_buffer();
@@ -90,7 +90,7 @@ fn uniforms_storage_multiple_values() {
 
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
-    target.draw(&vb, &ib, &program, &uniforms, &Default::default());
+    target.draw(&vb, &ib, &program, &uniforms, &Default::default()).unwrap();
     target.finish();
 
     let data: Vec<Vec<(u8, u8, u8)>> = display.read_front_buffer();
@@ -132,7 +132,7 @@ fn uniforms_storage_ignore_inactive_uniforms() {
 
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
-    target.draw(&vb, &ib, &program, &uniforms, &Default::default());
+    target.draw(&vb, &ib, &program, &uniforms, &Default::default()).unwrap();
     target.finish();
 
     let data: Vec<Vec<(u8, u8, u8)>> = display.read_front_buffer();
@@ -143,7 +143,6 @@ fn uniforms_storage_ignore_inactive_uniforms() {
 }
 
 #[test]
-#[should_fail]
 fn uniform_wrong_type() {    
     let display = support::build_display();
     let (vb, ib) = support::build_rectangle_vb_ib(&display);
@@ -173,5 +172,11 @@ fn uniform_wrong_type() {
 
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
-    target.draw(&vb, &ib, &program, &uniforms, &Default::default());
+    match target.draw(&vb, &ib, &program, &uniforms, &Default::default()) {
+        Err(glium::DrawError::UniformTypeMismatch { .. }) => (),
+        a => panic!("{:?}", a)
+    };
+    target.finish();
+
+    display.assert_no_error();
 }


### PR DESCRIPTION
Calling `draw(...).unwrap()` should restore the previous behavior.

Close #187