### PR TITLE
Use a FnvHasher in all HashMaps

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,36 @@
+//! Contains utility things used in glium's internals
+
+use std::default::Default;
+use std::hash::{Hasher, Writer};
+
+/// A speedy hash algorithm for node ids and def ids. The hashmap in
+/// libcollections by default uses SipHash which isn't quite as speedy as we
+/// want. In the compiler we're not really worried about DOS attempts, so we
+/// just default to a non-cryptographic hash.
+///
+/// This uses FNV hashing, as described here:
+/// http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+///
+/// Copy-pasted from rustc/util/nodemap.rs
+pub struct FnvHasher(u64);
+
+impl Default for FnvHasher {
+    fn default() -> FnvHasher { FnvHasher(0xcbf29ce484222325) }
+}
+
+impl Hasher for FnvHasher {
+    type Output = u64;
+    fn reset(&mut self) { *self = Default::default(); }
+    fn finish(&self) -> u64 { self.0 }
+}
+
+impl Writer for FnvHasher {
+    fn write(&mut self, bytes: &[u8]) {
+        let FnvHasher(mut hash) = *self;
+        for byte in bytes {
+            hash = hash ^ (*byte as u64);
+            hash = hash * 0x100000001b3;
+        }
+        *self = FnvHasher(hash);
+    }
+}


### PR DESCRIPTION
The default hasher is slow but suitable for cryptographic purposes. We don't care about this, 