### PR TITLE
Implement tessellation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ script:
     - cargo build --verbose
     - cargo test --features "headless" --verbose
     - cargo test --no-default-features --features "headless" --verbose
-    - cargo build --features "headless gl_read_buffer gl_uniform_blocks gl_sync gl_persistent_mapping gl_program_binary" --verbose
+    - cargo build --features "headless gl_read_buffer gl_uniform_blocks gl_sync gl_persistent_mapping gl_program_binary gl_tessellation" --verbose
 
 after_success: |
     [ $TRAVIS_BRANCH = master ] &&
     [ $TRAVIS_PULL_REQUEST = false ] &&
-    cargo doc --features "headless gl_read_buffer gl_uniform_blocks gl_sync gl_persistent_mapping gl_program_binary" &&
+    cargo doc --features "headless gl_read_buffer gl_uniform_blocks gl_sync gl_persistent_mapping gl_program_binary gl_tessellation" &&
     echo '<meta http-equiv=refresh content=0;url=glium/index.html>' > target/doc/index.html &&
     sudo pip install ghp-import &&
     ghp-import -n target/doc &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ gl_uniform_blocks = []
 gl_sync = []
 gl_persistent_mapping = ["gl_sync"]
 gl_program_binary = []
+gl_tessellation = []
 headless = ["glutin/headless"]
 
 [dependencies.compile_msg]

--- a/examples/tessellation.rs
+++ b/examples/tessellation.rs
@@ -1,0 +1,176 @@
+#![feature(plugin)]
+
+#[plugin]
+extern crate glium_macros;
+
+extern crate glutin;
+
+#[macro_use]
+extern crate glium;
+
+use glium::Surface;
+
+fn main() {
+    use glium::DisplayBuild;
+
+    // building the display, ie. the main object
+    let display = glutin::WindowBuilder::new()
+        .build_glium()
+        .unwrap();
+
+    // building the vertex buffer, which contains all the vertices that we will draw
+    let vertex_buffer = {
+        #[vertex_format]
+        #[derive(Copy)]
+        struct Vertex {
+            position: [f32; 2],
+        }
+
+        glium::VertexBuffer::new(&display, 
+            vec![
+                Vertex { position: [-0.5, -0.5] },
+                Vertex { position: [ 0.0,  0.5] },
+                Vertex { position: [ 0.5, -0.5] },
+            ]
+        )
+    };
+
+    // building the index buffer
+    let index_buffer = glium::IndexBuffer::new(&display,
+        glium::index_buffer::Patches(vec![0u16, 1, 2], 3));
+
+    // compiling shaders and linking them together
+    let program = glium::Program::new(&display,
+        glium::program::SourceCode {
+            vertex_shader: "
+                #version 130
+
+                in vec2 position;
+
+                void main() {
+                    gl_Position = vec4(position, 0.0, 1.0);
+                }
+            ",
+            fragment_shader: "
+                #version 130
+
+                in vec3 color;
+
+                void main() {
+                    gl_FragColor = vec4(color, 1.0);
+                }
+            ",
+            geometry_shader: Some("
+                #version 330
+
+                uniform mat4 matrix;
+
+                layout(triangles) in;
+                layout(triangle_strip, max_vertices=3) out;
+
+                out vec3 color;
+
+                float rand(vec2 co) {
+                    return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);
+                }
+
+                void main() {
+                    vec3 all_color = vec3(
+                        rand(gl_in[0].gl_Position.xy + gl_in[1].gl_Position.yz),
+                        rand(gl_in[1].gl_Position.yx + gl_in[2].gl_Position.zx),
+                        rand(gl_in[0].gl_Position.xz + gl_in[2].gl_Position.zy)
+                    );
+
+                    gl_Position = matrix * gl_in[0].gl_Position;
+                    color = all_color;
+                    EmitVertex();
+
+                    gl_Position = matrix * gl_in[1].gl_Position;
+                    color = all_color;
+                    EmitVertex();
+
+                    gl_Position = matrix * gl_in[2].gl_Position;
+                    color = all_color;
+                    EmitVertex();
+                }
+            "),
+            tessellation_control_shader: Some("
+                #version 400
+
+                layout(vertices = 3) out;
+
+                uniform int tess_level = 5;
+
+                void main() {
+                    gl_out[gl_InvocationID].gl_Position = gl_in[gl_InvocationID].gl_Position;
+
+                    gl_TessLevelOuter[0] = tess_level;
+                    gl_TessLevelOuter[1] = tess_level;
+                    gl_TessLevelOuter[2] = tess_level;
+                    gl_TessLevelInner[0] = tess_level;
+                }
+            "),
+            tessellation_evaluation_shader: Some("
+                #version 400
+
+                layout(triangles, equal_spacing) in;
+
+                void main() {
+                    vec3 position = vec3(gl_TessCoord.x) * gl_in[0].gl_Position.xyz +
+                                    vec3(gl_TessCoord.y) * gl_in[1].gl_Position.xyz +
+                                    vec3(gl_TessCoord.z) * gl_in[2].gl_Position.xyz;
+                    gl_Position = vec4(position, 1.0);
+                }
+
+            "),
+        }).unwrap();
+
+    // level of tessellation
+    let mut tess_level: i32 = 5;
+    println!("The current tessellation level is {} ; use the Up and Down keys to change it", tess_level);
+    
+    // the main loop
+    // each cycle will draw once
+    'main: loop {
+        use std::io::timer;
+        use std::time::Duration;
+
+        // building the uniforms
+        let uniforms = uniform! {
+            matrix: [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0f32]
+            ],
+            tess_level: tess_level
+        };
+
+        // drawing a frame
+        let mut target = display.draw();
+        target.clear_color(0.0, 0.0, 0.0, 0.0);
+        target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &std::default::Default::default()).unwrap();
+        target.finish();
+
+        // sleeping for some time in order not to use up too much CPU
+        timer::sleep(Duration::milliseconds(17));
+
+        // polling and handling the events received by the window
+        for event in display.poll_events().into_iter() {
+            match event {
+                glutin::Event::Closed => break 'main,
+                glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(glutin::VirtualKeyCode::Up)) => {
+                    tess_level += 1;
+                    println!("New tessellation level: {}", tess_level);
+                },
+                glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(glutin::VirtualKeyCode::Down)) => {
+                    if tess_level >= 2 {
+                        tess_level -= 1;
+                        println!("New tessellation level: {}", tess_level);
+                    }
+                },
+                _ => ()
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1277,6 +1277,15 @@ pub enum DrawError {
         /// Name of the block you are trying to bind.
         name: String,
     },
+
+    /// The number of vertices per patch that has been requested is not supported.
+    UnsupportedVerticesPerPatch,
+
+    /// Trying to use tessellation, but this is not supported by the underlying hardware.
+    TessellationNotSupported,
+
+    /// Using a program which contains tessellation shaders, but without submitting patches.
+    TessellationWithoutPatches,
 }
 
 #[doc(hidden)]

