### PR TITLE
Allow drawing without indices

### DIFF
--- a/src/index_buffer.rs
+++ b/src/index_buffer.rs
@@ -63,7 +63,14 @@ pub enum IndicesSource<'a, T: 'a> {
         offset: usize,
         /// Number of elements in the buffer to use.
         length: usize,
-    }
+    },
+
+    /// Don't use indices. Assemble primitives by using the order in which the vertices are in
+    /// the vertices source.
+    NoIndices {
+        /// Type of primitives contained in the vertex source.
+        primitives: PrimitiveType,
+    },
 }
 
 impl<'a, T> IndicesSource<'a, T> where T: Index {
@@ -72,30 +79,7 @@ impl<'a, T> IndicesSource<'a, T> where T: Index {
         match self {
             &IndicesSource::IndexBuffer { ref buffer, .. } => buffer.get_primitives_type(),
             &IndicesSource::Buffer { primitives, .. } => primitives,
-        }
-    }
-
-    /// Returns the type of the indices.
-    pub fn get_indices_type(&self) -> IndexType {
-        match self {
-            &IndicesSource::IndexBuffer { ref buffer, .. } => buffer.get_indices_type(),
-            &IndicesSource::Buffer { .. } => <T as Index>::get_type(),
-        }
-    }
-
-    /// Returns the first element to use from the buffer.
-    pub fn get_offset(&self) -> usize {
-        match self {
-            &IndicesSource::IndexBuffer { offset, .. } => offset,
-            &IndicesSource::Buffer { offset, .. } => offset,
-        }
-    }
-
-    /// Returns the length of the buffer.
-    pub fn get_length(&self) -> usize {
-        match self {
-            &IndicesSource::IndexBuffer { length, .. } => length,
-            &IndicesSource::Buffer { length, .. } => length,
+            &IndicesSource::NoIndices { primitives } => primitives,
         }
     }
 }
