### PR TITLE
Rework the way events are being gathered

### DIFF
--- a/examples/blitting.rs
+++ b/examples/blitting.rs
@@ -58,7 +58,7 @@ fn main() {
         target.finish();
 
         // polling and handling the events received by the window
-        for event in display.poll_events().into_iter() {
+        for event in display.poll_events() {
             match event {
                 glutin::Event::Closed => break 'main,
                 _ => ()

--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -369,7 +369,7 @@ fn main() {
         timer::sleep(Duration::milliseconds(17));
 
         // polling and handling the events received by the window
-        for event in display.poll_events().into_iter() {
+        for event in display.poll_events() {
             match event {
                 glutin::Event::Closed => break 'main,
                 _ => ()

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -115,7 +115,7 @@ fn main() {
         timer::sleep(Duration::milliseconds(17));
 
         // polling and handling the events received by the window
-        for event in display.poll_events().into_iter() {
+        for event in display.poll_events() {
             match event {
                 glutin::Event::Closed => break 'main,
                 _ => ()

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -96,7 +96,7 @@ fn main() {
         timer::sleep(Duration::milliseconds(17));
 
         // polling and handling the events received by the window
-        for event in display.poll_events().into_iter() {
+        for event in display.poll_events() {
             match event {
                 glutin::Event::Closed => break 'main,
                 _ => ()

--- a/examples/teapot.rs
+++ b/examples/teapot.rs
@@ -104,7 +104,7 @@ fn main() {
         timer::sleep(Duration::milliseconds(17));
 
         // polling and handling the events received by the window
-        for event in display.poll_events().into_iter() {
+        for event in display.poll_events() {
             match event {
                 glutin::Event::Closed => break 'main,
                 _ => ()

--- a/examples/tessellation.rs
+++ b/examples/tessellation.rs
@@ -156,7 +156,7 @@ fn main() {
         timer::sleep(Duration::milliseconds(17));
 
         // polling and handling the events received by the window
-        for event in display.poll_events().into_iter() {
+        for event in display.poll_events() {
             match event {
                 glutin::Event::Closed => break 'main,
                 glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(glutin::VirtualKeyCode::Up)) => {

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -99,7 +99,7 @@ fn main() {
         timer::sleep(Duration::milliseconds(17));
 
         // polling and handling the events received by the window
-        for event in display.poll_events().into_iter() {
+        for event in display.poll_events() {
             match event {
                 glutin::Event::Closed => break 'main,
                 _ => ()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,7 @@ extern crate libc;
 #[cfg(feature = "nalgebra")]
 extern crate nalgebra;
 
+pub use context::EventsIter;
 pub use index_buffer::IndexBuffer;
 pub use vertex::{VertexBuffer, Vertex, VertexFormat};
 pub use program::{Program, ProgramCreationError};
@@ -1488,8 +1489,8 @@ struct DisplayImpl {
 
 impl Display {
     /// Reads all events received by the window.
-    pub fn poll_events(&self) -> Vec<glutin::Event> {
-        self.context.context.recv()
+    pub fn poll_events(&self) -> EventsIter {
+        self.context.context.events()
     }
 
     /// Returns the dimensions of the main framebuffer.


### PR DESCRIPTION
**Breaking change**

`Display::poll_events` no longer returns a `Vec` but an `EventsIter`, which is an infinite iterator that produces events as they are received.

Close #325 
