### PR TITLE
Change the MultiVerticesSource trait to avoid an allocation

### DIFF
--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -223,7 +223,7 @@ impl<'a> Surface for SimpleFrameBuffer<'a> {
             }
         }
 
-        ops::draw(&self.display, Some(&self.attachments), vb.build_vertices_source().as_mut_slice(),
+        ops::draw(&self.display, Some(&self.attachments), vb,
                   ib.to_indices_source(), program, uniforms, draw_parameters, self.dimensions)
     }
 
@@ -420,8 +420,7 @@ impl<'a> Surface for MultiOutputFrameBuffer<'a> {
             }
         }
 
-        ops::draw(&self.display, Some(&self.build_attachments(program)),
-                  vb.build_vertices_source().as_mut_slice(),
+        ops::draw(&self.display, Some(&self.build_attachments(program)), vb,
                   ib.to_indices_source(), program, uniforms, draw_parameters, self.dimensions)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1422,9 +1422,8 @@ impl Surface for Frame {
             }
         }
 
-        ops::draw(&self.display, None, vertex_buffer.build_vertices_source().as_mut_slice(),
-                  index_buffer.to_indices_source(), program, uniforms, draw_parameters,
-                  (self.dimensions.0 as u32, self.dimensions.1 as u32))
+        ops::draw(&self.display, None, vertex_buffer, index_buffer.to_indices_source(), program,
+                  uniforms, draw_parameters, (self.dimensions.0 as u32, self.dimensions.1 as u32))
     }
 
     fn get_blit_helper(&self) -> BlitHelper {

--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -11,18 +11,21 @@ use sync;
 use uniforms::{Uniforms, UniformValue, SamplerBehavior};
 use {Program, DrawParameters, GlObject, ToGlEnum};
 use index::{self, IndicesSource};
-use vertex::VerticesSource;
+use vertex::{MultiVerticesSource, VerticesSource};
 
 use {program, vertex_array_object};
 use {gl, context};
 
 /// Draws everything.
-pub fn draw<'a, I, U>(display: &Display, framebuffer: Option<&FramebufferAttachments>,
-                      mut vertex_buffers: &mut [VerticesSource], mut indices: IndicesSource<I>,
-                      program: &Program, uniforms: U, draw_parameters: &DrawParameters,
-                      dimensions: (u32, u32)) -> Result<(), DrawError>
-                      where U: Uniforms, I: index::Index
+pub fn draw<'a, I, U, V>(display: &Display, framebuffer: Option<&FramebufferAttachments>,
+                         vertex_buffers: V, mut indices: IndicesSource<I>,
+                         program: &Program, uniforms: U, draw_parameters: &DrawParameters,
+                         dimensions: (u32, u32)) -> Result<(), DrawError>
+                         where U: Uniforms, I: index::Index, V: MultiVerticesSource<'a>
 {
+    // TODO: avoid this allocation
+    let mut vertex_buffers = vertex_buffers.iter().collect::<Vec<_>>();
+
     try!(draw_parameters.validate());
 
     // obtaining the identifier of the FBO to draw upon

--- a/src/vertex/mod.rs
+++ b/src/vertex/mod.rs
@@ -59,6 +59,9 @@ let vertex_buffer = glium::vertex::VertexBuffer::new(&display, data);
 use std::sync::mpsc::Sender;
 use sync::LinearSyncFence;
 
+use std::iter::Chain;
+use std::option::IntoIter;
+
 pub use self::buffer::{VertexBuffer, VertexBufferAny, Mapping};
 pub use self::format::{AttributeType, VertexFormat};
 pub use self::per_instance::{PerInstanceAttributesBuffer, PerInstanceAttributesBufferAny};
@@ -100,40 +103,75 @@ impl<'a> IntoVerticesSource<'a> for VerticesSource<'a> {
 
 /// Objects that describe multiple vertex sources.
 pub trait MultiVerticesSource<'a> {
-    /// Builds a list of `VerticesSource`.
-    fn build_vertices_source(self) -> Vec<VerticesSource<'a>>;
+    type Iterator: Iterator<Item = VerticesSource<'a>>;
+
+    /// Iterates over the `VerticesSource`.
+    fn iter(self) -> Self::Iterator;
 }
 
