### PR TITLE
Implement instancing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ script:
     - cargo build --verbose
     - cargo test --features "headless" --verbose
     - cargo test --no-default-features --features "headless" --verbose
-    - cargo build --features "headless gl_read_buffer gl_uniform_blocks gl_sync gl_persistent_mapping gl_program_binary gl_tessellation" --verbose
+    - cargo build --features "headless gl_read_buffer gl_uniform_blocks gl_sync gl_persistent_mapping gl_program_binary gl_tessellation gl_instancing" --verbose
 
 after_success: |
     [ $TRAVIS_BRANCH = master ] &&
     [ $TRAVIS_PULL_REQUEST = false ] &&
-    cargo doc --features "headless gl_read_buffer gl_uniform_blocks gl_sync gl_persistent_mapping gl_program_binary gl_tessellation" &&
+    cargo doc --features "headless gl_read_buffer gl_uniform_blocks gl_sync gl_persistent_mapping gl_program_binary gl_tessellation gl_instancing" &&
     cp -R doc/* target/doc &&
     sudo pip install ghp-import &&
     ghp-import -n target/doc &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ gl_sync = []
 gl_persistent_mapping = ["gl_sync"]
 gl_program_binary = []
 gl_tessellation = []
+gl_instancing = []
 headless = ["glutin/headless"]
 
 [dependencies.compile_msg]

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ In addition to this, it has the following OpenGL-related features:
  - `gl_persistent_mapping` (buffers permanently mapped in memory)
  - `gl_program_binary` (cache a compiled program in order to reload it faster next time)
  - `gl_tessellation` (ask the GPU to split primitives into multiple sub-primitives when rendering)
+ - `gl_instancing` (draw multiple times the same model in only one command)
 
 Enabling each of these features adds more restrictions towards the backend and increases the
 likehood that `build_glium` will return an `Err`. However, it also gives you access to more

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -1,0 +1,106 @@
+#![feature(plugin)]
+
+#[plugin]
+extern crate glium_macros;
+
+extern crate glutin;
+
+#[macro_use]
+extern crate glium;
+
+use glium::Surface;
+
+fn main() {
+    use glium::DisplayBuild;
+
+    // building the display, ie. the main object
+    let display = glutin::WindowBuilder::new()
+        .build_glium()
+        .unwrap();
+
+    // building the vertex buffer, which contains all the vertices that we will draw
+    let vertex_buffer = {
+        #[vertex_format]
+        #[derive(Copy)]
+        struct Vertex {
+            position: [f32; 2]
+        }
+
+        glium::VertexBuffer::new(&display, 
+            vec![
+                Vertex { position: [-0.005, -0.005] },
+                Vertex { position: [  0.0 , 0.005] },
+                Vertex { position: [ 0.005, -0.005] },
+            ]
+        )
+    };
+
+    // building the instances buffer
+    let per_instance = {
+        #[vertex_format]
+        #[derive(Copy)]
+        struct Attr {
+            world_position: [f32; 2],
+        }
+
+        let mut data = Vec::new();
+        for x in (0 .. 104) {
+            for y in (0 .. 82) {
+                data.push(Attr {
+                    world_position: [((x as f32) / 50.0) - 1.0, ((y as f32) / 40.0) - 1.0],
+                });
+            }
+        }
+
+        glium::vertex::PerInstanceAttributesBuffer::new_if_supported(&display, data).unwrap()
+    };
+
+    let index_buffer = glium::IndexBuffer::new(&display,
+        glium::index_buffer::TrianglesList(vec![0u16, 1, 2]));
+
+    let program = glium::Program::from_source(&display,
+        "
+            #version 110
+
+            attribute vec2 position;
+            attribute vec2 world_position;
+
+            void main() {
+                gl_Position = vec4(position + world_position, 0.0, 1.0);
+            }
+        ",
+        "
+            #version 110
+
+            void main() {
+                gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+            }
+        ",
+        None)
+        .unwrap();
+    
+    // the main loop
+    // each cycle will draw once
+    'main: loop {
+        use std::io::timer;
+        use std::time::Duration;
+
+        // drawing a frame
+        let mut target = display.draw();
+        target.clear_color(0.0, 0.0, 0.0, 0.0);
+        target.draw((&vertex_buffer, &per_instance), &index_buffer, &program, &uniform!{},
+                    &std::default::Default::default()).unwrap();
+        target.finish();
+
+        // sleeping for some time in order not to use up too much CPU
+        timer::sleep(Duration::milliseconds(17));
+
+        // polling and handling the events received by the window
+        for event in display.poll_events().into_iter() {
+            match event {
+                glutin::Event::Closed => break 'main,
+                _ => ()
+            }
+        }
+    }
+}

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -260,6 +260,8 @@ pub struct ExtensionsList {
     pub gl_arb_tessellation_shader: bool,
     /// GL_APPLE_vertex_array_object
     pub gl_apple_vertex_array_object: bool,
+    /// GL_ARB_instanced_arrays
+    pub gl_arb_instanced_arrays: bool,
 }
 
 impl Context {
@@ -556,6 +558,12 @@ fn check_gl_compatibility(ctxt: CommandContext) -> Result<(), GliumCreationError
         {
             result.push("OpenGL implementation doesn't support tessellation");
         }
+
+        if cfg!(feature = "gl_instancing") && ctxt.version < &GlVersion(3, 3) &&
+            !ctxt.extensions.gl_arb_instanced_arrays
+        {
+            result.push("OpenGL implementation doesn't support instancing");
+        }
     }
 
     if result.len() == 0 {
@@ -625,6 +633,7 @@ fn get_extensions(gl: &gl::Gl) -> ExtensionsList {
         gl_arb_get_programy_binary: false,
         gl_arb_tessellation_shader: false,
         gl_apple_vertex_array_object: false,
+        gl_arb_instanced_arrays: false,
     };
 
     for extension in strings.into_iter() {
@@ -646,6 +655,7 @@ fn get_extensions(gl: &gl::Gl) -> ExtensionsList {
             "GL_ARB_get_program_binary" => extensions.gl_arb_get_programy_binary = true,
             "GL_ARB_tessellation_shader" => extensions.gl_arb_tessellation_shader = true,
             "GL_APPLE_vertex_array_object" => extensions.gl_apple_vertex_array_object = true,
+            "GL_ARB_instanced_arrays" => extensions.gl_arb_instanced_arrays = true,
             _ => ()
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1290,6 +1290,9 @@ pub enum DrawError {
 
     /// Trying to use a sampler, but they are not supported by the backend.
     SamplersNotSupported,
+
+    /// When you use instancing, all vertices sources must have the same size.
+    InstancesCountMismatch,
 }
 
 #[doc(hidden)]

--- a/src/program.rs
+++ b/src/program.rs
@@ -669,6 +669,10 @@ unsafe fn reflect_attributes(ctxt: &mut CommandContext, program: gl::types::GLui
         attr_name_tmp.set_len(attr_name_tmp_len as usize);
 
         let attr_name = String::from_utf8(attr_name_tmp).unwrap();
+        if attr_name.starts_with("gl_") {   // ignoring everything built-in
+            continue;
+        }
+
         let location = ctxt.gl.GetAttribLocation(program, ffi::CString::from_slice(attr_name.as_bytes()).as_slice_with_nul().as_ptr());
 
         attributes.insert(attr_name, Attribute {

--- a/src/vertex/mod.rs
+++ b/src/vertex/mod.rs
@@ -62,9 +62,12 @@ use sync::LinearSyncFence;
 
 pub use self::buffer::{VertexBuffer, VertexBufferAny, Mapping};
 pub use self::format::{AttributeType, VertexFormat};
+pub use self::per_instance::{PerInstanceAttributesBuffer, PerInstanceAttributesBufferAny};
+pub use self::per_instance::Mapping as PerInstanceAttributesBufferMapping;
 
 mod buffer;
 mod format;
+mod per_instance;
 
 /// Describes the source to use for the vertices when drawing.
 #[derive(Clone)]
@@ -74,6 +77,12 @@ pub enum VerticesSource<'a> {
     /// If the second parameter is `Some`, then a fence *must* be sent with this sender for
     /// when the buffer stops being used.
     VertexBuffer(&'a VertexBufferAny, Option<Sender<LinearSyncFence>>),
+
+    /// A buffer uploaded in the video memory.
+    ///
+    /// If the second parameter is `Some`, then a fence *must* be sent with this sender for
+    /// when the buffer stops being used.
+    PerInstanceBuffer(&'a PerInstanceAttributesBufferAny, Option<Sender<LinearSyncFence>>),
 }
 
 /// Objects that can be used as vertex sources.

--- a/tests/instancing.rs
+++ b/tests/instancing.rs
@@ -1,0 +1,107 @@
+#![feature(plugin)]
+#![feature(unboxed_closures)]
+
+#[plugin]
+extern crate glium_macros;
+
+extern crate glutin;
+
+#[macro_use]
+extern crate glium;
+
+use glium::Surface;
+
+mod support;
+
+#[test]
+fn instancing() {
+    let display = support::build_display();
+
+    let buffer1 = {
+        #[vertex_format]
+        #[derive(Copy)]
+        struct Vertex {
+            position: [f32; 2],
+        }
+
+        glium::VertexBuffer::new(&display, 
+            vec![
+                Vertex { position: [-1.0,  1.0] },
+                Vertex { position: [ 1.0,  1.0] },
+                Vertex { position: [-1.0, -1.0] },
+                Vertex { position: [ 1.0, -1.0] },
+            ]
+        )
+    };
+
+    let buffer2 = {
+        #[vertex_format]
+        #[derive(Copy)]
+        struct Vertex {
+            color: [f32; 3],
+        }
+
+        match glium::vertex::PerInstanceAttributesBuffer::new_if_supported(&display, 
+            vec![
+                Vertex { color: [0.0, 0.0, 1.0] },
+                Vertex { color: [0.0, 0.0, 1.0] },
+                Vertex { color: [0.0, 0.0, 1.0] },
+                Vertex { color: [1.0, 0.0, 0.0] },
+            ]
+        ) {
+            Some(b) => b,
+            None => return
+        }
+    };
+
+    let index_buffer = glium::IndexBuffer::new(&display,
+        glium::index_buffer::TriangleStrip(vec![0u16, 1, 2, 3]));
+
+    let program = match glium::Program::from_source(&display,
+        "
+            #version 330
+
+            in vec2 position;
+            in vec3 color;
+
+            out vec3 v_color;
+            flat out int instance;
+
+            void main() {
+                gl_Position = vec4(position, 0.0, 1.0);
+                v_color = color;
+                instance = gl_InstanceID;
+            }
+        ",
+        "
+            #version 330
+            in vec3 v_color;
+            flat in int instance;
+
+            void main() {
+                if (instance != 3) {
+                    discard;
+                }
+
+                gl_FragColor = vec4(v_color, 1.0);
+            }
+        ",
+        None) {
+        Ok(p) => p,
+        _ => return
+    };
+
+    let texture = support::build_renderable_texture(&display);
+    texture.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
+    texture.as_surface().draw((&buffer1, &buffer2), &index_buffer, &program, &uniform!{},
+                              &std::default::Default::default()).unwrap();
+
+    let data: Vec<Vec<(f32, f32, f32, f32)>> = texture.read();
+    for row in data.iter() {
+        for pixel in row.iter() {
+            assert_eq!(pixel, &(1.0, 0.0, 0.0, 1.0));
+        }
+    }
+
+    display.assert_no_error();
+}


### PR DESCRIPTION
- Adds an `gl_instancing` Cargo feature.
- Adds `PerInstanceAttributesBuffer` (and `PerInstanceAttributesBufferAny`) which can be used as a vertices source.
- If one of them is passed, the number of instances corresponds to the number of elements in the `PerInstanceAttributesBuffer`.
- Adds a variant in `DrawError` if passing multiple `PerInstanceAttributesBuffer`s and they don't have the same number of elements.

Example:

```rust
let buffer1 = {
    #[vertex_format]
    #[derive(Copy)]
    struct Vertex {
        position: [f32; 2],
    }

    glium::VertexBuffer::new(&display, 
        vec![
            Vertex { position: [-1.0,  1.0] },
            Vertex { position: [ 1.0,  1.0] },
            Vertex { position: [-1.0, -1.0] },
            Vertex { position: [ 1.0, -1.0] },
        ]
    )
};

let buffer2 = {
    #[vertex_format]
    #[derive(Copy)]
    struct Vertex {
        color: [f32; 3],
    }

    glium::vertex::PerInstanceAttributesBuffer::new(&display, 
        vec![
            Vertex { color: [0.0, 0.0, 1.0] },
            Vertex { color: [0.0, 1.0, 0.0] },
            Vertex { color: [1.0, 0.0, 0.0] },
        ]
    )
};

target.as_surface().draw((&buffer1, &buffer2), &index_buffer, &program, &uniform!{},
                          &std::default::Default::default()).unwrap();

// draws 3 instances (one per element in `buffer2`) of 4 vertices
//   each (one per element in `buffer1`)
// the `color` attribute in the vertex shader matches the elements in buffer2
```

~~Not working for now (despite what travis says), need to investigate.~~
