### PR TITLE
Add draw_primitives parameter to DrawParameters

### DIFF
--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -31,6 +31,9 @@ pub struct GLState {
     /// Whether GL_POLYGON_OFFSET_FILL is enabled
     pub enabled_polygon_offset_fill: bool,
 
+    /// Whether GL_RASTERIZER_DISCARD is enabled
+    pub enabled_rasterizer_discard: bool,
+
     /// Whether GL_SAMPLE_ALPHA_TO_COVERAGE is enabled
     pub enabled_sample_alpha_to_coverage: bool,
 
@@ -137,6 +140,7 @@ impl Default for GLState {
             enabled_dither: false,
             enabled_multisample: true,
             enabled_polygon_offset_fill: false,
+            enabled_rasterizer_discard: false,
             enabled_sample_alpha_to_coverage: false,
             enabled_sample_coverage: false,
             enabled_scissor_test: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -645,6 +645,9 @@ pub enum DrawError {
 
     /// If you don't use indices, then all vertices sources must have the same size.
     VerticesSourcesLengthMismatch,
+
+    /// You requested not to draw primitives, but this is not supported by the backend.
+    TransformFeedbackNotSupported,
 }
 
 impl std::fmt::Display for DrawError {
@@ -692,6 +695,9 @@ impl std::fmt::Display for DrawError {
             &DrawError::VerticesSourcesLengthMismatch => write!(fmt, "If you don't use indices, \
                                                                       then all vertices sources \
                                                                       must have the same size."),
+            &DrawError::TransformFeedbackNotSupported => write!(fmt, "Requested not to draw \
+                                                                      primitves, but this is not \
+                                                                      supported by the backend."),
         }
     }
 }

--- a/src/ops/clear.rs
+++ b/src/ops/clear.rs
@@ -32,6 +32,11 @@ pub fn clear(display: &Arc<DisplayImpl>, framebuffer: Option<&FramebufferAttachm
         fbo::bind_framebuffer(&mut ctxt, fbo_id, true, false);
 
         unsafe {
+            if ctxt.state.enabled_rasterizer_discard {
+                ctxt.gl.Disable(gl::RASTERIZER_DISCARD);
+                ctxt.state.enabled_rasterizer_discard = false;
+            }
+
             if ctxt.state.enabled_scissor_test {
                 ctxt.gl.Disable(gl::SCISSOR_TEST);
                 ctxt.state.enabled_scissor_test = false;

--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -26,7 +26,7 @@ pub fn draw<'a, I, U, V>(display: &Display, framebuffer: Option<&FramebufferAtta
     // TODO: avoid this allocation
     let mut vertex_buffers = vertex_buffers.iter().collect::<Vec<_>>();
 
-    try!(draw_parameters::validate(draw_parameters));
+    try!(draw_parameters::validate(display, draw_parameters));
 
     // obtaining the identifier of the FBO to draw upon
     let fbo_id = display.context.framebuffer_objects.as_ref().unwrap()

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -249,3 +249,62 @@ fn viewport() {
 
     display.assert_no_error();
 }
+
+#[test]
+fn dont_draw_primitives() {
+    let display = support::build_display();
+
+    let params = glium::DrawParameters {
+        draw_primitives: false,
+        .. std::default::Default::default()
+    };
+
+    let (vb, ib, program) = support::build_fullscreen_red_pipeline(&display);
+
+    let texture = support::build_renderable_texture(&display);
+    texture.as_surface().clear_color(0.0, 1.0, 0.0, 0.0);
+    match texture.as_surface().draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params) {
+        Ok(_) => (),
+        Err(glium::DrawError::TransformFeedbackNotSupported) => return,
+        e => e.unwrap()
+    }
+
+    let data: Vec<Vec<(f32, f32, f32)>> = texture.read();
+    for row in data.iter() {
+        for pixel in row.iter() {
+            assert_eq!(pixel, &(0.0, 1.0, 0.0));
+        }
+    }
+
+    display.assert_no_error();
+}
+
+#[test]
+fn dont_draw_primitives_then_draw() {
+    let display = support::build_display();
+
+    let params = glium::DrawParameters {
+        draw_primitives: false,
+        .. std::default::Default::default()
+    };
+
+    let (vb, ib, program) = support::build_fullscreen_red_pipeline(&display);
+
+    let texture = support::build_renderable_texture(&display);
+    texture.as_surface().clear_color(0.0, 1.0, 0.0, 0.0);
+    match texture.as_surface().draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params) {
+        Ok(_) => (),
+        Err(glium::DrawError::TransformFeedbackNotSupported) => return,
+        e => e.unwrap()
+    }
+    texture.as_surface().draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &std::default::Default::default()).unwrap();
+
+    let data: Vec<Vec<(f32, f32, f32)>> = texture.read();
+    for row in data.iter() {
+        for pixel in row.iter() {
+            assert_eq!(pixel, &(1.0, 0.0, 0.0));
+        }
+    }
+
+    display.assert_no_error();
+}


### PR DESCRIPTION
~~Test won't pass with older devices though.~~

Adds a new `DrawError` if transform feedback is not supported.

cc #34