### PR TITLE
Allows drawing with slices of index buffers

### DIFF
--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -37,6 +37,7 @@ use ToGlEnum;
 
 use sync::LinearSyncFence;
 use std::sync::mpsc::Sender;
+use std::mem;
 
 pub use self::buffer::IndexBuffer;
 pub use self::local::{PointsList, LinesList, LinesListAdjacency, LineStrip, LineStripAdjacency};
@@ -177,6 +178,17 @@ pub enum IndexType {
     U16 = gl::UNSIGNED_SHORT,
     /// u32
     U32 = gl::UNSIGNED_INT,
+}
+
+impl IndexType {
+    /// Returns the size in bytes of each index of this type.
+    pub fn get_size(&self) -> usize {
+        match *self {
+            IndexType::U8 => mem::size_of::<u8>(),
+            IndexType::U16 => mem::size_of::<u16>(),
+            IndexType::U32 => mem::size_of::<u32>(),
+        }
+    }
 }
 
 impl ToGlEnum for IndexType {

--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -19,6 +19,7 @@ use draw_parameters::{DepthTest, PolygonMode};
 use Rect;
 
 use {program, vertex_array_object};
+use libc;
 use {gl, context, draw_parameters};
 use context::GlVersion;
 use version::Api;
@@ -115,12 +116,15 @@ pub fn draw<'a, I, U, V>(display: &Display, framebuffer: Option<&FramebufferAtta
     let draw_command = {
         let cmd = match &indices {
             &IndicesSource::IndexBuffer { ref buffer, offset, length, .. } => {
-                assert!(offset == 0);       // not yet implemented
                 must_sync = false;
+
+                let ptr: *const u8 = ptr::null_mut();
+                let ptr = unsafe { ptr.offset((offset * buffer.get_indices_type().get_size()) as isize) };
+
                 DrawCommand::DrawElements(buffer.get_primitives_type().to_glenum(),
                                           length as gl::types::GLsizei,
                                           buffer.get_indices_type().to_glenum(),
-                                          unsafe { ptr::Unique::new(ptr::null_mut()) })
+                                          unsafe { ptr::Unique::new(ptr as *mut libc::c_void) })
             },
             &IndicesSource::Buffer { ref pointer, primitives, offset, length } => {
                 assert!(offset == 0);       // not yet implemented


### PR DESCRIPTION
cc @XMPPwocky

- Adds a `IndexBufferSlice` struct which represents a slice of an IB
- Adds `IndexBuffer::slice` to get a `IndexBufferSlice`
- Implements `ToIndicesSource` trait for `IndexBufferSlice`
- Fixes the code in `ops::draw` to accept offsets != 0
- Adds tests
