### PR TITLE
Fix scissor box not being disabled before clearing

### DIFF
--- a/src/ops/clear.rs
+++ b/src/ops/clear.rs
@@ -32,6 +32,11 @@ pub fn clear(display: &Arc<DisplayImpl>, framebuffer: Option<&FramebufferAttachm
         fbo::bind_framebuffer(&mut ctxt, fbo_id, true, false);
 
         unsafe {
+            if ctxt.state.enabled_scissor_test {
+                ctxt.gl.Disable(gl::SCISSOR_TEST);
+                ctxt.state.enabled_scissor_test = false;
+            }
+
             if let Some(color) = color {
                 if ctxt.state.clear_color != color {
                     ctxt.gl.ClearColor(color.0, color.1, color.2, color.3);

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -142,3 +142,67 @@ fn sync() {
 
     display.assert_no_error();
 }
+
+#[test]
+fn scissor_followed_by_clear() {
+    let display = support::build_display();
+
+    let params = glium::DrawParameters {
+        scissor: Some(glium::Rect {
+            left: 2,
+            bottom: 2,
+            width: 2,
+            height: 2,
+        }),
+        .. std::default::Default::default()
+    };
+
+    let (vb, ib, program) = support::build_fullscreen_red_pipeline(&display);
+
+    let texture = support::build_renderable_texture(&display);
+    texture.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
+    texture.as_surface().draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms,
+                              &params).unwrap();
+    texture.as_surface().clear_color(1.0, 0.0, 1.0, 1.0);
+
+    let data: Vec<Vec<(f32, f32, f32, f32)>> = texture.read();
+    for row in data.iter() {
+        for pixel in row.iter() {
+            assert_eq!(pixel, &(1.0, 0.0, 1.0, 1.0));
+        }
+    }
+
+    display.assert_no_error();
+}
+
+#[test]
+fn viewport_followed_by_clear() {
+    let display = support::build_display();
+
+    let params = glium::DrawParameters {
+        viewport: Some(glium::Rect {
+            left: 2,
+            bottom: 2,
+            width: 2,
+            height: 2,
+        }),
+        .. std::default::Default::default()
+    };
+
+    let (vb, ib, program) = support::build_fullscreen_red_pipeline(&display);
+
+    let texture = support::build_renderable_texture(&display);
+    texture.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
+    texture.as_surface().draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms,
+                              &params).unwrap();
+    texture.as_surface().clear_color(1.0, 0.0, 1.0, 1.0);
+
+    let data: Vec<Vec<(f32, f32, f32, f32)>> = texture.read();
+    for row in data.iter() {
+        for pixel in row.iter() {
+            assert_eq!(pixel, &(1.0, 0.0, 1.0, 1.0));
+        }
+    }
+
+    display.assert_no_error();
+}


### PR DESCRIPTION
The `viewport_followed_by_clear` test is not very useful since `glViewport` doesn't affect `glClear`. But at least it's there to show that fact.