### PR TITLE
Add Texture::get_format function

### DIFF
--- a/build/textures.rs
+++ b/build/textures.rs
@@ -255,6 +255,10 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
                     fn get_array_size(&self) -> Option<u32> {{
                         self.0.get_array_size()
                     }}
+
+                    fn get_generic_format(&self) -> TextureFormat {{
+                        self.0.get_format()
+                    }}
                 }}
             ", name)).unwrap();
 

--- a/src/texture/format.rs
+++ b/src/texture/format.rs
@@ -177,7 +177,7 @@ pub enum UncompressedFloatFormat {
     /// Guaranteed to be supported for textures.
     I16I16,
     /// 
-    U3U32U,
+    U3U3U2,
     /// 
     U4U4U4,
     /// 
@@ -284,7 +284,7 @@ impl ToGlEnum for UncompressedFloatFormat {
             UncompressedFloatFormat::I8I8 => gl::RG8_SNORM,
             UncompressedFloatFormat::U16U16 => gl::RG16,
             UncompressedFloatFormat::I16I16 => gl::RG16_SNORM,
-            UncompressedFloatFormat::U3U32U => gl::R3_G3_B2,
+            UncompressedFloatFormat::U3U3U2 => gl::R3_G3_B2,
             UncompressedFloatFormat::U4U4U4 => gl::RGB4,
             UncompressedFloatFormat::U5U5U5 => gl::RGB5,
             UncompressedFloatFormat::U8U8U8 => gl::RGB8,

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -81,6 +81,9 @@ pub trait Texture {
 
     /// Returns the number of textures in the array, or `None` for non-arrays.
     fn get_array_size(&self) -> Option<u32>;
+
+    /// Returns the format of the texture.
+    fn get_generic_format(&self) -> TextureFormat;
 }
 
 /// Trait that describes data for a one-dimensional texture.


### PR DESCRIPTION
Remarks:

 - Not all formats are implemented, most notably sRGB and compressed formats. This will need to be added in other PRs.
 - OpenGL 1.0 doesn't support `glGetTexLevelParameterfv` ; this may need to be tackled, or maybe not
 - OpenGL ES 2 doesn't support this function either. However GLES2 is not allowed to perform any conversion when you upload data, so the format can be determined like this. This will need be tackled when GLES2 support is added.

Close #499 

