### PR TITLE
Add an implement_vertex! macro to replace #[vertex_format]

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -35,38 +35,54 @@ macro_rules! uniform {
     };
 }
 
-/*
-// TODO: doesn't work
+/// Implements the `glium::vertex::Vertex` trait for the given type.
+///
+/// The parameters must be the name of the struct and the names of its fields.
+///
+/// ## Example
+///
+/// ```ignore   // TODO: error "expected function, found `(String, usize, AttributeType)`"
+/// # #[macro_use]
+/// # extern crate glium;
+/// # fn main() {
+/// #[derive(Copy)]
+/// struct Vertex {
+///     position: [f32; 3],
+///     tex_coords: [f32; 2],
+/// }
+///
+/// implement_vertex!(Vertex, position, tex_coords);
+/// # }
+/// ```
+///
 #[macro_export]
-macro_rules! attributes {
-    ($(#[$attr:meta])* struct $struct_name:ident {
-        $($(#[$field_attr:meta])* $field:ident: $t:ty),*
-    }) => {
-        #[derive(Copy)]
-        $(#[$attr])*
-        pub struct $struct_name {
-            $(
-                $($field_attr)* pub $field: $t
-            ),+
-        }
-
+macro_rules! implement_vertex {
+    ($struct_name:ident, $($field_name:ident),+) => (
         impl $crate::vertex::Vertex for $struct_name {
             fn build_bindings() -> $crate::vertex::VertexFormat {
                 vec![
                     $(
                         (
-                            stringify!($field),
+                            stringify!($field_name).to_string(),
                             {
-                                let dummy: &$struct_name = unsafe { ::std::mem::transmute(0u) };
-                                let dummy_field = &dummy.$field;
+                                let dummy: &$struct_name = unsafe { ::std::mem::transmute(0usize) };
+                                let dummy_field = &dummy.$field_name;
                                 let dummy_field: usize = unsafe { ::std::mem::transmute(dummy_field) };
                                 dummy_field
                             },
-                            $crate::vertex::Attribute::get_type(None::<$t>)
+                            {
+                                fn attr_type_of_val<T: $crate::vertex::Attribute>(_: &T)
+                                    -> $crate::vertex::AttributeType
+                                {
+                                    <T as $crate::vertex::Attribute>::get_type()
+                                }
+                                let dummy: &$struct_name = unsafe { ::std::mem::transmute(0usize) };
+                                attr_type_of_val(&dummy.$field_name)
+                            },
                         )
                     )+
                 ]
             }
         }
-    }
-}*/
+    )
+}

--- a/tests/attrs.rs
+++ b/tests/attrs.rs
@@ -1,9 +1,6 @@
-#![feature(plugin)]
-#![feature(unboxed_closures)]
-#![plugin(glium_macros)]
-
-extern crate glutin;
+#[macro_use]
 extern crate glium;
+extern crate glutin;
 
 use glium::Surface;
 
