### PR TITLE
Remove unnecessary constraints on new_empty

### DIFF
--- a/build/textures.rs
+++ b/build/textures.rs
@@ -321,8 +321,8 @@ fn build_texture<W: Writer>(mut dest: &mut W, ty: TextureType, dimensions: Textu
                 ")).unwrap(),   // TODO: panic if dimensions are inconsistent
         }
         // writing the constructor
-        (write!(dest, "{}(TextureImplementation::new(display, format, Some(data), \
-                       client_format, ", name)).unwrap();
+        (write!(dest, "{}(TextureImplementation::new(display, format, \
+                       Some((client_format, data)), ", name)).unwrap();
         match dimensions {
             TextureDimensions::Texture1d => (write!(dest, "width, None, None, None")).unwrap(),
             TextureDimensions::Texture2d => (write!(dest, "width, Some(height), None, None")).unwrap(),
@@ -367,8 +367,7 @@ fn build_texture<W: Writer>(mut dest: &mut W, ty: TextureType, dimensions: Textu
             ", format = format, dim_params = dim_params, name = name)).unwrap();
 
         // writing the constructor
-        (write!(dest, "{}(TextureImplementation::new::<u8>(display, format, None, \
-                       ClientFormat::U8U8U8U8, ", name)).unwrap();
+        (write!(dest, "{}(TextureImplementation::new::<u8>(display, format, None, ", name)).unwrap();
         match dimensions {
             TextureDimensions::Texture1d => (write!(dest, "width, None, None, None")).unwrap(),
             TextureDimensions::Texture2d => (write!(dest, "width, Some(height), None, None")).unwrap(),


### PR DESCRIPTION
When creating an empty texture, you have to call `glTexImage2D(.., format, NULL);`

For the moment `new_empty` calls `TextureImplementation::new` with a dummy `U8U8U8U8` format. However with the recent checks that has been added, this sometimes fails for example with `Only ClientFormat::F32 can be used for depth textures` when you try to create an empty depth texture.

This fixes it.
