### PR TITLE
[Breaking change] Add depth_write and rename DepthFunction to DepthTest

### DIFF
--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -93,6 +93,9 @@ pub struct GLState {
     /// The latest value passed to `glDepthFunc`.
     pub depth_func: gl::types::GLenum,
 
+    /// The latest value passed to `glDepthMask`.
+    pub depth_mask: bool,
+
     /// The latest values passed to `glDepthRange`.
     pub depth_range: (f32, f32),
 
@@ -156,6 +159,7 @@ impl Default for GLState {
             default_framebuffer_read: None,
             renderbuffer: 0,
             depth_func: gl::LESS,
+            depth_mask: true,
             depth_range: (0.0, 1.0),
             blend_equation: gl::FUNC_ADD,
             blend_func: (gl::ONE, gl::ZERO),

--- a/src/draw_parameters.rs
+++ b/src/draw_parameters.rs
@@ -207,12 +207,16 @@ pub enum BackfaceCullingMode {
 /// In addition to the buffer where pixel colors are stored, you can also have a buffer
 /// which contains the depth value of each pixel. Whenever the GPU tries to write a pixel,
 /// it will first compare the depth value of the pixel to be written with the depth value that
-/// is stored at this location.
+/// is stored at this location. If `depth_write` is set to `true` in the draw parameters, it will
+/// then write the depth value in the buffer.
+///
+/// The most common value for depth testing is to set `depth_test` to `IfLess`, and `depth_write`
+/// to `true`.
 ///
 /// If you don't have a depth buffer available, you can only pass `Overwrite`. Glium detects if
 /// you pass any other value and reports an error.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum DepthFunction {
+pub enum DepthTest {
     /// Never replace the target pixel.
     ///
     /// This option doesn't really make sense, but is here for completeness.
@@ -242,33 +246,33 @@ pub enum DepthFunction {
     IfLessOrEqual
 }
 
-impl DepthFunction {
+impl DepthTest {
     /// Returns true if the function requires a depth buffer to be used.
     pub fn requires_depth_buffer(&self) -> bool {
         match *self {
-            DepthFunction::Ignore => true,
-            DepthFunction::Overwrite => false,
-            DepthFunction::IfEqual => true,
-            DepthFunction::IfNotEqual => true,
-            DepthFunction::IfMore => true,
-            DepthFunction::IfMoreOrEqual => true,
-            DepthFunction::IfLess => true,
-            DepthFunction::IfLessOrEqual => true,
+            DepthTest::Ignore => true,
+            DepthTest::Overwrite => false,
+            DepthTest::IfEqual => true,
+            DepthTest::IfNotEqual => true,
+            DepthTest::IfMore => true,
+            DepthTest::IfMoreOrEqual => true,
+            DepthTest::IfLess => true,
+            DepthTest::IfLessOrEqual => true,
         }
     }
 }
 
-impl ToGlEnum for DepthFunction {
+impl ToGlEnum for DepthTest {
     fn to_glenum(&self) -> gl::types::GLenum {
         match *self {
-            DepthFunction::Ignore => gl::NEVER,
-            DepthFunction::Overwrite => gl::ALWAYS,
-            DepthFunction::IfEqual => gl::EQUAL,
-            DepthFunction::IfNotEqual => gl::NOTEQUAL,
-            DepthFunction::IfMore => gl::GREATER,
-            DepthFunction::IfMoreOrEqual => gl::GEQUAL,
-            DepthFunction::IfLess => gl::LESS,
-            DepthFunction::IfLessOrEqual => gl::LEQUAL,
+            DepthTest::Ignore => gl::NEVER,
+            DepthTest::Overwrite => gl::ALWAYS,
+            DepthTest::IfEqual => gl::EQUAL,
+            DepthTest::IfNotEqual => gl::NOTEQUAL,
+            DepthTest::IfMore => gl::GREATER,
+            DepthTest::IfMoreOrEqual => gl::GEQUAL,
+            DepthTest::IfLess => gl::LESS,
+            DepthTest::IfLessOrEqual => gl::LEQUAL,
         }
     }
 }
@@ -324,7 +328,8 @@ impl ToGlEnum for PolygonMode {
 ///
 /// ```
 /// let params = glium::DrawParameters {
-///     depth_function: glium::DepthFunction::IfLess,
+///     depth_test: glium::DepthTest::IfLess,
+///     depth_write: true,
 ///     .. std::default::Default::default()
 /// };
 /// ```
@@ -332,12 +337,21 @@ impl ToGlEnum for PolygonMode {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DrawParameters {
     /// The function that the GPU will use to determine whether to write over an existing pixel
-    /// on the target.
+    /// on the target. Don't forget to set `depth_write` appropriately if you use a depth test.
     ///
-    /// See the `DepthFunction` documentation for more details.
+    /// See the `DepthTest` documentation for more details.
     ///
     /// The default is `Overwrite`.
-    pub depth_function: DepthFunction,
+    pub depth_test: DepthTest,
+    
+    /// Sets whether the GPU will write the depth values on the depth buffer if they pass the
+    /// depth test.
+    ///
+    /// The default is `false`. You most likely want `true` if you're doing depth testing.
+    ///
+    /// If you pass `true` but don't have a depth buffer available, drawing will produce
+    /// a `NoDepthBuffer` error.
+    pub depth_write: bool,
 
     /// The range of possible Z values in surface coordinates.
     ///
@@ -410,7 +424,8 @@ pub struct DrawParameters {
 impl Default for DrawParameters {
     fn default() -> DrawParameters {
         DrawParameters {
-            depth_function: DepthFunction::Overwrite,
+            depth_test: DepthTest::Overwrite,
+            depth_write: false,
             depth_range: (0.0, 1.0),
             blending_function: Some(BlendingFunction::AlwaysReplace),
             line_width: None,
@@ -440,8 +455,8 @@ pub fn sync(params: &DrawParameters, ctxt: &mut context::CommandContext,
             surface_dimensions: (u32, u32))
 {
     // depth function
-    match params.depth_function {
-        DepthFunction::Overwrite => unsafe {
+    match params.depth_test {
+        DepthTest::Overwrite => unsafe {
             if ctxt.state.enabled_depth_test {
                 ctxt.gl.Disable(gl::DEPTH_TEST);
                 ctxt.state.enabled_depth_test = false;
@@ -458,6 +473,14 @@ pub fn sync(params: &DrawParameters, ctxt: &mut context::CommandContext,
                 ctxt.state.enabled_depth_test = true;
             }
         }
+    }
+
+    // depth mask
+    if params.depth_write != ctxt.state.depth_mask {
+        unsafe {
+            ctxt.gl.DepthMask(if params.depth_write { gl::TRUE } else { gl::FALSE });
+        }
+        ctxt.state.depth_mask = params.depth_write;
     }
 
     // depth range

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -206,7 +206,9 @@ impl<'a> Surface for SimpleFrameBuffer<'a> {
     {
         use index::ToIndicesSource;
 
-        if draw_parameters.depth_function.requires_depth_buffer() && !self.has_depth_buffer() {
+        if !self.has_depth_buffer() && (draw_parameters.depth_test.requires_depth_buffer() ||
+                        draw_parameters.depth_write)
+        {
             return Err(DrawError::NoDepthBuffer);
         }
 
@@ -403,7 +405,9 @@ impl<'a> Surface for MultiOutputFrameBuffer<'a> {
     {
         use index::ToIndicesSource;
 
-        if draw_parameters.depth_function.requires_depth_buffer() && !self.has_depth_buffer() {
+        if !self.has_depth_buffer() && (draw_parameters.depth_test.requires_depth_buffer() ||
+                draw_parameters.depth_write)
+        {
             return Err(DrawError::NoDepthBuffer);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ extern crate nalgebra;
 
 pub use context::{PollEventsIter, WaitEventsIter};
 pub use draw_parameters::{BlendingFunction, LinearBlendingFactor, BackfaceCullingMode};
-pub use draw_parameters::{DepthFunction, PolygonMode, DrawParameters};
+pub use draw_parameters::{DepthTest, PolygonMode, DrawParameters};
 pub use index::IndexBuffer;
 pub use vertex::{VertexBuffer, Vertex, VertexFormat};
 pub use program::{Program, ProgramCreationError};
@@ -422,14 +422,16 @@ pub struct BlitTarget {
 /// depth value.
 ///
 /// If a depth buffer is present, the GPU will compare the depth value of the pixel currently
-/// being processed, with the existing depth value. Depending on the value of `depth_function`
+/// being processed, with the existing depth value. Depending on the value of `depth_test`
 /// in the draw parameters, the depth test will either pass, in which case the pipeline
-/// continues, or fail, in which case the pixel is discarded.
+/// continues, or fail, in which case the pixel is discarded. If the value of `depth_write`
+/// is true and the test passed, it will then also write the depth value of the pixel on the
+/// depth buffer.
 ///
 /// The purpose of this test is to avoid drawing elements that are in the background of the
 /// scene over elements that are in the foreground.
 ///
-/// See the documentation of `DepthFunction` for more informations.
+/// See the documentation of `DepthTest` for more informations.
 ///
 /// ## Step 15: Blending
 ///
@@ -741,7 +743,9 @@ impl Surface for Frame {
     {
         use index::ToIndicesSource;
 
-        if draw_parameters.depth_function.requires_depth_buffer() && !self.has_depth_buffer() {
+        if !self.has_depth_buffer() && (draw_parameters.depth_test.requires_depth_buffer() ||
+                draw_parameters.depth_write)
+        {
             return Err(DrawError::NoDepthBuffer);
         }
 

--- a/tests/framebuffer.rs
+++ b/tests/framebuffer.rs
@@ -10,7 +10,7 @@ use glium::Surface;
 mod support;
 
 #[test]
-fn no_depth_buffer() {
+fn no_depth_buffer_depth_test() {
     let display = support::build_display();
     let (vertex_buffer, index_buffer, program) = support::build_fullscreen_red_pipeline(&display);
 
@@ -19,7 +19,31 @@ fn no_depth_buffer() {
     let mut framebuffer = glium::framebuffer::SimpleFrameBuffer::new(&display, &texture);
 
     let parameters = glium::DrawParameters {
-        depth_function: glium::DepthFunction::IfLess,
+        depth_test: glium::DepthTest::IfLess,
+        .. std::default::Default::default()
+    };
+
+    match framebuffer.draw(&vertex_buffer, &index_buffer, &program,
+                           &glium::uniforms::EmptyUniforms, &parameters)
+    {
+        Err(glium::DrawError::NoDepthBuffer) => (),
+        a => panic!("{:?}", a)
+    };
+
+    display.assert_no_error();
+}
+
+#[test]
+fn no_depth_buffer_depth_write() {
+    let display = support::build_display();
+    let (vertex_buffer, index_buffer, program) = support::build_fullscreen_red_pipeline(&display);
+
+    let texture = glium::texture::Texture2d::new_empty(&display,
+                            glium::texture::UncompressedFloatFormat::U8U8U8U8, 128, 128);
+    let mut framebuffer = glium::framebuffer::SimpleFrameBuffer::new(&display, &texture);
+
+    let parameters = glium::DrawParameters {
+        depth_write: true,
         .. std::default::Default::default()
     };
 
@@ -114,7 +138,7 @@ fn depth_texture2d() {
     let mut framebuffer = glium::framebuffer::SimpleFrameBuffer::with_depth_buffer(&display,
                                                                                    &color, &depth);
     let params = glium::DrawParameters {
-        depth_function: glium::DepthFunction::IfLess,
+        depth_test: glium::DepthTest::IfLess,
         .. std::default::Default::default()
     };
 


### PR DESCRIPTION
- Renames `DepthFunction` to `DepthTest`
- Renames `depth_function` to `depth_test`
- Adds `depth_write`

Before this change, when a depth test passed the depth value of the pixel was always written on the depth buffer. This change adds a `depth_write` member to `DrawParameters` that allows you to set whether or not you want this.
**Its default value is `false`**. If you were using depth tests, you most likely should set `depth_write` to `true` in the parameters. See #433 for more details.

Close #433 