@@ -14,11 +11,12 @@ mod support;
 fn attribute_types_mismatch() {
     let display = support::build_display();
 
-    #[vertex_format]
     #[derive(Copy)]
     struct Vertex {
         field1: [f32; 4],
     }
+
+    implement_vertex!(Vertex, field1);
 
     let vertex_buffer = glium::VertexBuffer::new(&display, Vec::<Vertex>::new());
     let index_buffer = glium::IndexBuffer::new(&display,
@@ -60,11 +58,12 @@ fn attribute_types_mismatch() {
 fn missing_attribute() {
     let display = support::build_display();
 
-    #[vertex_format]
     #[derive(Copy)]
     struct Vertex {
         field1: [f32; 4],
     }
+
+    implement_vertex!(Vertex, field1);
 
     let vertex_buffer = glium::VertexBuffer::new(&display, Vec::<Vertex>::new());
     let index_buffer = glium::IndexBuffer::new(&display,
@@ -107,11 +106,12 @@ macro_rules! attribute_test(
         fn $name() {
             let display = support::build_display();
 
-            #[vertex_format]
             #[derive(Copy)]
             struct Vertex {
                 field1: $attr_ty,
             }
+
+            implement_vertex!(Vertex, field1);
 
             let vertex_buffer = glium::VertexBuffer::new(&display, vec![
                     Vertex { field1: $value }

--- a/tests/backface-culling.rs
+++ b/tests/backface-culling.rs
@@ -3,6 +3,7 @@
 #![plugin(glium_macros)]
 
 extern crate glutin;
+#[macro_use]
 extern crate glium;
 
 use glium::Surface;

--- a/tests/blit.rs
+++ b/tests/blit.rs
@@ -3,6 +3,7 @@
 #![plugin(glium_macros)]
 
 extern crate glutin;
+#[macro_use]
 extern crate glium;
 
 use glium::{Surface, BlitTarget, Rect};

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -3,6 +3,7 @@
 #![plugin(glium_macros)]
 
 extern crate glutin;
+#[macro_use]
 extern crate glium;
 
 use glium::Surface;

--- a/tests/framebuffer.rs
+++ b/tests/framebuffer.rs
@@ -3,6 +3,7 @@
 #![plugin(glium_macros)]
 
 extern crate glutin;
+#[macro_use]
 extern crate glium;
 
 use glium::Surface;

--- a/tests/indices.rs
+++ b/tests/indices.rs
@@ -3,6 +3,7 @@
 #![plugin(glium_macros)]
 
 extern crate glutin;
+#[macro_use]
 extern crate glium;
 
 use std::default::Default;

--- a/tests/samplers.rs
+++ b/tests/samplers.rs
@@ -3,6 +3,7 @@
 #![plugin(glium_macros)]
 
 extern crate glutin;
+#[macro_use]
 extern crate glium;
 
 use std::default::Default;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -50,11 +50,12 @@ pub fn build_unicolor_texture2d(display: &glium::Display, red: f32, green: f32, 
 pub fn build_fullscreen_red_pipeline(display: &glium::Display) -> (glium::vertex::VertexBufferAny,
     glium::IndexBuffer, glium::Program)
 {
-    #[vertex_format]
     #[derive(Copy)]
     struct Vertex {
         position: [f32; 2],
     }
+
+    implement_vertex!(Vertex, position);
 
     (
         glium::VertexBuffer::new(display, vec![
@@ -91,11 +92,12 @@ pub fn build_fullscreen_red_pipeline(display: &glium::Display) -> (glium::vertex
 pub fn build_rectangle_vb_ib(display: &glium::Display)
     -> (glium::vertex::VertexBufferAny, glium::IndexBuffer)
 {
-    #[vertex_format]
     #[derive(Copy)]
     struct Vertex {
         position: [f32; 2],
     }
+
+    implement_vertex!(Vertex, position);
 
     (
         glium::VertexBuffer::new(display, vec![

--- a/tests/texture_creation.rs
+++ b/tests/texture_creation.rs
@@ -3,6 +3,7 @@
 #![plugin(glium_macros)]
 
 extern crate glutin;
+#[macro_use]
 extern crate glium;
 
 use glium::{Texture, Surface};

--- a/tests/texture_read.rs
+++ b/tests/texture_read.rs
@@ -3,6 +3,7 @@
 #![plugin(glium_macros)]
 
 extern crate glutin;
+#[macro_use]
 extern crate glium;
 
 use glium::{Texture, Surface};

--- a/tests/texture_write.rs
+++ b/tests/texture_write.rs
@@ -3,6 +3,7 @@
 #![plugin(glium_macros)]
 
 extern crate glutin;
+#[macro_use]
 extern crate glium;
 
 use glium::{Texture, Surface};

--- a/tests/uniforms.rs
+++ b/tests/uniforms.rs
@@ -3,6 +3,7 @@
 #![plugin(glium_macros)]
 
 extern crate glutin;
+#[macro_use]
 extern crate glium;
 
 use std::default::Default;


### PR DESCRIPTION
Example:

```rust
struct Vertex {
    position: [f32; 3],
    tex_coords: [f32; 2],
}

implement_vertex!(Vertex, position, tex_coords);
```

Close #233