-impl<'a, T> MultiVerticesSource<'a> for T where T: IntoVerticesSource<'a> {
-    fn build_vertices_source(self) -> Vec<VerticesSource<'a>> {
-        vec![self.into_vertices_source()]
+impl<'a, T> MultiVerticesSource<'a> for T
+    where T: IntoVerticesSource<'a>
+{
+    type Iterator = IntoIter<VerticesSource<'a>>;
+
+    fn iter(self) -> IntoIter<VerticesSource<'a>> {
+        Some(self.into_vertices_source()).into_iter()
     }
 }
 
-impl<'a, T> MultiVerticesSource<'a> for Vec<T> where T: IntoVerticesSource<'a> {
-    fn build_vertices_source(self) -> Vec<VerticesSource<'a>> {
-        self.into_iter().map(|src| src.into_vertices_source()).collect()
-    }
-}
-
-macro_rules! impl_for_tuple(
-    ($($name:ident: $t:ident),+) => (
-        impl<'a, $($t),+> MultiVerticesSource<'a> for ($($t),+)
-            where $($t: IntoVerticesSource<'a>),+
+macro_rules! impl_for_tuple {
+    ($t:ident) => (
+        impl<'a, $t> MultiVerticesSource<'a> for ($t,)
+            where $t: IntoVerticesSource<'a>
         {
-            fn build_vertices_source(self) -> Vec<VerticesSource<'a>> {
-                let ($($name),+) = self;
-                vec![$($name.into_vertices_source()),+]
+            type Iterator = IntoIter<VerticesSource<'a>>;
+
+            fn iter(self) -> IntoIter<VerticesSource<'a>> {
+                Some(self.0.into_vertices_source()).into_iter()
             }
         }
-    )
-);
+    );
 
-impl_for_tuple!(a: A, b: B);
-impl_for_tuple!(a: A, b: B, c: C);
-impl_for_tuple!(a: A, b: B, c: C, d: D);
-impl_for_tuple!(a: A, b: B, c: C, d: D, e: E);
-impl_for_tuple!(a: A, b: B, c: C, d: D, e: E, f: F);
+    ($t1:ident, $t2:ident) => (
+        #[allow(non_snake_case)]
+        impl<'a, $t1, $t2> MultiVerticesSource<'a> for ($t1, $t2)
+            where $t1: IntoVerticesSource<'a>, $t2: IntoVerticesSource<'a>
+        {
+            type Iterator = Chain<<($t1,) as MultiVerticesSource<'a>>::Iterator,
+                                  <($t2,) as MultiVerticesSource<'a>>::Iterator>;
+
+            fn iter(self) -> Chain<<($t1,) as MultiVerticesSource<'a>>::Iterator,
+                                   <($t2,) as MultiVerticesSource<'a>>::Iterator>
+            {
+                let ($t1, $t2) = self;
+                Some($t1.into_vertices_source()).into_iter().chain(($t2,).iter())
+            }
+        }
+
+        impl_for_tuple!($t2);
+    );
+
+    ($t1:ident, $($t2:ident),+) => (
+        #[allow(non_snake_case)]
+        impl<'a, $t1, $($t2),+> MultiVerticesSource<'a> for ($t1, $($t2),+)
+            where $t1: IntoVerticesSource<'a>, $($t2: IntoVerticesSource<'a>),+
+        {
+            type Iterator = Chain<<($t1,) as MultiVerticesSource<'a>>::Iterator,
+                                  <($($t2),+) as MultiVerticesSource<'a>>::Iterator>;
+
+            fn iter(self) -> Chain<<($t1,) as MultiVerticesSource<'a>>::Iterator,
+                                  <($($t2),+) as MultiVerticesSource<'a>>::Iterator>
+            {
+                let ($t1, $($t2),+) = self;
+                Some($t1.into_vertices_source()).into_iter().chain(($($t2),+).iter())
+            }
+        }
+
+        impl_for_tuple!($($t2),+);
+    );
+}
+
+impl_for_tuple!(A, B, C, D, E, F, G);
 
 /// Trait for structures that represent a vertex.
 ///


### PR DESCRIPTION
This doesn't speed up anything because it moves the allocation to the `draw` function instead of making it mandatory in the trait. But it's a first step.