### PR TITLE
Add a nicer API for samplers

### DIFF
--- a/src/uniforms/mod.rs
+++ b/src/uniforms/mod.rs
@@ -62,10 +62,8 @@ use std::default::Default;
 # let display: glium::Display = unsafe { std::mem::uninitialized() };
 # let texture: glium::texture::Texture2d = unsafe { std::mem::uninitialized() };
 let uniforms = uniform! {
-    texture: glium::uniforms::Sampler(&texture, glium::uniforms::SamplerBehavior {
-        magnify_filter: glium::uniforms::MagnifySamplerFilter::Nearest,
-        .. Default::default()
-    })
+    texture: glium::uniforms::Sampler::new(&texture)
+                        .magnify_filter(glium::uniforms::MagnifySamplerFilter::Nearest)
 };
 # }
 ```

--- a/src/uniforms/sampler.rs
+++ b/src/uniforms/sampler.rs
@@ -88,6 +88,37 @@ impl ToGlEnum for MinifySamplerFilter {
 /// A sampler.
 pub struct Sampler<'t, T: 't>(pub &'t T, pub SamplerBehavior);
 
+impl<'t, T: 't> Sampler<'t, T> {
+    /// Builds a new `Sampler` with default parameters.
+    pub fn new(texture: &'t T) -> Sampler<'t, T> {
+        Sampler(texture, Default::default())
+    }
+
+    /// Changes the wrap functions of all three coordinates.
+    pub fn wrap_function(mut self, function: SamplerWrapFunction) -> Sampler<'t, T> {
+        self.1.wrap_function = (function, function, function);
+        self
+    }
+
+    /// Changes the minifying filter of the sampler.
+    pub fn minify_filter(mut self, filter: MinifySamplerFilter) -> Sampler<'t, T> {
+        self.1.minify_filter = filter;
+        self
+    }
+
+    /// Changes the magnifying filter of the sampler.
+    pub fn magnify_filter(mut self, filter: MagnifySamplerFilter) -> Sampler<'t, T> {
+        self.1.magnify_filter = filter;
+        self
+    }
+
+    /// Changes the magnifying filter of the sampler.
+    pub fn anisotropy(mut self, level: u16) -> Sampler<'t, T> {
+        self.1.max_anisotropy = level;
+        self
+    }
+}
+
 /// Behavior of a sampler.
 // TODO: GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS,
 //       GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC
@@ -95,10 +126,13 @@ pub struct Sampler<'t, T: 't>(pub &'t T, pub SamplerBehavior);
 pub struct SamplerBehavior {
     /// Functions to use for the X, Y, and Z coordinates.
     pub wrap_function: (SamplerWrapFunction, SamplerWrapFunction, SamplerWrapFunction),
+
     /// Filter to use when minifying the texture.
     pub minify_filter: MinifySamplerFilter,
+
     /// Filter to use when magnifying the texture.
     pub magnify_filter: MagnifySamplerFilter,
+
     /// `1` means no anisotropic filtering, any value above `1` sets the max anisotropy.
     ///
     /// ## Compatibility

--- a/tests/samplers.rs
+++ b/tests/samplers.rs
@@ -42,11 +42,10 @@ fn magnify_nearest_filtering() {
     let texture_data = vec![vec![(0u8, 0, 0), (255, 255, 255)]];
     let texture = glium::texture::Texture2d::new(&display, texture_data);
 
-    let uniforms = glium::uniforms::UniformsStorage::new("texture",
-        glium::uniforms::Sampler(&texture, glium::uniforms::SamplerBehavior {
-            magnify_filter: glium::uniforms::MagnifySamplerFilter::Nearest,
-            .. Default::default()
-        }));
+    let uniforms = uniform! {
+        texture: glium::uniforms::Sampler::new(&texture)
+                        .magnify_filter(glium::uniforms::MagnifySamplerFilter::Nearest)
+    };
 
     let output = support::build_renderable_texture(&display);
     output.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);


### PR DESCRIPTION
Instead of:

```rust
let uniforms = uniform! {
    texture: Sampler(&texture, SamplerBehavior { magnify_filter: Nearest, .. Default::default() })
};
```

You can now write:

```rust
let uniforms = uniform! {
    texture: Sampler::new(&texture).magnify_filter(Nearest)
};
```