--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -9,7 +9,7 @@ use fbo::{self, FramebufferAttachments};
 use sync;
 use uniforms::{Uniforms, UniformValue, SamplerBehavior};
 use {Program, DrawParameters, GlObject, ToGlEnum};
-use index_buffer::IndicesSource;
+use index_buffer::{self, IndicesSource};
 use vertex::VerticesSource;
 
 use {program, vertex_array_object};
@@ -40,6 +40,32 @@ pub fn draw<'a, I, U>(display: &Display,
     let data_type = indices.get_indices_type().to_glenum();
     assert!(indices.get_offset() == 0); // not yet implemented
     let indices_count = indices.get_length();
+
+    // handling tessellation
+    let vertices_per_patch = match indices.get_primitives_type() {
+        index_buffer::PrimitiveType::Patches { vertices_per_patch } => {
+            if let Some(max) = display.context.context.capabilities().max_patch_vertices {
+                if vertices_per_patch == 0 || vertices_per_patch as gl::types::GLint > max {
+                    return Err(DrawError::UnsupportedVerticesPerPatch);
+                }
+            } else {
+                return Err(DrawError::TessellationNotSupported);
+            }
+
+            if !program.has_tessellation_shaders() {    // TODO: 
+                panic!("Default tessellation level is not supported yet");
+            }
+
+            Some(vertices_per_patch)
+        },
+        _ => {
+            if program.has_tessellation_shaders() {
+                return Err(DrawError::TessellationWithoutPatches);
+            }
+
+            None
+        },
+    };
 
     // building the list of uniforms binders and the fences that must be fulfilled
     let (uniforms, fences): (Vec<Box<Fn(&mut context::CommandContext) + Send>>, _) = {
@@ -164,6 +190,15 @@ pub fn draw<'a, I, U>(display: &Display,
 
             // sync-ing parameters
             draw_parameters.sync(&mut ctxt, dimensions);
+
+            // vertices per patch
+            if let Some(vertices_per_patch) = vertices_per_patch {
+                let vertices_per_patch = vertices_per_patch as gl::types::GLint;
+                if ctxt.state.patch_patch_vertices != vertices_per_patch {
+                    ctxt.gl.PatchParameteri(gl::PATCH_VERTICES, vertices_per_patch);
+                    ctxt.state.patch_patch_vertices = vertices_per_patch;
+                }
+            }
 
             // drawing
             ctxt.gl.DrawElements(primitives, indices_count as i32, data_type, pointer.0);


### PR DESCRIPTION
- Adds a `gl_tessellation` feature
- Adds a `Patches` primitives type
- Adds a `Patches` struct as well
- Adds more elements in `DrawError`
- Adds `tessellation_control_shader` and `tessellation_evaluation_shader` in `program::SourceCode` and `program::ProgramCreationInput`

Does not support submitting patches with a default tessellation default level.