### PR TITLE
Rework the debug output to use the *const Context

### DIFF
--- a/src/backend/glutin_backend.rs
+++ b/src/backend/glutin_backend.rs
@@ -228,7 +228,7 @@ impl DisplayBuild for glutin::WindowBuilder<'static> {
         let context = try!(unsafe { context::Context::new(backend.clone(), true) });
 
         let display = GlutinFacade {
-            context: Rc::new(context),
+            context: context,
             backend: Rc::new(Some(RefCell::new(backend))),
         };
 
@@ -240,7 +240,7 @@ impl DisplayBuild for glutin::WindowBuilder<'static> {
         let context = try!(context::Context::new(backend.clone(), false));
 
         let display = GlutinFacade {
-            context: Rc::new(context),
+            context: context,
             backend: Rc::new(Some(RefCell::new(backend))),
         };
 
@@ -266,7 +266,7 @@ impl DisplayBuild for glutin::HeadlessRendererBuilder {
         let context = try!(unsafe { context::Context::new(backend.clone(), true) });
 
         let display = GlutinFacade {
-            context: Rc::new(context),
+            context: context,
             backend: Rc::new(None),
         };
 
@@ -278,7 +278,7 @@ impl DisplayBuild for glutin::HeadlessRendererBuilder {
         let context = try!(context::Context::new(backend.clone(), true));
 
         let display = GlutinFacade {
-            context: Rc::new(context),
+            context: context,
             backend: Rc::new(None),
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,6 +259,9 @@ trait BufferExt {
 
 /// Internal trait for contexts.
 trait ContextExt {
+    /// Sets whether the context's debug output callback should take errors into account.
+    fn set_report_debug_output_errors(&self, value: bool);
+
     fn make_current<'a>(&'a self) -> context::CommandContext<'a, 'a>;
 }
 

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -16,7 +16,6 @@ use std::collections::hash_map::{self, HashMap};
 use std::default::Default;
 use std::rc::Rc;
 use std::cell::RefCell;
-use std::sync::atomic::Ordering;
 use util::FnvHasher;
 
 use GlObject;
@@ -282,7 +281,7 @@ impl Program {
             {
                 let _lock = COMPILER_GLOBAL_LOCK.lock();
 
-                ctxt.shared_debug_output.report_errors.store(false, Ordering::Relaxed);
+                ctxt.report_debug_output_errors.set(false);
 
                 match id {
                     Handle::Id(id) => {
@@ -295,7 +294,7 @@ impl Program {
                     }
                 }
 
-                ctxt.shared_debug_output.report_errors.store(true, Ordering::Relaxed);
+                ctxt.report_debug_output_errors.set(true);
             }
 
             // checking for errors

--- a/src/program/shader.rs
+++ b/src/program/shader.rs
@@ -8,7 +8,6 @@ use context::Context;
 use ContextExt;
 
 use std::{ffi, mem, ptr};
-use std::sync::atomic::Ordering;
 use std::rc::Rc;
 
 use GlObject;
@@ -95,7 +94,7 @@ pub fn build_shader<F>(facade: &F, shader_type: gl::types::GLenum, source_code: 
         {
             let _lock = COMPILER_GLOBAL_LOCK.lock();
 
-            ctxt.shared_debug_output.report_errors.store(false, Ordering::Relaxed);
+            ctxt.report_debug_output_errors.set(false);
 
             match id {
                 Handle::Id(id) => {
@@ -109,7 +108,7 @@ pub fn build_shader<F>(facade: &F, shader_type: gl::types::GLenum, source_code: 
                 }
             }
 
-            ctxt.shared_debug_output.report_errors.store(true, Ordering::Relaxed);
+            ctxt.report_debug_output_errors.set(true);
         }
 
         // checking compilation success


### PR DESCRIPTION
Technically a breaking change, as `Context::new` now returns a `Rc<Context>` instead of a `Context`, but I don't think anyone uses this API.