### PR TITLE
Allow blitting with negative width and height

### DIFF
--- a/examples/blitting.rs
+++ b/examples/blitting.rs
@@ -41,11 +41,11 @@ fn main() {
         // we have one out of 60 chances to blit one `opengl_texture` over `dest_texture`
         if rand::random::<f64>() <= 0.016666 {
             let (left, bottom, dimensions): (f32, f32, f32) = rand::random();
-            let dest_rect = glium::Rect {
+            let dest_rect = glium::BlitTarget {
                 left: (left * dest_texture.get_width() as f32) as u32,
                 bottom: (bottom * dest_texture.get_height().unwrap() as f32) as u32,
-                width: (dimensions * dest_texture.get_width() as f32) as u32,
-                height: (dimensions * dest_texture.get_height().unwrap() as f32) as u32,
+                width: (dimensions * dest_texture.get_width() as f32) as i32,
+                height: (dimensions * dest_texture.get_height().unwrap() as f32) as i32,
             };
 
             opengl_texture.as_surface().blit_whole_color_to(&dest_texture.as_surface(), &dest_rect,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -931,6 +931,23 @@ pub struct Rect {
     pub height: u32,
 }
 
+/// Area of a surface in pixels. Similar to a `Rect` except that dimensions can be negative.
+///
+/// In the OpenGL ecosystem, the (0,0) coordinate is at the bottom-left hand corner of the images.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct BlitTarget {
+    /// Number of pixels between the left border of the surface and the left border of
+    /// the rectangle.
+    pub left: u32,
+    /// Number of pixels between the bottom border of the surface and the bottom border
+    /// of the rectangle.
+    pub bottom: u32,
+    /// Width of the area in pixels. Can be negative.
+    pub width: i32,
+    /// Height of the area in pixels. Can be negative.
+    pub height: i32,
+}
+
 /// Object that can be drawn upon.
 ///
 /// # What does the GPU do when you draw?
@@ -1201,7 +1218,7 @@ pub trait Surface: Sized {
     /// Note that there is no alpha blending, depth/stencil checking, etc. This function just
     /// copies pixels.
     #[unstable = "The name will likely change"]
-    fn blit_color<S>(&self, source_rect: &Rect, target: &S, target_rect: &Rect,
+    fn blit_color<S>(&self, source_rect: &Rect, target: &S, target_rect: &BlitTarget,
         filter: uniforms::MagnifySamplerFilter) where S: Surface
     {
         ops::blit(self, target, gl::COLOR_BUFFER_BIT, source_rect, target_rect,
@@ -1210,7 +1227,7 @@ pub trait Surface: Sized {
 
     /// Copies the entire surface to a target surface. See `blit_color`.
     #[unstable = "The name will likely change"]
-    fn blit_whole_color_to<S>(&self, target: &S, target_rect: &Rect,
+    fn blit_whole_color_to<S>(&self, target: &S, target_rect: &BlitTarget,
         filter: uniforms::MagnifySamplerFilter) where S: Surface
     {
         let src_dim = self.get_dimensions();
@@ -1224,7 +1241,7 @@ pub trait Surface: Sized {
         let src_dim = self.get_dimensions();
         let src_rect = Rect { left: 0, bottom: 0, width: src_dim.0 as u32, height: src_dim.1 as u32 };
         let target_dim = target.get_dimensions();
-        let target_rect = Rect { left: 0, bottom: 0, width: target_dim.0 as u32, height: target_dim.1 as u32 };
+        let target_rect = BlitTarget { left: 0, bottom: 0, width: target_dim.0 as i32, height: target_dim.1 as i32 };
         self.blit_color(&src_rect, target, &target_rect, filter)
     }
 }

--- a/src/ops/blit.rs
+++ b/src/ops/blit.rs
@@ -1,3 +1,4 @@
+use BlitTarget;
 use Rect;
 use Surface;
 
@@ -5,7 +6,7 @@ use gl;
 use context;
 
 pub fn blit<S1: Surface, S2: Surface>(source: &S1, target: &S2, mask: gl::types::GLbitfield,
-    src_rect: &Rect, target_rect: &Rect, filter: gl::types::GLenum)
+    src_rect: &Rect, target_rect: &BlitTarget, filter: gl::types::GLenum)
 {
     let ::BlitHelper(display, source) = source.get_blit_helper();
     let ::BlitHelper(_, target) = target.get_blit_helper();
@@ -29,8 +30,8 @@ pub fn blit<S1: Surface, S2: Surface>(source: &S1, target: &S2, mask: gl::types:
                     (src_rect.left + src_rect.width) as gl::types::GLint,
                     (src_rect.bottom + src_rect.height) as gl::types::GLint,
                     target_rect.left as gl::types::GLint, target_rect.bottom as gl::types::GLint,
-                    (target_rect.left + target_rect.width) as gl::types::GLint,
-                    (target_rect.bottom + target_rect.height) as gl::types::GLint, mask, filter);
+                    (target_rect.left as i32 + target_rect.width) as gl::types::GLint,
+                    (target_rect.bottom as i32 + target_rect.height) as gl::types::GLint, mask, filter);
 
                 return;
             }
@@ -66,8 +67,8 @@ pub fn blit<S1: Surface, S2: Surface>(source: &S1, target: &S2, mask: gl::types:
                     (src_rect.left + src_rect.width) as gl::types::GLint,
                     (src_rect.bottom + src_rect.height) as gl::types::GLint,
                     target_rect.left as gl::types::GLint, target_rect.bottom as gl::types::GLint,
-                    (target_rect.left + target_rect.width) as gl::types::GLint,
-                    (target_rect.bottom + target_rect.height) as gl::types::GLint, mask, filter);
+                    (target_rect.left as i32 + target_rect.width) as gl::types::GLint,
+                    (target_rect.bottom as i32 + target_rect.height) as gl::types::GLint, mask, filter);
 
             } else {
                 ctxt.gl.BlitFramebufferEXT(src_rect.left as gl::types::GLint,
@@ -75,8 +76,8 @@ pub fn blit<S1: Surface, S2: Surface>(source: &S1, target: &S2, mask: gl::types:
                     (src_rect.left + src_rect.width) as gl::types::GLint,
                     (src_rect.bottom + src_rect.height) as gl::types::GLint,
                     target_rect.left as gl::types::GLint, target_rect.bottom as gl::types::GLint,
-                    (target_rect.left + target_rect.width) as gl::types::GLint,
-                    (target_rect.bottom + target_rect.height) as gl::types::GLint, mask, filter);
+                    (target_rect.left as i32 + target_rect.width) as gl::types::GLint,
+                    (target_rect.bottom as i32 + target_rect.height) as gl::types::GLint, mask, filter);
             }
         }
     });

--- a/tests/blit.rs
+++ b/tests/blit.rs
@@ -7,7 +7,7 @@ extern crate glium_macros;
 extern crate glutin;
 extern crate glium;
 
-use glium::{Surface, Rect};
+use glium::{Surface, BlitTarget, Rect};
 
 mod support;
 
@@ -28,7 +28,7 @@ fn blit_texture_to_window() {
         height: 2,
     };
 
-    let dest_rect = Rect {
+    let dest_rect = BlitTarget {
         left: 1,
         bottom: 1,
         width: 2,


### PR DESCRIPTION
Close #452
cc @dylanede 

*Breaking change*: the blit functions now take a `BlitTarget` instead of `Rect`