### PR TITLE
Add BufferFlags for better flags handling

### DIFF
--- a/src/index/buffer.rs
+++ b/src/index/buffer.rs
@@ -1,4 +1,4 @@
-use buffer::{Buffer, BufferType};
+use buffer::{Buffer, BufferFlags, BufferType};
 use gl;
 use BufferExt;
 use Display;
@@ -43,7 +43,8 @@ impl IndexBuffer {
         assert!(mem::align_of::<T>() <= mem::size_of::<T>(), "Buffer elements are not \
                                                               packed in memory");
         IndexBuffer {
-            buffer: Buffer::new(display, data, BufferType::ArrayBuffer, false).unwrap(),    // FIXME: ElementArrayBuffer
+            buffer: Buffer::new(display, data, BufferType::ArrayBuffer,
+                                BufferFlags::simple()).unwrap(),    // FIXME: ElementArrayBuffer
             data_type: <T as Index>::get_type(),
             primitives: prim,
         }

--- a/src/pixel_buffer.rs
+++ b/src/pixel_buffer.rs
@@ -11,7 +11,7 @@ use Display;
 use texture::{RawImage2d, Texture2dDataSink, ClientFormat};
 
 use GlObject;
-use buffer::{Buffer, BufferType};
+use buffer::{Buffer, BufferFlags, BufferType};
 use gl;
 
 /// Buffer that stores the content of a texture.
@@ -29,7 +29,7 @@ impl<T> PixelBuffer<T> {
     pub fn new_empty(display: &Display, capacity: usize) -> PixelBuffer<T> {
         PixelBuffer {
             buffer: Buffer::new_empty(display, BufferType::PixelPackBuffer, 1, capacity,
-                                      gl::DYNAMIC_READ),
+                                      BufferFlags::simple()).unwrap(),
             dimensions: None,
             format: None,
             marker: PhantomData,

--- a/src/uniforms/buffer.rs
+++ b/src/uniforms/buffer.rs
@@ -1,5 +1,5 @@
 use Display;
-use buffer::{self, Buffer, BufferType, BufferCreationError};
+use buffer::{self, Buffer, BufferFlags, BufferType, BufferCreationError};
 use uniforms::{IntoUniformValue, UniformValue, UniformBlock};
 
 use std::marker::PhantomData;
@@ -34,7 +34,8 @@ impl<T> UniformBuffer<T> where T: Copy + Send + 'static {
     /// Only available if the `gl_uniform_blocks` feature is enabled.
     #[cfg(feature = "gl_uniform_blocks")]
     pub fn new(display: &Display, data: T) -> UniformBuffer<T> {
-        let buffer = Buffer::new(display, vec![data], BufferType::UniformBuffer, false).unwrap();
+        let buffer = Buffer::new(display, vec![data], BufferType::UniformBuffer,
+                                 BufferFlags::simple()).unwrap();
 
         UniformBuffer {
             buffer: TypelessUniformBuffer {
@@ -74,7 +75,11 @@ impl<T> UniformBuffer<T> where T: Copy + Send + 'static {
 
         } else {
             let buffer = match Buffer::new(display, vec![data], BufferType::UniformBuffer,
-                                           persistent)
+                                           if persistent {
+                                               BufferFlags::persistent()
+                                           } else {
+                                               BufferFlags::simple()
+                                           })
             {
                 Err(BufferCreationError::PersistentMappingNotSupported) => return None,
                 b => b.unwrap()

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::sync::mpsc::Sender;
 
-use buffer::{self, Buffer, BufferType, BufferCreationError};
+use buffer::{self, Buffer, BufferFlags, BufferType, BufferCreationError};
 use vertex::{Vertex, VerticesSource, IntoVerticesSource};
 use vertex::format::VertexFormat;
 
@@ -56,7 +56,8 @@ impl<T: Vertex + 'static + Send> VertexBuffer<T> {
     pub fn new(display: &Display, data: Vec<T>) -> VertexBuffer<T> {
         let bindings = <T as Vertex>::build_bindings();
 
-        let buffer = Buffer::new(display, data, BufferType::ArrayBuffer, false).unwrap();
+        let buffer = Buffer::new(display, data, BufferType::ArrayBuffer,
+                                 BufferFlags::simple()).unwrap();
         let elements_size = buffer.get_elements_size();
 
         VertexBuffer {
@@ -75,7 +76,8 @@ impl<T: Vertex + 'static + Send> VertexBuffer<T> {
     pub fn new_dynamic(display: &Display, data: Vec<T>) -> VertexBuffer<T> {
         let bindings = <T as Vertex>::build_bindings();
 
-        let buffer = Buffer::new(display, data, BufferType::ArrayBuffer, false).unwrap();
+        let buffer = Buffer::new(display, data, BufferType::ArrayBuffer,
+                                 BufferFlags::simple()).unwrap();
         let elements_size = buffer.get_elements_size();
 
         VertexBuffer {
@@ -104,7 +106,9 @@ impl<T: Vertex + 'static + Send> VertexBuffer<T> {
     {
         let bindings = <T as Vertex>::build_bindings();
 
-        let buffer = match Buffer::new(display, data, BufferType::ArrayBuffer, true) {
+        let buffer = match Buffer::new(display, data, BufferType::ArrayBuffer,
+                                       BufferFlags::persistent())
+        {
             Err(BufferCreationError::PersistentMappingNotSupported) => return None,
             b => b.unwrap()
         };
@@ -159,7 +163,8 @@ impl<T: Send + Copy + 'static> VertexBuffer<T> {
     {
         VertexBuffer {
             buffer: VertexBufferAny {
-                buffer: Buffer::new(display, data, BufferType::ArrayBuffer, false).unwrap(),
+                buffer: Buffer::new(display, data, BufferType::ArrayBuffer,
+                                    BufferFlags::simple()).unwrap(),
                 bindings: bindings,
                 elements_size: elements_size,
             },

--- a/src/vertex/per_instance.rs
+++ b/src/vertex/per_instance.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::sync::mpsc::Sender;
 
-use buffer::{self, Buffer, BufferType, BufferCreationError};
+use buffer::{self, Buffer, BufferFlags, BufferType, BufferCreationError};
 use vertex::{Vertex, VerticesSource, IntoVerticesSource};
 use vertex::format::VertexFormat;
 
@@ -65,7 +65,8 @@ impl<T: Vertex + 'static + Send> PerInstanceAttributesBuffer<T> {
 
         let bindings = <T as Vertex>::build_bindings();
 
-        let buffer = Buffer::new(display, data, BufferType::ArrayBuffer, false).unwrap();
+        let buffer = Buffer::new(display, data, BufferType::ArrayBuffer,
+                                 BufferFlags::simple()).unwrap();
         let elements_size = buffer.get_elements_size();
 
         Some(PerInstanceAttributesBuffer {
@@ -84,7 +85,8 @@ impl<T: Vertex + 'static + Send> PerInstanceAttributesBuffer<T> {
     pub fn new_dynamic(display: &Display, data: Vec<T>) -> PerInstanceAttributesBuffer<T> {
         let bindings = <T as Vertex>::build_bindings();
 
-        let buffer = Buffer::new(display, data, BufferType::ArrayBuffer, false).unwrap();
+        let buffer = Buffer::new(display, data, BufferType::ArrayBuffer,
+                                 BufferFlags::simple()).unwrap();
         let elements_size = buffer.get_elements_size();
 
         PerInstanceAttributesBuffer {
@@ -119,7 +121,9 @@ impl<T: Vertex + 'static + Send> PerInstanceAttributesBuffer<T> {
 
         let bindings = <T as Vertex>::build_bindings();
 
-        let buffer = match Buffer::new(display, data, BufferType::ArrayBuffer, true) {
+        let buffer = match Buffer::new(display, data, BufferType::ArrayBuffer,
+                                       BufferFlags::persistent())
+        {
             Err(BufferCreationError::PersistentMappingNotSupported) => return None,
             b => b.unwrap()
         };
@@ -174,7 +178,8 @@ impl<T: Send + Copy + 'static> PerInstanceAttributesBuffer<T> {
     {
         PerInstanceAttributesBuffer {
             buffer: PerInstanceAttributesBufferAny {
-                buffer: Buffer::new(display, data, BufferType::ArrayBuffer, false).unwrap(),
+                buffer: Buffer::new(display, data, BufferType::ArrayBuffer,
+                                    BufferFlags::simple()).unwrap(),
                 bindings: bindings,
                 elements_size: elements_size,
             },


### PR DESCRIPTION
Internal change only.

For the moment, `Buffer::new` takes a `persistent: bool` parameter and just adds `DYNAMIC | MAP_READ | MAP_WRITE` (and `COHERENT` when necessary) itself. This PR changes that so that you pass actual flags to `Buffer::new`.
