### PR TITLE
External library integration features - expose GlObject and allow in-context execution

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,8 +224,8 @@ mod gl {
     include!(concat!(env!("OUT_DIR"), "/gl_bindings.rs"));
 }
 
-/// Internal trait for objects that are OpenGL objects.
-trait GlObject {
+/// Trait for objects that are OpenGL objects.
+pub trait GlObject {
     type Id;
 
     /// Returns the id of the object.


### PR DESCRIPTION
We've been working on exposing the Oculus SDK via FFI to Rust. There's a bit of a handshake with the SDK that isn't possible with the current glium API. Feedback is of course totally welcome on the shape of this; in the end, I'm trying to accomplish two things:

* Expose the OpenGL id of the textures that serve as color attachments for framebuffers. In the case of the Oculus SDK, it's required to do all rendering to a pair of frame-buffers (one per eye), then hand these to the SDK via these ids for further post-processing prior to pushing them out to the display.
* Allow the SDK to run arbitrary code with the glium OpenGL context active. There's quite a bit of OpenGL context manipulation done by the C API itself. Though the SDK does create its own OpenGL context for some of the work it does, there is pre- and postamble work done on your behalf per frame, and init code that also has to use your OpenGL context.

   I know there are already some open issues discussing the longer-term implications of the threading model used by glium currently. This seemed like the most durable approach even if a change is made in the threading/context model.
