### PR TITLE
Update to latest nightly

### DIFF
--- a/src/context/version.rs
+++ b/src/context/version.rs
@@ -34,8 +34,8 @@ pub fn get_gl_version(gl: &gl::Gl) -> GlVersion {
         let minor = iter.next().expect("glGetString(GL_VERSION) did not return a correct version");
 
         GlVersion(
-            major.parse().expect("failed to parse GL major version"),
-            minor.parse().expect("failed to parse GL minor version"),
+            major.parse().ok().expect("failed to parse GL major version"),
+            minor.parse().ok().expect("failed to parse GL minor version"),
         )
     }
 }


### PR DESCRIPTION
String parsing now yields a Result instead of an Option.

I thought, I'd just share this, because I needed glium to working for other things. Discard it, if more things need to be done. This commit fixes the build itself, but when running `cargo test`, odd things start to happen:

```rust
thread 'glium rendering thread' panicked at 'Debug message with high or medium severity: `GL_INVALID_OPERATION error generated. <framebuffer> is not a valid framebuffer object.`.
Please report this error: https://github.com/tomaka/glium/issues', src/lib.rs:1656
stack backtrace:
   1:     0x7f87be95ee80 - sys::backtrace::write::h84a1347ec8a3d425Aru
   2:     0x7f87be9824a0 - failure::on_fail::h1cb2299eb5e255ae9GB
   3:     0x7f87be8ed2d0 - rt::unwind::begin_unwind_inner::ha34a1c7f0630f466IlB
   4:     0x7f87be8eddf0 - rt::unwind::begin_unwind_fmt::h7ce8b0d056a126fdekB
   5:     0x7f87be982300 - rust_begin_unwind
   6:     0x7f87be9cb290 - panicking::panic_fmt::haefa65e91191458cljw
   7:     0x7f87bf5f5db0 - result::Result<T, E>::unwrap::h16076174516961258784
   8:     0x7f87bf7207b0 - context::Context::exec::h7877870527013976503
   9:     0x7f87bf7173f0 - fbo::FrameBufferObject::destroy::h77ef21dc736845afQ4p
  10:     0x7f87bf7143f0 - fbo::FramebuffersContainer::purge_if::h15734833065018314699
  11:     0x7f87bf67afe0 - fbo::FramebuffersContainer::purge_texture::hd5f89422b84a650daOp
  12:     0x7f87bf67af10 - texture::tex_impl::TextureImplementation.Drop::drop::h50a0a77b5aab2f6d0Nk
  13:     0x7f87bf5a8170 - glium..texture..tex_impl..TextureImplementation::glue_drop.7325::hb33e7d8b0b5c13c9
  14:     0x7f87bf5a8140 - glium..texture..Texture2d::glue_drop.7322::h04961f746ac98ebd
  15:     0x7f87bf5e98c0 - cull_clockwise_trianglestrip::ha0f7b0d38332546ckva
  16:     0x7f87bf0f52c0 - thunk::F.Invoke<A, R>::invoke::h6657674549921570033
  17:     0x7f87bf0ff010 - thunk::F.Invoke<A, R>::invoke::h15971407284406694800
  18:     0x7f87bf0f5970 - thunk::F.Invoke<A, R>::invoke::h5652380358568928806
  19:     0x7f87bf0f6120 - rt::unwind::try::try_fn::h13958861113646144964
  20:     0x7f87be9ed910 - rust_try_inner
  21:     0x7f87be9ed900 - rust_try
  22:     0x7f87bf0f63d0 - thunk::F.Invoke<A, R>::invoke::h17587152980792264238
  23:     0x7f87be96eca0 - sys::thread::thread_start::h756cedb2df1b4200Pnx
  24:     0x7f87be625250 - start_thread
  25:     0x7f87bd39d219 - clone
  26:                0x0 - <unknown>
thread panicked while panicking. aborting.
```

