### PR TITLE
Support GL_ARB_shader_objects

### DIFF
--- a/build/main.rs
+++ b/build/main.rs
@@ -28,6 +28,8 @@ fn main() {
                                         "GL_ARB_buffer_storage".to_string(),
                                         "GL_APPLE_vertex_array_object".to_string(),
                                         "GL_ARB_vertex_buffer_object".to_string(),
+                                        "GL_ARB_shader_objects".to_string(),
+                                        "GL_ARB_vertex_shader".to_string(),
                                     ],
                                     "4.5", "compatibility", &mut gl_bindings).unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,6 +241,16 @@ trait GlObject {
     fn get_id(&self) -> Self::Id;
 }
 
+/// Handle to a shader or a program.
+// TODO: Handle(null()) is equal to Id(0)
+#[derive(PartialEq, Eq, Copy, Clone, Show, Hash)]
+enum Handle {
+    Id(gl::types::GLuint),
+    Handle(gl::types::GLhandleARB),
+}
+
+unsafe impl Send for Handle {}
+
 /// Internal trait for enums that can be turned into GLenum.
 trait ToGlEnum {
     /// Returns the value.
@@ -1482,7 +1492,7 @@ struct DisplayImpl {
 
     // we maintain a list of VAOs for each vertexbuffer-indexbuffer-program association
     // the key is a (buffers-list, program) ; the buffers list must be sorted
-    vertex_array_objects: Mutex<HashMap<(Vec<gl::types::GLuint>, gl::types::GLuint),
+    vertex_array_objects: Mutex<HashMap<(Vec<gl::types::GLuint>, Handle),
                                         vertex_array_object::VertexArrayObject>>,
 
     // we maintain a list of samplers for each possible behavior


### PR DESCRIPTION
cc #343

Remains to do:
- Fix the bugs (apparently I broke something)
- Use `glUniform*ARB` instead of `glUniform`
