### PR TITLE
Remove opengl_es member from the context

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -521,16 +521,11 @@ impl Buffer {
         let (tx, rx) = channel();
 
         self.display.context.context.exec(move |ctxt| {
-            if ctxt.opengl_es {
-                tx.send(None).ok();
-                return;
-            }
-
             unsafe {
                 let mut data = Vec::with_capacity(size);
                 data.set_len(size);
 
-                if !ctxt.opengl_es && ctxt.version >= &GlVersion(Api::Gl, 4, 5) {
+                if ctxt.version >= &GlVersion(Api::Gl, 4, 5) {
                     ctxt.gl.GetNamedBufferSubData(id, (offset * elements_size) as gl::types::GLintptr,
                         (size * elements_size) as gl::types::GLsizei,
                         data.as_mut_ptr() as *mut libc::c_void);

--- a/src/context/capabilities.rs
+++ b/src/context/capabilities.rs
@@ -34,19 +34,19 @@ pub struct Capabilities {
 }
 
 /// Loads the capabilities.
-pub fn get_capabilities(gl: &gl::Gl, version: &GlVersion, extensions: &ExtensionsList,
-                        gl_es: bool) -> Capabilities
+pub fn get_capabilities(gl: &gl::Gl, version: &GlVersion, extensions: &ExtensionsList)
+                        -> Capabilities
 {
     use std::mem;
 
     Capabilities {
         stereo: unsafe {
-            if gl_es {
-                false
-            } else {
+            if version >= &GlVersion(Api::Gl, 1, 0) {
                 let mut val: gl::types::GLboolean = mem::uninitialized();
                 gl.GetBooleanv(gl::STEREO, &mut val);
                 val != 0
+            } else {
+                false
             }
         },
 

--- a/src/context/glutin_context.rs
+++ b/src/context/glutin_context.rs
@@ -31,11 +31,9 @@ pub fn new_from_window(window: glutin::WindowBuilder)
         let mut gl_state = Default::default();
 
         // getting the GL version and extensions
-        let opengl_es = match locked_win.get_api() { glutin::Api::OpenGlEs => true, _ => false };       // TODO: fix glutin::Api not implementing Eq
         let version = version::get_gl_version(&gl);
         let extensions = extensions::get_extensions(&gl);
-        let capabilities = Arc::new(capabilities::get_capabilities(&gl, &version,
-                                                                   &extensions, opengl_es));
+        let capabilities = Arc::new(capabilities::get_capabilities(&gl, &version, &extensions));
 
         drop(locked_win);
 
@@ -45,7 +43,6 @@ pub fn new_from_window(window: glutin::WindowBuilder)
             state: &mut gl_state,
             version: &version,
             extensions: &extensions,
-            opengl_es: opengl_es,
             capabilities: &*capabilities,
         }) {
             Err(e) => {
@@ -95,7 +92,6 @@ pub fn new_from_window(window: glutin::WindowBuilder)
                     state: &mut gl_state,
                     version: &version,
                     extensions: &extensions,
-                    opengl_es: opengl_es,
                     capabilities: &*capabilities,
                 }),
                 commands::Message::Stop => break
@@ -138,11 +134,9 @@ pub fn new_from_headless(window: glutin::HeadlessRendererBuilder)
 
         // building the GLState, version, and extensions
         let mut gl_state = Default::default();
-        let opengl_es = match window.get_api() { glutin::Api::OpenGlEs => true, _ => false };       // TODO: fix glutin::Api not implementing Eq
         let version = version::get_gl_version(&gl);
         let extensions = extensions::get_extensions(&gl);
-        let capabilities = Arc::new(capabilities::get_capabilities(&gl, &version,
-                                                                   &extensions, opengl_es));
+        let capabilities = Arc::new(capabilities::get_capabilities(&gl, &version, &extensions));
 
         // checking compatibility with glium
         match check_gl_compatibility(CommandContext {
@@ -150,7 +144,6 @@ pub fn new_from_headless(window: glutin::HeadlessRendererBuilder)
             state: &mut gl_state,
             version: &version,
             extensions: &extensions,
-            opengl_es: opengl_es,
             capabilities: &*capabilities,
         }) {
             Err(e) => {
@@ -170,7 +163,6 @@ pub fn new_from_headless(window: glutin::HeadlessRendererBuilder)
                     state: &mut gl_state,
                     version: &version,
                     extensions: &extensions,
-                    opengl_es: opengl_es,
                     capabilities: &*capabilities,
                 }),
                 commands::Message::EndFrame => (),        // ignoring buffer swapping

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -36,7 +36,6 @@ pub struct CommandContext<'a, 'b> {
     pub state: &'b mut GLState,
     pub version: &'a GlVersion,
     pub extensions: &'a ExtensionsList,
-    pub opengl_es: bool,
     pub capabilities: &'a Capabilities,
 }
 
@@ -152,95 +151,85 @@ impl Context {
 fn check_gl_compatibility(ctxt: CommandContext) -> Result<(), GliumCreationError> {
     let mut result = Vec::new();
 
-    if ctxt.opengl_es {
-        if ctxt.version < &GlVersion(Api::Gl, 3, 0) {
-            result.push("OpenGL ES version inferior to 3.0");
-        }
-
-        if cfg!(feature = "gl_read_buffer") {
-            result.push("OpenGL ES doesn't support gl_read_buffer");
-        }
-
-    } else {
-        if ctxt.version < &GlVersion(Api::Gl, 1, 5) && (!ctxt.extensions.gl_arb_vertex_buffer_object ||
+    if !(ctxt.version >= &GlVersion(Api::Gl, 1, 5)) &&
+        (!ctxt.extensions.gl_arb_vertex_buffer_object ||
             !ctxt.extensions.gl_arb_map_buffer_range)
-        {
-            result.push("OpenGL implementation doesn't support buffer objects");
-        }
+    {
+        result.push("OpenGL implementation doesn't support buffer objects");
+    }
 
-        if ctxt.version < &GlVersion(Api::Gl, 2, 0) && (!ctxt.extensions.gl_arb_shader_objects ||
-            !ctxt.extensions.gl_arb_vertex_shader || !ctxt.extensions.gl_arb_fragment_shader)
-        {
-            result.push("OpenGL implementation doesn't support vertex/fragment shaders");
-        }
+    if !(ctxt.version >= &GlVersion(Api::Gl, 2, 0)) && (!ctxt.extensions.gl_arb_shader_objects ||
+        !ctxt.extensions.gl_arb_vertex_shader || !ctxt.extensions.gl_arb_fragment_shader)
+    {
+        result.push("OpenGL implementation doesn't support vertex/fragment shaders");
+    }
 
-        if !ctxt.extensions.gl_ext_framebuffer_object && ctxt.version < &GlVersion(Api::Gl, 3, 0) {
-            result.push("OpenGL implementation doesn't support framebuffers");
-        }
+    if !ctxt.extensions.gl_ext_framebuffer_object && ctxt.version < &GlVersion(Api::Gl, 3, 0) {
+        result.push("OpenGL implementation doesn't support framebuffers");
+    }
 
-        if !ctxt.extensions.gl_ext_framebuffer_blit && ctxt.version < &GlVersion(Api::Gl, 3, 0) {
-            result.push("OpenGL implementation doesn't support blitting framebuffers");
-        }
+    if !ctxt.extensions.gl_ext_framebuffer_blit && ctxt.version < &GlVersion(Api::Gl, 3, 0) {
+        result.push("OpenGL implementation doesn't support blitting framebuffers");
+    }
 
-        if !ctxt.extensions.gl_arb_vertex_array_object &&
-            !ctxt.extensions.gl_apple_vertex_array_object &&
-            ctxt.version < &GlVersion(Api::Gl, 3, 0)
-        {
-            result.push("OpenGL implementation doesn't support vertex array objects");
-        }
+    if !ctxt.extensions.gl_arb_vertex_array_object &&
+        !ctxt.extensions.gl_apple_vertex_array_object &&
+        !(ctxt.version >= &GlVersion(Api::Gl, 3, 0))
+    {
+        result.push("OpenGL implementation doesn't support vertex array objects");
+    }
 
-        if cfg!(feature = "gl_uniform_blocks") && ctxt.version < &GlVersion(Api::Gl, 3, 1) &&
-            !ctxt.extensions.gl_arb_uniform_buffer_object
-        {
-            result.push("OpenGL implementation doesn't support uniform blocks");
-        }
+    if cfg!(feature = "gl_uniform_blocks") && ctxt.version < &GlVersion(Api::Gl, 3, 1) &&
+        !ctxt.extensions.gl_arb_uniform_buffer_object
+    {
+        result.push("OpenGL implementation doesn't support uniform blocks");
+    }
 
-        if cfg!(feature = "gl_sync") && ctxt.version < &GlVersion(Api::Gl, 3, 2) &&
-            !ctxt.extensions.gl_arb_sync
-        {
-            result.push("OpenGL implementation doesn't support synchronization objects");
-        }
+    if cfg!(feature = "gl_sync") && ctxt.version < &GlVersion(Api::Gl, 3, 2) &&
+        !ctxt.extensions.gl_arb_sync
+    {
+        result.push("OpenGL implementation doesn't support synchronization objects");
+    }
 
-        if cfg!(feature = "gl_persistent_mapping") && ctxt.version < &GlVersion(Api::Gl, 4, 4) &&
-            !ctxt.extensions.gl_arb_buffer_storage
-        {
-            result.push("OpenGL implementation doesn't support persistent mapping");
-        }
+    if cfg!(feature = "gl_persistent_mapping") && ctxt.version < &GlVersion(Api::Gl, 4, 4) &&
+        !ctxt.extensions.gl_arb_buffer_storage
+    {
+        result.push("OpenGL implementation doesn't support persistent mapping");
+    }
 
-        if cfg!(feature = "gl_program_binary") && ctxt.version < &GlVersion(Api::Gl, 4, 1) &&
-            !ctxt.extensions.gl_arb_get_programy_binary
-        {
-            result.push("OpenGL implementation doesn't support program binary");
-        }
+    if cfg!(feature = "gl_program_binary") && ctxt.version < &GlVersion(Api::Gl, 4, 1) &&
+        !ctxt.extensions.gl_arb_get_programy_binary
+    {
+        result.push("OpenGL implementation doesn't support program binary");
+    }
 
-        if cfg!(feature = "gl_tessellation") && ctxt.version < &GlVersion(Api::Gl, 4, 0) &&
-            !ctxt.extensions.gl_arb_tessellation_shader
-        {
-            result.push("OpenGL implementation doesn't support tessellation");
-        }
+    if cfg!(feature = "gl_tessellation") && ctxt.version < &GlVersion(Api::Gl, 4, 0) &&
+        !ctxt.extensions.gl_arb_tessellation_shader
+    {
+        result.push("OpenGL implementation doesn't support tessellation");
+    }
 
-        if cfg!(feature = "gl_instancing") && ctxt.version < &GlVersion(Api::Gl, 3, 3) &&
-            !ctxt.extensions.gl_arb_instanced_arrays
-        {
-            result.push("OpenGL implementation doesn't support instancing");
-        }
+    if cfg!(feature = "gl_instancing") && ctxt.version < &GlVersion(Api::Gl, 3, 3) &&
+        !ctxt.extensions.gl_arb_instanced_arrays
+    {
+        result.push("OpenGL implementation doesn't support instancing");
+    }
 
-        if cfg!(feature = "gl_integral_textures") && ctxt.version < &GlVersion(Api::Gl, 3, 0) &&
-            !ctxt.extensions.gl_ext_texture_integer
-        {
-            result.push("OpenGL implementation doesn't support integral textures");
-        }
+    if cfg!(feature = "gl_integral_textures") && ctxt.version < &GlVersion(Api::Gl, 3, 0) &&
+        !ctxt.extensions.gl_ext_texture_integer
+    {
+        result.push("OpenGL implementation doesn't support integral textures");
+    }
 
-        if cfg!(feature = "gl_depth_textures") && ctxt.version < &GlVersion(Api::Gl, 3, 0) &&
-            (!ctxt.extensions.gl_arb_depth_texture || !ctxt.extensions.gl_ext_packed_depth_stencil)
-        {
-            result.push("OpenGL implementation doesn't support depth or depth-stencil textures");
-        }
+    if cfg!(feature = "gl_depth_textures") && ctxt.version < &GlVersion(Api::Gl, 3, 0) &&
+        (!ctxt.extensions.gl_arb_depth_texture || !ctxt.extensions.gl_ext_packed_depth_stencil)
+    {
+        result.push("OpenGL implementation doesn't support depth or depth-stencil textures");
+    }
 
-        if cfg!(feature = "gl_stencil_textures") && ctxt.version < &GlVersion(Api::Gl, 3, 0)
-        {
-            result.push("OpenGL implementation doesn't support stencil textures");
-        }
+    if cfg!(feature = "gl_stencil_textures") && ctxt.version < &GlVersion(Api::Gl, 3, 0)
+    {
+        result.push("OpenGL implementation doesn't support stencil textures");
     }
 
     if result.len() == 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -989,7 +989,9 @@ impl Display {
     pub fn release_shader_compiler(&self) {
         self.context.context.exec(move |ctxt| {
             unsafe {
-                if ctxt.opengl_es || ctxt.version >= &context::GlVersion(Api::Gl, 4, 1) {
+                if ctxt.version >= &context::GlVersion(Api::GlEs, 2, 0) ||
+                    ctxt.version >= &context::GlVersion(Api::Gl, 4, 1)
+                {
                     ctxt.gl.ReleaseShaderCompiler();
                 }
             }


### PR DESCRIPTION
Removes this obsolete member now that the GlVersion contains the Api.

Will need to be rebased over #576 

cc #574
