### PR TITLE
Improve the implementation of UniformsStorage

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -26,9 +26,9 @@ macro_rules! uniform {
 
     ($field1:ident: $value1:expr, $($field:ident: $value:expr),+) => {
         {
-            let mut uniforms = $crate::uniforms::UniformsStorage::new(stringify!($field1), $value1);
+            let uniforms = $crate::uniforms::UniformsStorage::new(stringify!($field1), $value1);
             $(
-                uniforms = uniforms.add(stringify!($field), $value);
+                let uniforms = uniforms.add(stringify!($field), $value);
             )+
             uniforms
         }

--- a/src/uniforms/uniforms.rs
+++ b/src/uniforms/uniforms.rs
@@ -1,3 +1,7 @@
+use std::option::IntoIter;
+use std::iter::Chain;
+use std::cell::RefCell;
+
 use uniforms::{Uniforms, UniformValue, IntoUniformValue};
 
 /// Object that can be used when you don't have any uniforms.
@@ -26,35 +30,48 @@ impl Uniforms for EmptyUniforms {
 /// # let texture: glium::Texture2d = unsafe { ::std::mem::uninitialized() };
 /// let uniforms = uniforms.add("name3", &texture);
 ///
-/// // the final type is `UniformsStorage<&Texture2d, UniformsStorage<f32, UniformsStorage<f32, EmptyUniforms>>>`,
-/// // but you shouldn't care about it
+/// // the final type is very complex, but you don't care about it
 /// ```
 ///
-pub struct UniformsStorage<'a> {
-    uniforms: Vec<(&'a str, UniformValue<'a>)>,
+pub struct UniformsStorage<I> {
+    // FIXME: this RefCell<Option<>> hack is here because the `Uniforms` trait is implemented
+    //        only on &UniformsStorage
+    iterator: RefCell<Option<I>>,
 }
 
-impl<'a> UniformsStorage<'a> {
+impl<'n, 'u> UniformsStorage<IntoIter<(&'n str, UniformValue<'u>)>> {
     /// Builds a new storage with a value.
-    pub fn new<T>(name: &'a str, value: T) -> UniformsStorage<'a> where T: IntoUniformValue<'a> {
+    pub fn new<T>(name: &'n str, value: T)
+                  -> UniformsStorage<IntoIter<(&'n str, UniformValue<'u>)>>
+                  where T: IntoUniformValue<'u>
+    {
         UniformsStorage {
-            uniforms: vec![(name, value.into_uniform_value())]
+            iterator: RefCell::new(Some(Some((name, value.into_uniform_value())).into_iter())),
         }
     }
+}
 
+impl<'n, 'u, I> UniformsStorage<I> where I: Iterator<Item = (&'n str, UniformValue<'u>)> {
     /// Adds a value to the storage.
-    pub fn add<T>(mut self, name: &'a str, value: T) -> UniformsStorage<'a>
-                  where T: IntoUniformValue<'a>
+    pub fn add<T>(self, name: &'n str, value: T)
+                  -> UniformsStorage<Chain<I, IntoIter<(&'n str, UniformValue<'u>)>>>
+                  where T: IntoUniformValue<'u>
     {
-        self.uniforms.push((name, value.into_uniform_value()));
-        self
+        let iter = self.iterator.borrow_mut().take().unwrap();
+
+        UniformsStorage {
+            iterator: RefCell::new(Some(iter.chain(Some((name, value.into_uniform_value())).into_iter())))
+        }
     }
 }
 
-impl<'a: 'b, 'b> Uniforms for &'b UniformsStorage<'a> {
+impl<'a, 'n, 'u, I: 'a> Uniforms for &'a UniformsStorage<I>
+                                     where I: Iterator<Item = (&'n str, UniformValue<'u>)>
+{
     fn visit_values<F: FnMut(&str, &UniformValue)>(self, mut output: F) {
-        for &(n, ref v) in self.uniforms.iter() {
-            output(n, v)
+        let iterator = self.iterator.borrow_mut().take().unwrap();
+        for (n, v) in iterator {
+            output(n, &v)
         }
     }
 }


### PR DESCRIPTION
Removes the allocation when using `uniform!`. With `-O` it should be as fast as using a regular struct now.

The implementation is hacky due to a bad API and will need to be tweaked again.
