### PR TITLE
Modified data source traits to support taking Copy-on-Write data.

### DIFF
--- a/build/textures.rs
+++ b/build/textures.rs
@@ -239,8 +239,8 @@ fn build_texture<W: Writer>(mut dest: &mut W, ty: TextureType, dimensions: Textu
                 /// Builds a new texture by uploading data.
                 ///
                 /// This function will automatically generate all mipmaps of the texture.
-                pub fn new<T>(display: &::Display, data: {param})
-                              -> {name} where T: {data_type}
+                pub fn new<'a, T>(display: &::Display, data: {param})
+                              -> {name} where T: {data_type}<'a>
                 {{
             ", data_type = data_type, param = param, name = name)).unwrap();
 
@@ -287,7 +287,7 @@ fn build_texture<W: Writer>(mut dest: &mut W, ty: TextureType, dimensions: Textu
 
             TextureDimensions::Texture1dArray => (write!(dest, "
                     let array_size = 0;
-                    let data = Vec::<u8>::new();
+                    let data = ::std::borrow::Cow::Owned(Vec::<u8>::new());
                     let width = 0;
                     let client_format = unsafe {{ ::std::mem::uninitialized() }};
                     unimplemented!();
@@ -295,7 +295,7 @@ fn build_texture<W: Writer>(mut dest: &mut W, ty: TextureType, dimensions: Textu
 
             TextureDimensions::Texture2dArray => (write!(dest, "
                     let array_size = 0;
-                    let data = Vec::<u8>::new();
+                    let data = ::std::borrow::Cow::Owned(Vec::<u8>::new());
                     let width = 0;
                     let height = 0;
                     let client_format = unsafe {{ ::std::mem::uninitialized() }};
@@ -435,7 +435,7 @@ fn build_texture<W: Writer>(mut dest: &mut W, ty: TextureType, dimensions: Textu
                 /// ## Panic
                 ///
                 /// Panics if the the dimensions of `data` don't match the `Rect`.
-                pub fn write<T>(&self, rect: Rect, data: T) where T: {data} {{
+                pub fn write<'a, T>(&self, rect: Rect, data: T) where T: {data}<'a> {{
                     let RawImage2d {{ data, width, height, format: client_format }} =
                                             data.into_raw();
 

--- a/build/textures.rs
+++ b/build/textures.rs
@@ -287,7 +287,7 @@ fn build_texture<W: Writer>(mut dest: &mut W, ty: TextureType, dimensions: Textu
 
             TextureDimensions::Texture1dArray => (write!(dest, "
                     let array_size = 0;
-                    let data = ::std::borrow::Cow::Owned(Vec::<u8>::new());
+                    let data = Cow::Owned(Vec::<u8>::new());
                     let width = 0;
                     let client_format = unsafe {{ ::std::mem::uninitialized() }};
                     unimplemented!();
@@ -295,7 +295,7 @@ fn build_texture<W: Writer>(mut dest: &mut W, ty: TextureType, dimensions: Textu
 
             TextureDimensions::Texture2dArray => (write!(dest, "
                     let array_size = 0;
-                    let data = ::std::borrow::Cow::Owned(Vec::<u8>::new());
+                    let data = Cow::Owned(Vec::<u8>::new());
                     let width = 0;
                     let height = 0;
                     let client_format = unsafe {{ ::std::mem::uninitialized() }};

--- a/src/ops/read.rs
+++ b/src/ops/read.rs
@@ -124,7 +124,7 @@ fn read_impl<P, T>(fbo: gl::types::GLuint, readbuffer: gl::types::GLenum,
 
     rx.map(|rx| {
         let data = texture::RawImage2d {
-            data: rx.recv().unwrap(),
+            data: ::std::borrow::Cow::Owned(rx.recv().unwrap()),
             width: dimensions.0 as u32,
             height: dimensions.1 as u32,
             format: chosen_format,

--- a/src/pixel_buffer.rs
+++ b/src/pixel_buffer.rs
@@ -3,7 +3,9 @@ Pixel buffers are buffers that contain two-dimensional texture data.
 
 Contrary to textures, pixel buffers are stored in a client-defined format. They are used
 to transfer data to or from the video memory, before or after being turned into a texture.
-*/
+ */
+use std::borrow::Cow;
+
 use Display;
 use texture::{RawImage2d, Texture2dDataSink, ClientFormat};
 
@@ -71,7 +73,7 @@ impl<T> PixelBuffer<T> where T: Texture2dDataSink {
         let dimensions = self.dimensions.expect("The pixel buffer is empty");
 
         let data = RawImage2d {
-            data: data,
+            data: Cow::Owned(data),
             width: dimensions.0,
             height: dimensions.1,
             format: self.format.expect("The pixel buffer is empty"),

--- a/src/texture/tex_impl.rs
+++ b/src/texture/tex_impl.rs
@@ -48,10 +48,10 @@ pub struct TextureImplementation {
 
 impl TextureImplementation {
     /// Builds a new texture.
-    pub fn new<'a, P: Clone + 'a>(display: &Display, format: TextureFormatRequest,
-                  data: Option<(ClientFormat, Cow<'a, Vec<P>, [P]>)>, width: u32, height: Option<u32>,
-                  depth: Option<u32>, array_size: Option<u32>)
-                  -> TextureImplementation where P: Send
+    pub fn new<'a, P>(display: &Display, format: TextureFormatRequest,
+                      data: Option<(ClientFormat, Cow<'a, Vec<P>, [P]>)>, width: u32, height: Option<u32>,
+                      depth: Option<u32>, array_size: Option<u32>)
+                      -> TextureImplementation where P: Send + Clone + 'a
     {
         use std::num::Float;
 
@@ -273,9 +273,9 @@ impl TextureImplementation {
     }
 
     /// Changes some parts of the texture.
-    pub fn upload<'a, P: Clone + 'a>(&self, x_offset: u32, y_offset: u32, z_offset: u32,
-                     (format, data): (ClientFormat, Cow<'a, Vec<P>, [P]>), width: u32, height: Option<u32>,
-                     depth: Option<u32>) where P: Send + Copy
+    pub fn upload<'a, P>(&self, x_offset: u32, y_offset: u32, z_offset: u32,
+                         (format, data): (ClientFormat, Cow<'a, Vec<P>, [P]>), width: u32, height: Option<u32>,
+                         depth: Option<u32>) where P: Send + Copy + Clone + 'a
     {
         let id = self.id;
         let bind_point = self.bind_point;

--- a/src/texture/tex_impl.rs
+++ b/src/texture/tex_impl.rs
@@ -15,6 +15,7 @@ use std::fmt;
 use std::mem;
 use std::ptr;
 use std::sync::mpsc::channel;
+use std::borrow::Cow;
 
 use ops;
 use fbo;
@@ -47,8 +48,8 @@ pub struct TextureImplementation {
 
 impl TextureImplementation {
     /// Builds a new texture.
-    pub fn new<P>(display: &Display, format: TextureFormatRequest,
-                  data: Option<(ClientFormat, Vec<P>)>, width: u32, height: Option<u32>,
+    pub fn new<'a, P: Clone + 'a>(display: &Display, format: TextureFormatRequest,
+                  data: Option<(ClientFormat, Cow<'a, Vec<P>, [P]>)>, width: u32, height: Option<u32>,
                   depth: Option<u32>, array_size: Option<u32>)
                   -> TextureImplementation where P: Send
     {
@@ -106,7 +107,8 @@ impl TextureImplementation {
         };
 
         let (tx, rx) = channel();
-        display.context.context.exec(move |: ctxt| {
+        //This always syncs with rx later.
+        display.context.context.exec_maybe_sync(false, move |: ctxt| {
             unsafe {
                 let data = data;
                 let data_raw = if let Some((_, ref data)) = data {
@@ -271,8 +273,8 @@ impl TextureImplementation {
     }
 
     /// Changes some parts of the texture.
-    pub fn upload<P>(&self, x_offset: u32, y_offset: u32, z_offset: u32,
-                     (format, data): (ClientFormat, Vec<P>), width: u32, height: Option<u32>,
+    pub fn upload<'a, P: Clone + 'a>(&self, x_offset: u32, y_offset: u32, z_offset: u32,
+                     (format, data): (ClientFormat, Cow<'a, Vec<P>, [P]>), width: u32, height: Option<u32>,
                      depth: Option<u32>) where P: Send + Copy
     {
         let id = self.id;
@@ -288,8 +290,8 @@ impl TextureImplementation {
 
         let (client_format, client_type) = client_format_to_glenum(&self.display, format,
                                                                    self.requested_format);
-
-        self.display.context.context.exec(move |: ctxt| {
+        let should_sync = data.is_borrowed();
+        self.display.context.context.exec_maybe_sync(should_sync, move |: ctxt| {
             unsafe {
                 if ctxt.state.pixel_store_unpack_alignment != 1 {
                     ctxt.state.pixel_store_unpack_alignment = 1;
@@ -431,33 +433,33 @@ fn format_request_to_glenum(display: &Display, client: Option<ClientFormat>,
                     (value, true)
                 },
                 _ => {
-                    assert!(version >= &GlVersion(3, 0));       // FIXME: 
+                    assert!(version >= &GlVersion(3, 0));       // FIXME:
                     (value, true)
                 }
             }
         },
         TextureFormatRequest::Specific(TextureFormat::CompressedFormat(f)) => {
-            assert!(version >= &GlVersion(3, 0));       // FIXME: 
+            assert!(version >= &GlVersion(3, 0));       // FIXME:
             (f.to_glenum(), true)
         },
         TextureFormatRequest::Specific(TextureFormat::UncompressedIntegral(f)) => {
-            assert!(version >= &GlVersion(3, 0));       // FIXME: 
+            assert!(version >= &GlVersion(3, 0));       // FIXME:
             (f.to_glenum(), true)
         },
         TextureFormatRequest::Specific(TextureFormat::UncompressedUnsigned(f)) => {
-            assert!(version >= &GlVersion(3, 0));       // FIXME: 
+            assert!(version >= &GlVersion(3, 0));       // FIXME:
             (f.to_glenum(), true)
         },
         TextureFormatRequest::Specific(TextureFormat::DepthFormat(f)) => {
-            assert!(version >= &GlVersion(3, 0));       // FIXME: 
+            assert!(version >= &GlVersion(3, 0));       // FIXME:
             (f.to_glenum(), true)
         },
         TextureFormatRequest::Specific(TextureFormat::StencilFormat(f)) => {
-            assert!(version >= &GlVersion(3, 0));       // FIXME: 
+            assert!(version >= &GlVersion(3, 0));       // FIXME:
             (f.to_glenum(), true)
         },
         TextureFormatRequest::Specific(TextureFormat::DepthStencilFormat(f)) => {
-            assert!(version >= &GlVersion(3, 0));       // FIXME: 
+            assert!(version >= &GlVersion(3, 0));       // FIXME:
             (f.to_glenum(), true)
         },
 


### PR DESCRIPTION
In the process, added optionally synchronising exec function to Context. Made texture creation and uploading synchronise with the GL thread if using shared data.

This patch should not affect existing user code that does not manually implement data sources.