### PR TITLE
Default the viewport and scissor states to an unknown value

### DIFF
--- a/src/context/glutin_context.rs
+++ b/src/context/glutin_context.rs
@@ -5,6 +5,7 @@ use context::{Context, CommandContext, GLState, check_gl_compatibility};
 use context::{capabilities, extensions, commands};
 use GliumCreationError;
 
+use std::default::Default;
 use std::sync::{Arc, RwLock};
 use std::sync::mpsc::channel;
 
@@ -26,16 +27,8 @@ pub fn new_from_window(window: glutin::WindowBuilder)
 
         let gl = gl::Gl::load_with(|symbol| locked_win.get_proc_address(symbol));
 
-        // building the GLState and modifying to GL state to match it
-        let mut gl_state = {
-            let viewport = {
-                let dim = locked_win.get_inner_size().unwrap();
-                (0, 0, dim.0 as gl::types::GLsizei, dim.1 as gl::types::GLsizei)
-            };
-
-            unsafe { gl.Viewport(viewport.0, viewport.1, viewport.2, viewport.3) };
-            GLState::new_defaults(viewport)
-        };
+        // building the GLState
+        let mut gl_state = Default::default();
 
         // getting the GL version and extensions
         let opengl_es = match locked_win.get_api() { glutin::Api::OpenGlEs => true, _ => false };       // TODO: fix glutin::Api not implementing Eq
@@ -94,7 +87,7 @@ pub fn new_from_window(window: glutin::WindowBuilder)
 
                     let mut window = window.write().unwrap();
                     unsafe { win_tmp.make_current(); };
-                    gl_state = GLState::new_defaults((0, 0, 0, 0));
+                    gl_state = Default::default();
                     *window = win_tmp;
                 },
                 commands::Message::Execute(cmd) => cmd.execute(CommandContext {
@@ -144,7 +137,7 @@ pub fn new_from_headless(window: glutin::HeadlessRendererBuilder)
         // TODO: call glViewport
 
         // building the GLState, version, and extensions
-        let mut gl_state = GLState::new_defaults((0, 0, 0, 0));    // FIXME:
+        let mut gl_state = Default::default();
         let opengl_es = match window.get_api() { glutin::Api::OpenGlEs => true, _ => false };       // TODO: fix glutin::Api not implementing Eq
         let version = version::get_gl_version(&gl);
         let extensions = extensions::get_extensions(&gl);

--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -1,6 +1,8 @@
 use Handle;
 use gl;
 
+use std::default::Default;
+
 /// Represents the current OpenGL state.
 ///
 /// The current state is passed to each function and can be freely updated.
@@ -94,11 +96,13 @@ pub struct GLState {
     /// The latest values passed to `glDepthRange`.
     pub depth_range: (f32, f32),
 
-    /// The latest values passed to `glViewport`.
-    pub viewport: (gl::types::GLint, gl::types::GLint, gl::types::GLsizei, gl::types::GLsizei),
+    /// The latest values passed to `glViewport`. `None` means unknown.
+    pub viewport: Option<(gl::types::GLint, gl::types::GLint,
+                          gl::types::GLsizei, gl::types::GLsizei)>,
 
-    /// The latest values passed to `glScissor`.
-    pub scissor: (gl::types::GLint, gl::types::GLint, gl::types::GLsizei, gl::types::GLsizei),
+    /// The latest values passed to `glScissor`. `None` means unknown.
+    pub scissor: Option<(gl::types::GLint, gl::types::GLint,
+                         gl::types::GLsizei, gl::types::GLsizei)>,
 
     /// The latest value passed to `glLineWidth`.
     pub line_width: gl::types::GLfloat,
@@ -122,11 +126,8 @@ pub struct GLState {
     pub active_texture: gl::types::GLenum,
 }
 
-impl GLState {
-    /// Builds the `GLState` corresponding to the default GL values.
-    pub fn new_defaults(viewport: (gl::types::GLint, gl::types::GLint, gl::types::GLsizei,
-                                   gl::types::GLsizei)) -> GLState
-    {
+impl Default for GLState {
+    fn default() -> GLState {
         GLState {
             enabled_blend: false,
             enabled_cull_face: false,
@@ -158,8 +159,8 @@ impl GLState {
             depth_range: (0.0, 1.0),
             blend_equation: gl::FUNC_ADD,
             blend_func: (gl::ONE, gl::ZERO),
-            viewport: viewport,
-            scissor: viewport,
+            viewport: None,
+            scissor: None,
             line_width: 1.0,
             cull_face: gl::BACK,
             polygon_mode: gl::FILL,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -869,9 +869,9 @@ impl DrawParameters {
                             viewport.width as gl::types::GLsizei,
                             viewport.height as gl::types::GLsizei);
 
-            if ctxt.state.viewport != viewport {
+            if ctxt.state.viewport != Some(viewport) {
                 unsafe { ctxt.gl.Viewport(viewport.0, viewport.1, viewport.2, viewport.3); }
-                ctxt.state.viewport = viewport;
+                ctxt.state.viewport = Some(viewport);
             }
 
         } else {
@@ -883,9 +883,9 @@ impl DrawParameters {
             let viewport = (0, 0, surface_dimensions.0 as gl::types::GLsizei,
                             surface_dimensions.1 as gl::types::GLsizei);
 
-            if ctxt.state.viewport != viewport {
+            if ctxt.state.viewport != Some(viewport) {
                 unsafe { ctxt.gl.Viewport(viewport.0, viewport.1, viewport.2, viewport.3); }
-                ctxt.state.viewport = viewport;
+                ctxt.state.viewport = Some(viewport);
             }
         }
 
@@ -896,9 +896,9 @@ impl DrawParameters {
                            scissor.height as gl::types::GLsizei);
 
             unsafe {
-                if ctxt.state.scissor != scissor {
+                if ctxt.state.scissor != Some(scissor) {
                     ctxt.gl.Scissor(scissor.0, scissor.1, scissor.2, scissor.3);
-                    ctxt.state.scissor = scissor;
+                    ctxt.state.scissor = Some(scissor);
                 }
 
                 if !ctxt.state.enabled_scissor_test {


### PR DESCRIPTION
Instead of reading the size of the window on creation, we just say that we don't know the size.
This means one additional call to `glViewport`, but leads to cleaner code.