### PR TITLE
Reworked texture API to fix the copy-on-write part of #388.

### DIFF
--- a/build/textures.rs
+++ b/build/textures.rs
@@ -239,7 +239,7 @@ fn build_texture<W: Writer>(mut dest: &mut W, ty: TextureType, dimensions: Textu
                 /// Builds a new texture by uploading data.
                 ///
                 /// This function will automatically generate all mipmaps of the texture.
-                pub fn new<T>(display: &::Display, data: {param})
+                pub fn new<T>(display: &::Display, data: &{param})
                               -> {name} where T: {data_type}
                 {{
             ", data_type = data_type, param = param, name = name)).unwrap();
@@ -272,17 +272,17 @@ fn build_texture<W: Writer>(mut dest: &mut W, ty: TextureType, dimensions: Textu
 
         match dimensions {
             TextureDimensions::Texture1d => (write!(dest, "
-                    let RawImage1d {{ data, width, format: client_format }} = data.into_raw();
+                    let RawImage1d {{ data, width, format: client_format }} = data.as_raw();
                 ")).unwrap(),
 
             TextureDimensions::Texture2d => (write!(dest, "
                     let RawImage2d {{ data, width, height, format: client_format }} =
-                                            data.into_raw();
+                                            data.as_raw();
                 ")).unwrap(),
 
             TextureDimensions::Texture3d => (write!(dest, "
                     let RawImage3d {{ data, width, height, depth, format: client_format }} =
-                                            data.into_raw();
+                                            data.as_raw();
                 ")).unwrap(),
 
             TextureDimensions::Texture1dArray => (write!(dest, "
@@ -304,7 +304,7 @@ fn build_texture<W: Writer>(mut dest: &mut W, ty: TextureType, dimensions: Textu
         }
         // writing the constructor
         (write!(dest, "{}(TextureImplementation::new(display, format, \
-                       Some((client_format, data)), ", name)).unwrap();
+                       Some((client_format, &*data)), ", name)).unwrap();
         match dimensions {
             TextureDimensions::Texture1d => (write!(dest, "width, None, None, None")).unwrap(),
             TextureDimensions::Texture2d => (write!(dest, "width, Some(height), None, None")).unwrap(),
@@ -435,14 +435,14 @@ fn build_texture<W: Writer>(mut dest: &mut W, ty: TextureType, dimensions: Textu
                 /// ## Panic
                 ///
                 /// Panics if the the dimensions of `data` don't match the `Rect`.
-                pub fn write<T>(&self, rect: Rect, data: T) where T: {data} {{
+                pub fn write<T>(&self, rect: Rect, data: &T) where T: {data} {{
                     let RawImage2d {{ data, width, height, format: client_format }} =
-                                            data.into_raw();
+                                            data.as_raw();
 
                     assert_eq!(width, rect.width);
                     assert_eq!(height, rect.height);
 
-                    self.0.upload(rect.left, rect.bottom, 0, (client_format, data), width,
+                    self.0.upload(rect.left, rect.bottom, 0, (client_format, &*data), width,
                                   Some(height), None);
                 }}
             "#, data = data_type)).unwrap();

--- a/examples/blitting.rs
+++ b/examples/blitting.rs
@@ -28,7 +28,7 @@ fn main() {
     // building a texture with "OpenGL" drawn on it
     let image = image::load(BufReader::new(include_bytes!("../tests/fixture/opengl.png")),
         image::PNG).unwrap();
-    let opengl_texture = glium::Texture2d::new(&display, image);
+    let opengl_texture = glium::Texture2d::new(&display, &image);
 
     // building a 1024x1024 empty texture
     let dest_texture = glium::Texture2d::new_empty(&display, glium::texture::

--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -32,7 +32,7 @@ fn main() {
         .unwrap();
 
     let image = image::load(BufReader::new(include_bytes!("../tests/fixture/opengl.png")), image::PNG).unwrap();
-    let opengl_texture = glium::texture::Texture2d::new(&display, image);
+    let opengl_texture = glium::texture::Texture2d::new(&display, &image);
 
     let floor_vertex_buffer = {
         #[vertex_format]
@@ -42,7 +42,7 @@ fn main() {
             normal: [f32; 4],
             texcoord: [f32; 2]
         }
-        
+
         glium::VertexBuffer::new(&display,
             vec![
                 Vertex { position: [-1.0, 0.0, -1.0, 1.0], normal: [0.0, 1.0, 0.0, 1.0], texcoord: [0.0, 0.0] },
@@ -63,7 +63,7 @@ fn main() {
             position: [f32; 4],
             texcoord: [f32; 2]
         }
-        
+
         glium::VertexBuffer::new(&display,
             vec![
                 Vertex { position: [0.0, 0.0, 0.0, 1.0], texcoord: [0.0, 0.0] },
@@ -106,7 +106,7 @@ fn main() {
         // fragment shader
         "
             #version 130
-            
+
             uniform sampler2D texture;
 
             smooth in vec4 frag_position;
@@ -151,7 +151,7 @@ fn main() {
         // fragment shader
         "
             #version 130
-            
+
             uniform sampler2D position_texture;
             uniform sampler2D normal_texture;
             uniform vec4 light_position;
@@ -178,7 +178,7 @@ fn main() {
                     );
                     attenuation_factor *= (1.0 - pow((light_distance / light_radius), 2.0));
                     diffuse *= attenuation_factor;
-                    
+
                 }
                 frag_output = vec4(light_color * diffuse, 1.0);
             }

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -31,7 +31,7 @@ fn main() {
     // building a texture with "OpenGL" drawn on it
     let image = image::load(BufReader::new(include_bytes!("../tests/fixture/opengl.png")),
         image::PNG).unwrap();
-    let opengl_texture = glium::texture::CompressedTexture2d::new(&display, image);
+    let opengl_texture = glium::texture::CompressedTexture2d::new(&display, &image);
 
     // building the vertex buffer, which contains all the vertices that we will draw
     let vertex_buffer = {
@@ -42,7 +42,7 @@ fn main() {
             tex_coords: [f32; 2],
         }
 
-        glium::VertexBuffer::new(&display, 
+        glium::VertexBuffer::new(&display,
             vec![
                 Vertex { position: [-1.0, -1.0], tex_coords: [0.0, 0.0] },
                 Vertex { position: [-1.0,  1.0], tex_coords: [0.0, 1.0] },
@@ -87,7 +87,7 @@ fn main() {
         matrix: [[f32; 4]; 4],
         texture: &'a glium::texture::CompressedTexture2d,
     }
-    
+
     // the main loop
     // each cycle will draw once
     'main: loop {

--- a/src/context/glutin_context.rs
+++ b/src/context/glutin_context.rs
@@ -5,7 +5,7 @@ use context::{capabilities, extensions, version};
 use GliumCreationError;
 
 use std::sync::{Arc, Mutex};
-use std::sync::mpsc::channel;
+use std::sync::mpsc::{channel, sync_channel};
 
 pub fn new_from_window(window: glutin::WindowBuilder, previous: Option<Context>)
     -> Result<Context, GliumCreationError>
@@ -13,6 +13,7 @@ pub fn new_from_window(window: glutin::WindowBuilder, previous: Option<Context>)
     use std::thread::Builder;
 
     let (tx_commands, rx_commands) = channel();
+    let (tx_sync, rx_sync) = sync_channel(0);
 
     let org_window = Arc::new(try!(window.build()));
     let window = org_window.clone();
@@ -78,6 +79,11 @@ pub fn new_from_window(window: glutin::WindowBuilder, previous: Option<Context>)
                     opengl_es: opengl_es,
                     capabilities: &*capabilities,
                 }),
+                Ok(Message::Sync) => {
+                    if let Err(_) = rx_sync.recv() {
+                        break
+                    }
+                },
                 Err(_) => break
             }
         }
@@ -86,6 +92,7 @@ pub fn new_from_window(window: glutin::WindowBuilder, previous: Option<Context>)
     let (capabilities, version, extensions) = try!(rx_success.recv().unwrap());
     Ok(Context {
         commands: Mutex::new(tx_commands),
+        sync: Mutex::new(tx_sync),
         window: Some(org_window),
         capabilities: capabilities,
         version: version,

--- a/src/ops/read.rs
+++ b/src/ops/read.rs
@@ -61,6 +61,7 @@ fn read_impl<P, T>(fbo: gl::types::GLuint, readbuffer: gl::types::GLenum,
                    T: texture::Texture2dDataSink<Data = P>
 {
     use std::mem;
+    use std::borrow::Cow;
 
     let pixels_count = dimensions.0 * dimensions.1;
 
@@ -124,7 +125,7 @@ fn read_impl<P, T>(fbo: gl::types::GLuint, readbuffer: gl::types::GLenum,
 
     rx.map(|rx| {
         let data = texture::RawImage2d {
-            data: rx.recv().unwrap(),
+            data: Cow::Owned(rx.recv().unwrap()),
             width: dimensions.0 as u32,
             height: dimensions.1 as u32,
             format: chosen_format,

--- a/src/pixel_buffer.rs
+++ b/src/pixel_buffer.rs
@@ -3,7 +3,9 @@ Pixel buffers are buffers that contain two-dimensional texture data.
 
 Contrary to textures, pixel buffers are stored in a client-defined format. They are used
 to transfer data to or from the video memory, before or after being turned into a texture.
-*/
+ */
+use std::borrow::Cow;
+
 use Display;
 use texture::{RawImage2d, Texture2dDataSink, ClientFormat};
 
@@ -71,7 +73,7 @@ impl<T> PixelBuffer<T> where T: Texture2dDataSink {
         let dimensions = self.dimensions.expect("The pixel buffer is empty");
 
         let data = RawImage2d {
-            data: data,
+            data: Cow::Owned(data),
             width: dimensions.0,
             height: dimensions.1,
             format: self.format.expect("The pixel buffer is empty"),

--- a/tests/framebuffer.rs
+++ b/tests/framebuffer.rs
@@ -68,7 +68,7 @@ fn simple_render_to_texture() {
     assert_eq!(read_back[0][0], (1.0, 0.0, 0.0, 1.0));
     assert_eq!(read_back[64][64], (1.0, 0.0, 0.0, 1.0));
     assert_eq!(read_back[127][127], (1.0, 0.0, 0.0, 1.0));
-    
+
     display.assert_no_error();
 }
 
@@ -107,7 +107,7 @@ fn depth_texture2d() {
     // depth texture with a value of 0.5 everywhere
     let depth_data = iter::repeat(iter::repeat(0.5f32).take(128).collect::<Vec<_>>())
                                   .take(128).collect::<Vec<_>>();
-    let depth = glium::texture::DepthTexture2d::new(&display, depth_data);
+    let depth = glium::texture::DepthTexture2d::new(&display, &depth_data);
 
     // drawing with the `IfLess` depth test
     let mut framebuffer = glium::framebuffer::SimpleFrameBuffer::with_depth_buffer(&display,

--- a/tests/samplers.rs
+++ b/tests/samplers.rs
@@ -19,7 +19,7 @@ fn magnify_nearest_filtering() {
     if ::std::os::getenv("TRAVIS").is_some() {
         return;
     }
-    
+
     let display = support::build_display();
     let (vb, ib) = support::build_rectangle_vb_ib(&display);
 
@@ -45,7 +45,7 @@ fn magnify_nearest_filtering() {
         None).unwrap();
 
     let texture_data = vec![vec![(0u8, 0, 0), (255, 255, 255)]];
-    let texture = glium::texture::Texture2d::new(&display, texture_data);
+    let texture = glium::texture::Texture2d::new(&display, &texture_data);
 
     let uniforms = glium::uniforms::UniformsStorage::new("texture",
         glium::uniforms::Sampler(&texture, glium::uniforms::SamplerBehavior {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -40,7 +40,7 @@ pub fn build_unicolor_texture2d(display: &glium::Display, red: f32, green: f32, 
 {
     let color = ((red * 255.0) as u8, (green * 255.0) as u8, (blue * 255.0) as u8);
 
-    glium::texture::Texture2d::new(display, vec![
+    glium::texture::Texture2d::new(display, &vec![
         vec![color, color],
         vec![color, color],
     ])

--- a/tests/texture.rs
+++ b/tests/texture.rs
@@ -12,10 +12,10 @@ use glium::{Texture, Surface};
 mod support;
 
 #[test]
-fn texture_1d_creation() {    
+fn texture_1d_creation() {
     let display = support::build_display();
 
-    let texture = glium::texture::Texture1d::new(&display, vec![
+    let texture = glium::texture::Texture1d::new(&display, &vec![
         (0, 0, 0, 0),
         (0, 0, 0, 0),
         (0, 0, 0, 0u8),
@@ -30,10 +30,10 @@ fn texture_1d_creation() {
 }
 
 #[test]
-fn texture_2d_creation() {    
+fn texture_2d_creation() {
     let display = support::build_display();
 
-    let texture = glium::texture::Texture2d::new(&display, vec![
+    let texture = glium::texture::Texture2d::new(&display, &vec![
         vec![(0, 0, 0, 0), (0, 0, 0, 0)],
         vec![(0, 0, 0, 0), (0, 0, 0, 0)],
         vec![(0, 0, 0, 0), (0, 0, 0, 0u8)],
@@ -48,10 +48,10 @@ fn texture_2d_creation() {
 }
 
 #[test]
-fn texture_3d_creation() {    
+fn texture_3d_creation() {
     let display = support::build_display();
 
-    let texture = glium::texture::Texture3d::new(&display, vec![
+    let texture = glium::texture::Texture3d::new(&display, &vec![
         vec![
             vec![(0, 0, 0, 0)],
             vec![(0, 0, 0, 0)],
@@ -78,7 +78,7 @@ fn texture_3d_creation() {
 fn compressed_texture_2d_creation() {
     let display = support::build_display();
 
-    let texture = glium::texture::CompressedTexture2d::new(&display, vec![
+    let texture = glium::texture::CompressedTexture2d::new(&display, &vec![
         vec![(0, 0, 0, 0), (0, 0, 0, 0)],
         vec![(0, 0, 0, 0), (0, 0, 0, 0)],
         vec![(0, 0, 0, 0), (0, 0, 0, 0u8)],
@@ -104,7 +104,7 @@ fn empty_texture2d() {
     display.assert_no_error();
 
     drop(texture);
-    
+
     display.assert_no_error();
 }
 
@@ -127,6 +127,6 @@ fn render_to_texture2d() {
     assert_eq!(read_back[0][0], (255, 0, 0, 255));
     assert_eq!(read_back[512][512], (255, 0, 0, 255));
     assert_eq!(read_back[1023][1023], (255, 0, 0, 255));
-    
+
     display.assert_no_error();
 }

--- a/tests/texture_draw.rs
+++ b/tests/texture_draw.rs
@@ -15,11 +15,11 @@ use glium::Surface;
 mod support;
 
 #[test]
-fn texture_2d_draw() {    
+fn texture_2d_draw() {
     let display = support::build_display();
     let (vb, ib) = support::build_rectangle_vb_ib(&display);
 
-    let texture = glium::texture::Texture2d::new(&display, vec![
+    let texture = glium::texture::Texture2d::new(&display, &vec![
         vec![(255, 0, 0, 255), (255, 0, 0, 255)],
         vec![(255, 0, 0, 255), (255, 0, 0, 255u8)],
     ]);
@@ -61,11 +61,11 @@ fn texture_2d_draw() {
 }
 
 #[test]
-fn compressed_texture_2d_draw() {    
+fn compressed_texture_2d_draw() {
     let display = support::build_display();
     let (vb, ib) = support::build_rectangle_vb_ib(&display);
 
-    let texture = glium::texture::CompressedTexture2d::new(&display, vec![
+    let texture = glium::texture::CompressedTexture2d::new(&display, &vec![
         vec![(255, 0, 0, 255), (255, 0, 0, 255)],
         vec![(255, 0, 0, 255), (255, 0, 0, 255u8)],
     ]);

--- a/tests/texture_read.rs
+++ b/tests/texture_read.rs
@@ -16,7 +16,7 @@ fn texture_2d_read() {
     let display = support::build_display();
 
     // we use only powers of two, in order to avoid float rounding errors
-    let texture = glium::texture::Texture2d::new(&display, vec![
+    let texture = glium::texture::Texture2d::new(&display, &vec![
         vec![(0u8, 1u8, 2u8), (4u8, 8u8, 16u8)],
         vec![(32u8, 64u8, 128u8), (32u8, 16u8, 4u8)],
     ]);
@@ -47,7 +47,7 @@ fn texture_2d_read_pixelbuffer() {
     let display = support::build_display();
 
     // we use only powers of two, in order to avoid float rounding errors
-    let texture = glium::texture::Texture2d::new(&display, vec![
+    let texture = glium::texture::Texture2d::new(&display, &vec![
         vec![(0u8, 1u8, 2u8), (4u8, 8u8, 16u8)],
         vec![(32u8, 64u8, 128u8), (32u8, 16u8, 4u8)],
     ]);

--- a/tests/texture_write.rs
+++ b/tests/texture_write.rs
@@ -16,13 +16,13 @@ fn texture_2d_write() {
     let display = support::build_display();
 
     // we use only powers of two, in order to avoid float rounding errors
-    let texture = glium::texture::Texture2d::new(&display, vec![
+    let texture = glium::texture::Texture2d::new(&display, &vec![
         vec![(0u8, 1u8, 2u8), (4u8, 8u8, 16u8)],
         vec![(32u8, 64u8, 128u8), (32u8, 16u8, 4u8)],
     ]);
 
     texture.write(glium::Rect { bottom: 1, left: 1, width: 1, height: 1 },
-                  vec![vec![(128u8, 64u8, 2u8)]]);
+                  &vec![vec![(128u8, 64u8, 2u8)]]);
 
     let read_back: Vec<Vec<(u8, u8, u8)>> = texture.read();
     assert_eq!(read_back[0][0], (0, 1, 2));


### PR DESCRIPTION
**Edit: Please do not merge this until I have run further tests.**
This implements the desired texture API from #388 that cuts down on copies. In order to do so I have created an additional blocking version of `exec` called `exec_sync` that ensures that the context thread can safely use any references from the calling thread. Due to limitations with the current version of `Send` in Rust this has been implemented using `unsafe` code, but in this case the safety of the code is easily verified.

All tests pass, the examples work and the docs build.

Also note that my emacs has removed trailing whitespace in a few places. I can split this into a separate commit if necessary.