### PR TITLE
Fix build error: Catch up gl_generator API changes

### DIFF
--- a/build/main.rs
+++ b/build/main.rs
@@ -25,6 +25,7 @@ fn generate_gl_bindings<W>(dest: &mut W) where W: Writer {
 
         let filter = gl_generator::registry::Filter {
             api: gl_generator::registry::Ns::Gl.to_string(),
+            fallbacks: gl_generator::registry::Fallbacks::All,
             extensions: vec![
                 "GL_EXT_direct_state_access".to_string(),
                 "GL_ARB_direct_state_access".to_string(),
@@ -65,6 +66,7 @@ fn generate_gl_bindings<W>(dest: &mut W) where W: Writer {
 
         let filter = gl_generator::registry::Filter {
             api: gl_generator::registry::Ns::Gles2.to_string(),
+            fallbacks: gl_generator::registry::Fallbacks::All,
             extensions: vec![
                 "GL_OES_texture_npot".to_string(),
                 "GL_EXT_disjoint_timer_query".to_string(),

--- a/build/main.rs
+++ b/build/main.rs
@@ -1,3 +1,5 @@
+#![feature(env, old_io, old_path)]
+
 extern crate gl_generator;
 extern crate khronos_api;
 


### PR DESCRIPTION
It was always `Fallback::All` before, but now you can choose one of `All` and `None`.

Reference: https://github.com/bjz/gl-rs/commit/368255d830ca991b029a3b324650aaff2d2560cf