### PR TITLE
Rename index_buffer to index

### DIFF
--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -54,7 +54,7 @@ fn main() {
     };
 
     let floor_index_buffer = glium::IndexBuffer::new(&display,
-        glium::index_buffer::TrianglesList(vec![0u16, 1, 2, 0, 2, 3]));
+        glium::index::TrianglesList(vec![0u16, 1, 2, 0, 2, 3]));
 
     let quad_vertex_buffer = {
         #[vertex_format]
@@ -75,7 +75,7 @@ fn main() {
     };
 
     let quad_index_buffer = glium::IndexBuffer::new(&display,
-        glium::index_buffer::TrianglesList(vec![0u16, 1, 2, 0, 2, 3]));
+        glium::index::TrianglesList(vec![0u16, 1, 2, 0, 2, 3]));
 
     // compiling shaders and linking them together
     let prepass_program = glium::Program::from_source(&display,

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -54,7 +54,7 @@ fn main() {
 
     // building the index buffer
     let index_buffer = glium::IndexBuffer::new(&display,
-        glium::index_buffer::TriangleStrip(vec![1 as u16, 2, 0, 3]));
+        glium::index::TriangleStrip(vec![1 as u16, 2, 0, 3]));
 
     // compiling shaders and linking them together
     let program = glium::Program::from_source(&display, r"

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -56,7 +56,7 @@ fn main() {
     };
 
     let index_buffer = glium::IndexBuffer::new(&display,
-        glium::index_buffer::TrianglesList(vec![0u16, 1, 2]));
+        glium::index::TrianglesList(vec![0u16, 1, 2]));
 
     let program = glium::Program::from_source(&display,
         "

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -46,7 +46,7 @@ fn main() {
 
     // building the index buffer
     let index_buffer = glium::IndexBuffer::new(&display,
-        glium::index_buffer::TrianglesList(vec![0u16, 1, 2]));
+        glium::index::TrianglesList(vec![0u16, 1, 2]));
 
     // compiling shaders and linking them together
     let program = glium::Program::from_source(&display,

--- a/examples/teapot_model/mod.rs
+++ b/examples/teapot_model/mod.rs
@@ -12,7 +12,7 @@ pub struct Vertex {
     normal: [f32; 3],
 }
 
-pub fn build_model() -> (Vec<Vertex>, glium::index_buffer::TrianglesList<u16>) {
+pub fn build_model() -> (Vec<Vertex>, glium::index::TrianglesList<u16>) {
     let vertices = vec![
         [5.929688, 4.125, 0.0],
         [5.387188, 4.125, 2.7475],
@@ -1048,5 +1048,5 @@ pub fn build_model() -> (Vec<Vertex>, glium::index_buffer::TrianglesList<u16>) {
         })
     }
 
-    (output, glium::index_buffer::TrianglesList(ib))
+    (output, glium::index::TrianglesList(ib))
 }

--- a/examples/tessellation.rs
+++ b/examples/tessellation.rs
@@ -37,7 +37,7 @@ fn main() {
 
     // building the index buffer
     let index_buffer = glium::IndexBuffer::new(&display,
-        glium::index_buffer::Patches(vec![0u16, 1, 2], 3));
+        glium::index::Patches(vec![0u16, 1, 2], 3));
 
     // compiling shaders and linking them together
     let program = glium::Program::new(&display,

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -38,7 +38,7 @@ fn main() {
 
     // building the index buffer
     let index_buffer = glium::IndexBuffer::new(&display,
-        glium::index_buffer::TrianglesList(vec![0u16, 1, 2]));
+        glium::index::TrianglesList(vec![0u16, 1, 2]));
 
     // compiling shaders and linking them together
     let program = glium::Program::from_source(&display,

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -203,10 +203,10 @@ impl<'a> Surface for SimpleFrameBuffer<'a> {
 
     fn draw<'b, 'v, V, I, U>(&mut self, vb: V, ib: &I, program: &::Program,
         uniforms: U, draw_parameters: &::DrawParameters) -> Result<(), DrawError>
-        where I: ::index_buffer::ToIndicesSource, U: ::uniforms::Uniforms,
+        where I: ::index::ToIndicesSource, U: ::uniforms::Uniforms,
         V: ::vertex::MultiVerticesSource<'v>
     {
-        use index_buffer::ToIndicesSource;
+        use index::ToIndicesSource;
 
         if draw_parameters.depth_function.requires_depth_buffer() && !self.has_depth_buffer() {
             return Err(DrawError::NoDepthBuffer);
@@ -400,10 +400,10 @@ impl<'a> Surface for MultiOutputFrameBuffer<'a> {
 
     fn draw<'v, V, I, U>(&mut self, vb: V, ib: &I, program: &::Program,
         uniforms: U, draw_parameters: &::DrawParameters) -> Result<(), DrawError>
-        where I: ::index_buffer::ToIndicesSource,
+        where I: ::index::ToIndicesSource,
         U: ::uniforms::Uniforms, V: ::vertex::MultiVerticesSource<'v>
     {
-        use index_buffer::ToIndicesSource;
+        use index::ToIndicesSource;
 
         if draw_parameters.depth_function.requires_depth_buffer() && !self.has_depth_buffer() {
             return Err(DrawError::NoDepthBuffer);

--- a/src/index.rs
+++ b/src/index.rs
@@ -167,7 +167,7 @@ impl IndexBuffer {
     /// # fn main() {
     /// # let display: glium::Display = unsafe { ::std::mem::uninitialized() };
     /// let index_buffer = glium::IndexBuffer::new(&display,
-    ///     glium::index_buffer::TrianglesList(vec![0u8, 1, 2, 1, 3, 4, 2, 4, 3]));
+    ///     glium::index::TrianglesList(vec![0u8, 1, 2, 1, 3, 4, 2, 4, 3]));
     /// # }
     /// ```
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,12 @@ pub mod uniforms;
 pub mod vertex;
 pub mod texture;
 
+#[deprecated = "`index_buffer` has been renamed to `index`"]
+#[allow(missing_docs)]
+pub mod index_buffer {
+    pub use index::*;
+}
+
 mod buffer;
 mod context;
 mod fbo;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ buffer, but since we only have a single triangle the simpler solution here is no
 
 ```no_run
 use glium::index_buffer;
-let indices = index_buffer::NoIndices(index_buffer::PrimitiveType::TrianglesList);
+let indices = index::NoIndices(index::PrimitiveType::TrianglesList);
 ```
 
 Next, we create the program, which is composed of a *vertex shader*, a program executed once for
@@ -178,7 +178,7 @@ extern crate libc;
 extern crate nalgebra;
 
 pub use context::{PollEventsIter, WaitEventsIter};
-pub use index_buffer::IndexBuffer;
+pub use index::IndexBuffer;
 pub use vertex::{VertexBuffer, Vertex, VertexFormat};
 pub use program::{Program, ProgramCreationError};
 pub use program::ProgramCreationError::{CompilationError, LinkingError, ShaderTypeNotSupported};
@@ -192,7 +192,7 @@ use std::sync::mpsc::channel;
 
 pub mod debug;
 pub mod framebuffer;
-pub mod index_buffer;
+pub mod index;
 pub mod pixel_buffer;
 pub mod macros;
 pub mod program;
@@ -1177,7 +1177,7 @@ pub trait Surface: Sized {
     ///
     fn draw<'a, 'b, V, I, U>(&mut self, V, &I, program: &Program, uniforms: U,
         draw_parameters: &DrawParameters) -> Result<(), DrawError> where
-        V: vertex::MultiVerticesSource<'b>, I: index_buffer::ToIndicesSource,
+        V: vertex::MultiVerticesSource<'b>, I: index::ToIndicesSource,
         U: uniforms::Uniforms;
 
     /// Returns an opaque type that is used by the implementation of blit functions.
@@ -1380,10 +1380,10 @@ impl Surface for Frame {
     fn draw<'a, 'b, V, I, U>(&mut self, vertex_buffer: V,
                          index_buffer: &I, program: &Program, uniforms: U,
                          draw_parameters: &DrawParameters) -> Result<(), DrawError>
-                         where I: index_buffer::ToIndicesSource, U: uniforms::Uniforms,
+                         where I: index::ToIndicesSource, U: uniforms::Uniforms,
                          V: vertex::MultiVerticesSource<'b>
     {
-        use index_buffer::ToIndicesSource;
+        use index::ToIndicesSource;
 
         if draw_parameters.depth_function.requires_depth_buffer() && !self.has_depth_buffer() {
             return Err(DrawError::NoDepthBuffer);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ We will also need to tell glium how the vertices must be linked together. We cou
 buffer, but since we only have a single triangle the simpler solution here is not to use indices.
 
 ```no_run
-use glium::index_buffer;
+use glium::index;
 let indices = index::NoIndices(index::PrimitiveType::TrianglesList);
 ```
 

--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -11,7 +11,7 @@ use fbo::{self, FramebufferAttachments};
 use sync;
 use uniforms::{Uniforms, UniformValue, SamplerBehavior};
 use {Program, DrawParameters, GlObject, ToGlEnum};
-use index_buffer::{self, IndicesSource};
+use index::{self, IndicesSource};
 use vertex::VerticesSource;
 
 use {program, vertex_array_object};
@@ -22,7 +22,7 @@ pub fn draw<'a, I, U>(display: &Display, framebuffer: Option<&FramebufferAttachm
                       mut vertex_buffers: &mut [VerticesSource], mut indices: IndicesSource<I>,
                       program: &Program, uniforms: U, draw_parameters: &DrawParameters,
                       dimensions: (u32, u32)) -> Result<(), DrawError>
-                      where U: Uniforms, I: index_buffer::Index
+                      where U: Uniforms, I: index::Index
 {
     try!(draw_parameters.validate());
 
@@ -104,7 +104,7 @@ pub fn draw<'a, I, U>(display: &Display, framebuffer: Option<&FramebufferAttachm
                 assert!(offset == 0);       // not yet implemented
                 must_sync = true;
                 DrawCommand::DrawElements(primitives.to_glenum(), length as gl::types::GLsizei,
-                                          <I as index_buffer::Index>::get_type().to_glenum(),
+                                          <I as index::Index>::get_type().to_glenum(),
                                           ptr::Unique(pointer.as_ptr() as *mut gl::types::GLvoid))
             },
             &IndicesSource::NoIndices { primitives } => {
@@ -133,7 +133,7 @@ pub fn draw<'a, I, U>(display: &Display, framebuffer: Option<&FramebufferAttachm
 
     // handling tessellation
     let vertices_per_patch = match indices.get_primitives_type() {
-        index_buffer::PrimitiveType::Patches { vertices_per_patch } => {
+        index::PrimitiveType::Patches { vertices_per_patch } => {
             if let Some(max) = display.context.context.capabilities().max_patch_vertices {
                 if vertices_per_patch == 0 || vertices_per_patch as gl::types::GLint > max {
                     return Err(DrawError::UnsupportedVerticesPerPatch);

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -290,7 +290,7 @@ impl<'a> Surface for TextureSurface<'a> {
 
     fn draw<'b, 'v, V, I, U>(&mut self, vb: V, ib: &I, program: &::Program,
         uniforms: U, draw_parameters: &::DrawParameters) -> Result<(), ::DrawError>
-        where I: ::index_buffer::ToIndicesSource,
+        where I: ::index::ToIndicesSource,
         U: ::uniforms::Uniforms, V: ::vertex::MultiVerticesSource<'v>
     {
         self.0.draw(vb, ib, program, uniforms, draw_parameters)

--- a/src/vertex_array_object.rs
+++ b/src/vertex_array_object.rs
@@ -3,7 +3,7 @@ use std::sync::mpsc::channel;
 use std::mem;
 
 use program::Program;
-use index_buffer::IndicesSource;
+use index::IndicesSource;
 use vertex::{VerticesSource, AttributeType};
 use {DisplayImpl, GlObject};
 
@@ -223,7 +223,7 @@ impl GlObject for VertexArrayObject {
 /// passed as parameters. Creates a new VAO if no existing one matches these.
 pub fn get_vertex_array_object<I>(display: &Arc<DisplayImpl>, vertex_buffers: &[&VerticesSource],
                                   indices: &IndicesSource<I>, program: &Program)
-                                  -> gl::types::GLuint where I: ::index_buffer::Index
+                                  -> gl::types::GLuint where I: ::index::Index
 {
     let ib_id = match indices {
         &IndicesSource::Buffer { .. } => 0,

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -25,7 +25,7 @@ fn attribute_types_matching() {
             Vertex { field1: [0.0, 0.0] }
         ]);
     let index_buffer = glium::IndexBuffer::new(&display,
-                            glium::index_buffer::PointsList(vec![0u16]));
+                            glium::index::PointsList(vec![0u16]));
 
     let program = glium::Program::from_source(&display,
         // vertex shader
@@ -71,7 +71,7 @@ fn attribute_types_mismatch() {
 
     let vertex_buffer = glium::VertexBuffer::new(&display, Vec::<Vertex>::new());
     let index_buffer = glium::IndexBuffer::new(&display,
-                            glium::index_buffer::PointsList(Vec::<u16>::new()));
+                            glium::index::PointsList(Vec::<u16>::new()));
 
     let program = glium::Program::from_source(&display,
         // vertex shader
@@ -117,7 +117,7 @@ fn missing_attribute() {
 
     let vertex_buffer = glium::VertexBuffer::new(&display, Vec::<Vertex>::new());
     let index_buffer = glium::IndexBuffer::new(&display,
-                            glium::index_buffer::PointsList(Vec::<u16>::new()));
+                            glium::index::PointsList(Vec::<u16>::new()));
 
     let program = glium::Program::from_source(&display,
         // vertex shader

--- a/tests/backface-culling.rs
+++ b/tests/backface-culling.rs
@@ -33,7 +33,7 @@ fn cull_clockwise() {
     // first triangle covers the top-left side of the screen and is clockwise
     // second triangle covers the bottom-right side of the screen and is ccw
     let index_buffer = glium::IndexBuffer::new(&display,
-        glium::index_buffer::TrianglesList(vec![0u16, 1, 2, 1, 2, 3]));
+        glium::index::TrianglesList(vec![0u16, 1, 2, 1, 2, 3]));
 
     let program = glium::Program::from_source(&display,
         "
@@ -92,7 +92,7 @@ fn cull_counterclockwise() {
     // first triangle covers the top-left side of the screen and is clockwise
     // second triangle covers the bottom-right side of the screen and is ccw
     let index_buffer = glium::IndexBuffer::new(&display,
-        glium::index_buffer::TrianglesList(vec![0u16, 1, 2, 1, 2, 3]));
+        glium::index::TrianglesList(vec![0u16, 1, 2, 1, 2, 3]));
 
     let program = glium::Program::from_source(&display,
         "
@@ -150,7 +150,7 @@ fn cull_clockwise_trianglestrip() {
 
     // both triangles are clockwise
     let index_buffer = glium::IndexBuffer::new(&display,
-        glium::index_buffer::TriangleStrip(vec![0u16, 1, 2, 3]));
+        glium::index::TriangleStrip(vec![0u16, 1, 2, 3]));
 
     let program = glium::Program::from_source(&display,
         "
@@ -208,7 +208,7 @@ fn cull_counterclockwise_trianglestrip() {
 
     // both triangles are clockwise
     let index_buffer = glium::IndexBuffer::new(&display,
-        glium::index_buffer::TriangleStrip(vec![0u16, 1, 2, 3]));
+        glium::index::TriangleStrip(vec![0u16, 1, 2, 3]));
 
     let program = glium::Program::from_source(&display,
         "

--- a/tests/indices.rs
+++ b/tests/indices.rs
@@ -8,7 +8,7 @@ extern crate glutin;
 extern crate glium;
 
 use std::default::Default;
-use glium::{index_buffer, Surface};
+use glium::{index, Surface};
 
 mod support;
 
@@ -49,7 +49,7 @@ fn triangles_list_cpu() {
         Vertex { position: [-1.0, -1.0] }, Vertex { position: [1.0, -1.0] },
     ]);
 
-    let indices = glium::index_buffer::TrianglesList(vec![0u16, 1, 2, 2, 1, 3]);
+    let indices = glium::index::TrianglesList(vec![0u16, 1, 2, 2, 1, 3]);
 
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
@@ -74,7 +74,7 @@ fn triangle_strip_cpu() {
         Vertex { position: [-1.0, -1.0] }, Vertex { position: [1.0, -1.0] },
     ]);
 
-    let indices = glium::index_buffer::TriangleStrip(vec![0u16, 1, 2, 3]);
+    let indices = glium::index::TriangleStrip(vec![0u16, 1, 2, 3]);
 
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
@@ -100,7 +100,7 @@ fn triangle_fan_cpu() {
         Vertex { position: [-1.0, -1.0] }, Vertex { position: [1.0, -1.0] },
     ]);
 
-    let indices = glium::index_buffer::TriangleFan(vec![0u16, 1, 2, 4, 3, 1]);
+    let indices = glium::index::TriangleFan(vec![0u16, 1, 2, 4, 3, 1]);
 
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
@@ -125,7 +125,7 @@ fn triangles_list_gpu() {
         Vertex { position: [-1.0, -1.0] }, Vertex { position: [1.0, -1.0] },
     ]);
 
-    let indices = glium::index_buffer::TrianglesList(vec![0u16, 1, 2, 2, 1, 3]);
+    let indices = glium::index::TrianglesList(vec![0u16, 1, 2, 2, 1, 3]);
     let indices = glium::IndexBuffer::new(&display, indices);
 
     let mut target = display.draw();
@@ -151,7 +151,7 @@ fn triangle_strip_gpu() {
         Vertex { position: [-1.0, -1.0] }, Vertex { position: [1.0, -1.0] },
     ]);
 
-    let indices = glium::index_buffer::TriangleStrip(vec![0u16, 1, 2, 3]);
+    let indices = glium::index::TriangleStrip(vec![0u16, 1, 2, 3]);
     let indices = glium::IndexBuffer::new(&display, indices);
 
     let mut target = display.draw();
@@ -178,7 +178,7 @@ fn triangle_fan_gpu() {
         Vertex { position: [-1.0, -1.0] }, Vertex { position: [1.0, -1.0] },
     ]);
 
-    let indices = glium::index_buffer::TriangleFan(vec![0u16, 1, 2, 4, 3, 1]);
+    let indices = glium::index::TriangleFan(vec![0u16, 1, 2, 4, 3, 1]);
     let indices = glium::IndexBuffer::new(&display, indices);
 
     let mut target = display.draw();
@@ -198,10 +198,10 @@ fn triangle_fan_gpu() {
 fn get_primitives_type() {
     let display = support::build_display();
 
-    let indices = glium::index_buffer::TriangleStrip(vec![0u16, 1, 2, 3]);
+    let indices = glium::index::TriangleStrip(vec![0u16, 1, 2, 3]);
     let indices = glium::IndexBuffer::new(&display, indices);
 
-    assert_eq!(indices.get_primitives_type(), glium::index_buffer::PrimitiveType::TriangleStrip);
+    assert_eq!(indices.get_primitives_type(), glium::index::PrimitiveType::TriangleStrip);
 
     display.assert_no_error();
 }
@@ -210,10 +210,10 @@ fn get_primitives_type() {
 fn get_indices_type_u8() {
     let display = support::build_display();
 
-    let indices = glium::index_buffer::TriangleStrip(vec![0u8, 1, 2, 3]);
+    let indices = glium::index::TriangleStrip(vec![0u8, 1, 2, 3]);
     let indices = glium::IndexBuffer::new(&display, indices);
 
-    assert_eq!(indices.get_indices_type(), glium::index_buffer::IndexType::U8);
+    assert_eq!(indices.get_indices_type(), glium::index::IndexType::U8);
 
     display.assert_no_error();
 }
@@ -222,10 +222,10 @@ fn get_indices_type_u8() {
 fn get_indices_type_u16() {
     let display = support::build_display();
 
-    let indices = glium::index_buffer::TriangleStrip(vec![0u16, 1, 2, 3]);
+    let indices = glium::index::TriangleStrip(vec![0u16, 1, 2, 3]);
     let indices = glium::IndexBuffer::new(&display, indices);
 
-    assert_eq!(indices.get_indices_type(), glium::index_buffer::IndexType::U16);
+    assert_eq!(indices.get_indices_type(), glium::index::IndexType::U16);
 
     display.assert_no_error();
 }
@@ -234,10 +234,10 @@ fn get_indices_type_u16() {
 fn get_indices_type_u32() {
     let display = support::build_display();
 
-    let indices = glium::index_buffer::TriangleStrip(vec![0u32, 1, 2, 3]);
+    let indices = glium::index::TriangleStrip(vec![0u32, 1, 2, 3]);
     let indices = glium::IndexBuffer::new(&display, indices);
 
-    assert_eq!(indices.get_indices_type(), glium::index_buffer::IndexType::U32);
+    assert_eq!(indices.get_indices_type(), glium::index::IndexType::U32);
 
     display.assert_no_error();
 }
@@ -258,7 +258,7 @@ fn triangles_list_noindices() {
 
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
-    target.draw(&vb, &index_buffer::NoIndices(index_buffer::PrimitiveType::TrianglesList),
+    target.draw(&vb, &index::NoIndices(index::PrimitiveType::TrianglesList),
                 &program, &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
     target.finish();
 
@@ -284,7 +284,7 @@ fn triangle_strip_noindices() {
 
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
-    target.draw(&vb, &index_buffer::NoIndices(index_buffer::PrimitiveType::TriangleStrip),
+    target.draw(&vb, &index::NoIndices(index::PrimitiveType::TriangleStrip),
                 &program, &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
     target.finish();
 
@@ -312,7 +312,7 @@ fn triangle_fan_noindices() {
 
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
-    target.draw(&vb, &index_buffer::NoIndices(index_buffer::PrimitiveType::TriangleFan),
+    target.draw(&vb, &index::NoIndices(index::PrimitiveType::TriangleFan),
                 &program, &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
     target.finish();
 

--- a/tests/instancing.rs
+++ b/tests/instancing.rs
@@ -55,7 +55,7 @@ fn instancing() {
     };
 
     let index_buffer = glium::IndexBuffer::new(&display,
-        glium::index_buffer::TriangleStrip(vec![0u16, 1, 2, 3]));
+        glium::index::TriangleStrip(vec![0u16, 1, 2, 3]));
 
     let program = match glium::Program::from_source(&display,
         "
@@ -167,7 +167,7 @@ fn per_instance_length_mismatch() {
     };
 
     let index_buffer = glium::IndexBuffer::new(&display,
-        glium::index_buffer::TriangleStrip(vec![0u16, 1, 2, 3]));
+        glium::index::TriangleStrip(vec![0u16, 1, 2, 3]));
 
     let program = glium::Program::from_source(&display,
         "

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -62,7 +62,7 @@ pub fn build_fullscreen_red_pipeline(display: &glium::Display) -> (glium::vertex
             Vertex { position: [-1.0, -1.0] }, Vertex { position: [1.0, -1.0] },
         ]).into_vertex_buffer_any(),
 
-        glium::IndexBuffer::new(display, glium::index_buffer::TriangleStrip(vec![0u8, 1, 2, 3])),
+        glium::IndexBuffer::new(display, glium::index::TriangleStrip(vec![0u8, 1, 2, 3])),
 
         glium::Program::from_source(display,
             "
@@ -103,7 +103,7 @@ pub fn build_rectangle_vb_ib(display: &glium::Display)
             Vertex { position: [-1.0, -1.0] }, Vertex { position: [1.0, -1.0] },
         ]).into_vertex_buffer_any(),
 
-        glium::IndexBuffer::new(display, glium::index_buffer::TriangleStrip(vec![0u8, 1, 2, 3])),
+        glium::IndexBuffer::new(display, glium::index::TriangleStrip(vec![0u8, 1, 2, 3])),
     )
 }
 

--- a/tests/tmp.rs
+++ b/tests/tmp.rs
@@ -35,7 +35,7 @@ fn test() {
 
     // building the index buffer
     let index_buffer = glium::IndexBuffer::new(&display,
-        glium::index_buffer::TrianglesList(vec![0u16, 1, 2]));
+        glium::index::TrianglesList(vec![0u16, 1, 2]));
 
     // compiling shaders and linking them together
     let program = glium::Program::from_source(&display,

--- a/tests/vertex_buffer.rs
+++ b/tests/vertex_buffer.rs
@@ -265,7 +265,7 @@ fn multiple_buffers_source() {
     };
 
     let index_buffer = glium::IndexBuffer::new(&display,
-        glium::index_buffer::TriangleStrip(vec![0u16, 1, 2, 3]));
+        glium::index::TriangleStrip(vec![0u16, 1, 2, 3]));
 
     let program = glium::Program::from_source(&display,
         "


### PR DESCRIPTION
A deprecated `index_buffer` module still exists, so this shouldn't break anything.