### PR TITLE
Use associated types in GlObject trait

### DIFF
--- a/build/textures.rs
+++ b/build/textures.rs
@@ -135,6 +135,7 @@ fn build_texture<W: Writer>(mut dest: &mut W, ty: TextureType, dimensions: Textu
     // `GlObject` trait impl
     (writeln!(dest, "
                 impl GlObject for {} {{
+                    type Id = gl::types::GLuint;
                     fn get_id(&self) -> gl::types::GLuint {{
                         self.0.get_id()
                     }}

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -558,6 +558,7 @@ impl Drop for Buffer {
 }
 
 impl GlObject for Buffer {
+    type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {
         self.id
     }

--- a/src/fbo.rs
+++ b/src/fbo.rs
@@ -317,6 +317,7 @@ impl FrameBufferObject {
 }
 
 impl GlObject for FrameBufferObject {
+    type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {
         self.id
     }

--- a/src/index_buffer.rs
+++ b/src/index_buffer.rs
@@ -191,6 +191,7 @@ impl IndexBuffer {
 }
 
 impl GlObject for IndexBuffer {
+    type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {
         self.buffer.get_id()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,8 +234,10 @@ mod gl {
 
 /// Internal trait for objects that are OpenGL objects.
 trait GlObject {
+    type Id;
+
     /// Returns the id of the object.
-    fn get_id(&self) -> gl::types::GLuint;
+    fn get_id(&self) -> Self::Id;
 }
 
 /// Internal trait for enums that can be turned into GLenum.

--- a/src/pixel_buffer.rs
+++ b/src/pixel_buffer.rs
@@ -70,6 +70,7 @@ impl<T> PixelBuffer<T> where T: Texture2dData {
 }
 
 impl<T> GlObject for PixelBuffer<T> {
+    type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {
         self.buffer.get_id()
     }

--- a/src/program.rs
+++ b/src/program.rs
@@ -507,6 +507,7 @@ impl fmt::Show for Program {
 }
 
 impl GlObject for Program {
+    type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {
         self.id
     }

--- a/src/render_buffer.rs
+++ b/src/render_buffer.rs
@@ -50,6 +50,7 @@ impl ToColorAttachment for RenderBuffer {
 }
 
 impl GlObject for RenderBuffer {
+    type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {
         self.buffer.get_id()
     }
@@ -85,6 +86,7 @@ impl ToDepthAttachment for DepthRenderBuffer {
 }
 
 impl GlObject for DepthRenderBuffer {
+    type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {
         self.buffer.get_id()
     }
@@ -120,6 +122,7 @@ impl ToStencilAttachment for StencilRenderBuffer {
 }
 
 impl GlObject for StencilRenderBuffer {
+    type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {
         self.buffer.get_id()
     }
@@ -155,6 +158,7 @@ impl ToDepthStencilAttachment for DepthStencilRenderBuffer {
 }
 
 impl GlObject for DepthStencilRenderBuffer {
+    type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {
         self.buffer.get_id()
     }
@@ -240,6 +244,7 @@ impl Drop for RenderBufferImpl {
 }
 
 impl GlObject for RenderBufferImpl {
+    type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {
         self.id
     }

--- a/src/sampler_object.rs
+++ b/src/sampler_object.rs
@@ -62,6 +62,7 @@ impl SamplerObject {
 }
 
 impl GlObject for SamplerObject {
+    type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {
         self.id
     }

--- a/src/texture/tex_impl.rs
+++ b/src/texture/tex_impl.rs
@@ -237,6 +237,7 @@ impl TextureImplementation {
 }
 
 impl GlObject for TextureImplementation {
+    type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {
         self.id
     }

--- a/src/uniforms/buffer.rs
+++ b/src/uniforms/buffer.rs
@@ -119,12 +119,14 @@ impl<T> UniformBuffer<T> where T: Copy + Send {
 }
 
 impl<T> GlObject for UniformBuffer<T> {
+    type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {
         self.buffer.get_id()
     }
 }
 
 impl GlObject for TypelessUniformBuffer {
+    type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {
         self.buffer.get_id()
     }

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -253,6 +253,7 @@ impl<T> VertexBuffer<T> {
 }
 
 impl<T> GlObject for VertexBuffer<T> {
+    type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {
         self.buffer.get_id()
     }
@@ -318,6 +319,7 @@ impl Drop for VertexBufferAny {
 }
 
 impl GlObject for VertexBufferAny {
+    type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {
         self.buffer.get_id()
     }

--- a/src/vertex/per_instance.rs
+++ b/src/vertex/per_instance.rs
@@ -273,6 +273,7 @@ impl<T> PerInstanceAttributesBuffer<T> {
 }
 
 impl<T> GlObject for PerInstanceAttributesBuffer<T> {
+    type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {
         self.buffer.get_id()
     }
@@ -338,6 +339,7 @@ impl Drop for PerInstanceAttributesBufferAny {
 }
 
 impl GlObject for PerInstanceAttributesBufferAny {
+    type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {
         self.buffer.get_id()
     }

--- a/src/vertex_array_object.rs
+++ b/src/vertex_array_object.rs
@@ -213,6 +213,7 @@ impl Drop for VertexArrayObject {
 }
 
 impl GlObject for VertexArrayObject {
+    type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {
         self.id
     }


### PR DESCRIPTION
Will be needed because the `GL_ARB_shader_objects` extension uses `GLhandleARB` and not `GLuint`.

cc #343 