@@ -144,6 +128,22 @@ impl ToGlEnum for PrimitiveType {
             &PrimitiveType::TriangleStripAdjacency => gl::TRIANGLE_STRIP_ADJACENCY,
             &PrimitiveType::TriangleFan => gl::TRIANGLE_FAN,
             &PrimitiveType::Patches { .. } => gl::PATCHES,
+        }
+    }
+}
+
+/// Marker that can be used as an indices source when you don't need indices.
+///
+/// If you use this, then the primitives will be constructed using the order in which the
+/// vertices are in the vertices sources.
+pub struct NoIndices(pub PrimitiveType);
+
+impl ToIndicesSource for NoIndices {
+    type Data = u16;      // TODO: u16?
+
+    fn to_indices_source(&self) -> IndicesSource<u16> {     // TODO: u16?
+        IndicesSource::NoIndices {
+            primitives: self.0,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1306,6 +1306,9 @@ pub enum DrawError {
 
     /// When you use instancing, all vertices sources must have the same size.
     InstancesCountMismatch,
+
+    /// If you don't use indices, then all vertices sources must have the same size.
+    VerticesSourcesLengthMismatch,
 }
 
 impl std::fmt::Display for DrawError {
@@ -1350,6 +1353,9 @@ impl std::fmt::Display for DrawError {
             &DrawError::InstancesCountMismatch => write!(fmt, "When you use instancing, all \
                                                                vertices sources must have the \
                                                                same size"),
+            &DrawError::VerticesSourcesLengthMismatch => write!(fmt, "If you don't use indices, \
+                                                                      then all vertices sources \
+                                                                      must have the same size."),
         }
     }
 }

--- a/src/vertex_array_object.rs
+++ b/src/vertex_array_object.rs
@@ -227,7 +227,8 @@ pub fn get_vertex_array_object<I>(display: &Arc<DisplayImpl>, vertex_buffers: &[
 {
     let ib_id = match indices {
         &IndicesSource::Buffer { .. } => 0,
-        &IndicesSource::IndexBuffer { ref buffer, .. } => buffer.get_id()
+        &IndicesSource::IndexBuffer { ref buffer, .. } => buffer.get_id(),
+        &IndicesSource::NoIndices { .. } => 0,
     };
 
     let buffers_list = {

--- a/tests/indices.rs
+++ b/tests/indices.rs
@@ -8,7 +8,7 @@ extern crate glutin;
 extern crate glium;
 
 use std::default::Default;
-use glium::Surface;
+use glium::{index_buffer, Surface};
 
 mod support;
 
@@ -238,6 +238,88 @@ fn get_indices_type_u32() {
     let indices = glium::IndexBuffer::new(&display, indices);
 
     assert_eq!(indices.get_indices_type(), glium::index_buffer::IndexType::U32);
+
+    display.assert_no_error();
+}
+
+#[test]
+fn triangles_list_noindices() {    
+    let display = support::build_display();
+    let program = build_program(&display);
+
+    let vb = glium::VertexBuffer::new(&display, vec![
+        Vertex { position: [-1.0,  1.0] },
+        Vertex { position: [ 1.0,  1.0] },
+        Vertex { position: [-1.0, -1.0] },
+        Vertex { position: [-1.0, -1.0] },
+        Vertex { position: [ 1.0,  1.0] },
+        Vertex { position: [ 1.0, -1.0] },
+    ]);
+
+    let mut target = display.draw();
+    target.clear_color(0.0, 0.0, 0.0, 0.0);
+    target.draw(&vb, &index_buffer::NoIndices(index_buffer::PrimitiveType::TrianglesList),
+                &program, &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
+    target.finish();
+
+    let data: Vec<Vec<(u8, u8, u8)>> = display.read_front_buffer();
+
+    assert_eq!(data[0][0], (255, 0, 0));
+    assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0));
+
+    display.assert_no_error();
+}
+
+#[test]
+fn triangle_strip_noindices() {
+    let display = support::build_display();
+    let program = build_program(&display);
+
+    let vb = glium::VertexBuffer::new(&display, vec![
+        Vertex { position: [-1.0,  1.0] },
+        Vertex { position: [ 1.0,  1.0] },
+        Vertex { position: [-1.0, -1.0] },
+        Vertex { position: [ 1.0, -1.0] },
+    ]);
+
+    let mut target = display.draw();
+    target.clear_color(0.0, 0.0, 0.0, 0.0);
+    target.draw(&vb, &index_buffer::NoIndices(index_buffer::PrimitiveType::TriangleStrip),
+                &program, &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
+    target.finish();
+
+    let data: Vec<Vec<(u8, u8, u8)>> = display.read_front_buffer();
+
+    assert_eq!(data[0][0], (255, 0, 0));
+    assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0));
+
+    display.assert_no_error();
+}
+
+#[test]
+fn triangle_fan_noindices() {
+    let display = support::build_display();
+    let program = build_program(&display);
+
+    let vb = glium::VertexBuffer::new(&display, vec![
+        Vertex { position: [ 0.0,  0.0] },
+        Vertex { position: [-1.0,  1.0] },
+        Vertex { position: [ 1.0,  1.0] },
+        Vertex { position: [ 1.0, -1.0] },
+        Vertex { position: [-1.0, -1.0] },
+        Vertex { position: [-1.0,  1.0] },
+    ]);
+
+    let mut target = display.draw();
+    target.clear_color(0.0, 0.0, 0.0, 0.0);
+    target.draw(&vb, &index_buffer::NoIndices(index_buffer::PrimitiveType::TriangleFan),
+                &program, &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
+    target.finish();
+
+    let data: Vec<Vec<(u8, u8, u8)>> = display.read_front_buffer();
+
+    assert_eq!(data[0][0], (255, 0, 0));
+    assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0));
 
     display.assert_no_error();
 }


### PR DESCRIPTION
- Adds `glium::index_buffer::NoIndices(PrimitiveType)` to use the vertices in the same order as they are in the vertices source.
- Removes some member functions of `IndicesSource`.
- Adds `DrawError::VerticesSourcesLengthMismatch` that is returned if you use `NoIndices` and multiple vertices sources with different sizes.