### PR TITLE
Reform VAOs organization

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -440,6 +440,8 @@ impl Drop for Buffer {
     fn drop(&mut self) {
         let mut ctxt = self.display.context.context.make_current();
 
+        self.display.context.vertex_array_objects.purge_buffer(&mut ctxt, self.id);
+
         if ctxt.state.array_buffer_binding == self.id {
             ctxt.state.array_buffer_binding = 0;
         }

--- a/src/index/buffer.rs
+++ b/src/index/buffer.rs
@@ -97,21 +97,6 @@ impl ToIndicesSource for IndexBuffer {
     }
 }
 
-impl Drop for IndexBuffer {
-    fn drop(&mut self) {
-        // removing VAOs which contain this index buffer
-        let mut vaos = self.buffer.get_display().context.vertex_array_objects.borrow_mut();
-        let to_delete = vaos.keys()
-                            .filter(|&&(ref bufs, _)| {
-                                bufs.iter().find(|&&b| b == self.buffer.get_id()).is_some()
-                            })
-                            .map(|k| k.clone()).collect::<Vec<_>>();
-        for k in to_delete.into_iter() {
-            vaos.remove(&k);
-        }
-    }
-}
-
 impl<'a> ToIndicesSource for IndexBufferSlice<'a> {
     type Data = u16;      // TODO: u16?
 

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -537,18 +537,12 @@ impl GlObject for Program {
 
 impl Drop for Program {
     fn drop(&mut self) {
+        let mut ctxt = self.display.context.context.make_current();
+
         // removing VAOs which contain this program
-        {
-            let mut vaos = self.display.context.vertex_array_objects.borrow_mut();
-            let to_delete = vaos.keys().filter(|&&(_, p)| p == self.id)
-                .map(|k| k.clone()).collect::<Vec<_>>();
-            for k in to_delete.into_iter() {
-                vaos.remove(&k);
-            }
-        }
+        self.display.context.vertex_array_objects.purge_program(&mut ctxt, self.id);
 
         // sending the destroy command
-        let mut ctxt = self.display.context.context.make_current();
         unsafe {
             match self.id {
                 Handle::Id(id) => {

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -368,21 +368,6 @@ impl VertexBufferAny {
     }
 }
 
-impl Drop for VertexBufferAny {
-    fn drop(&mut self) {
-        // removing VAOs which contain this vertex buffer
-        let mut vaos = self.buffer.get_display().context.vertex_array_objects.borrow_mut();
-        let to_delete = vaos.keys()
-                            .filter(|&&(ref v, _)| {
-                                v.iter().find(|&&b| b == self.buffer.get_id()).is_some()
-                            })
-                            .map(|k| k.clone()).collect::<Vec<_>>();
-        for k in to_delete.into_iter() {
-            vaos.remove(&k);
-        }
-    }
-}
-
 impl GlObject for VertexBufferAny {
     type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {

--- a/src/vertex/per_instance.rs
+++ b/src/vertex/per_instance.rs
@@ -324,21 +324,6 @@ impl PerInstanceAttributesBufferAny {
     }
 }
 
-impl Drop for PerInstanceAttributesBufferAny {
-    fn drop(&mut self) {
-        // removing VAOs which contain this vertex buffer
-        let mut vaos = self.buffer.get_display().context.vertex_array_objects.borrow_mut();
-        let to_delete = vaos.keys()
-                            .filter(|&&(ref v, _)| {
-                                v.iter().find(|&&b| b == self.buffer.get_id()).is_some()
-                            })
-                            .map(|k| k.clone()).collect::<Vec<_>>();
-        for k in to_delete.into_iter() {
-            vaos.remove(&k);
-        }
-    }
-}
-
 impl GlObject for PerInstanceAttributesBufferAny {
     type Id = gl::types::GLuint;
     fn get_id(&self) -> gl::types::GLuint {


### PR DESCRIPTION
 - Isolate the hash map in a dedicated type.
 - Provide `purge` functions.
