### PR TITLE
Add the empty, empty_with_mipmaps and empty_with_format functions

### DIFF
--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -109,7 +109,5 @@ pub fn build_rectangle_vb_ib(display: &glium::Display)
 
 /// Builds a texture suitable for rendering.
 pub fn build_renderable_texture(display: &glium::Display) -> glium::Texture2d {
-    glium::Texture2d::new_empty(display,
-                                glium::texture::UncompressedFloatFormat::U8U8U8U8,
-                                1024, 1024)
+    glium::Texture2d::empty(display, 1024, 1024)
 }


### PR DESCRIPTION
Close #486 
cc #471 

The `empty` method is like the current `new_empty` but doesn't need to pass any format and does not generate mipmaps.

The `new_empty` method has been deprecated.
