### PR TITLE
Calculate correct framebuffer size with hidpi_factor

### DIFF
--- a/src/backend/glutin_backend.rs
+++ b/src/backend/glutin_backend.rs
@@ -305,7 +305,9 @@ impl Backend for GlutinWindowBackend {
     }
 
     fn get_framebuffer_dimensions(&self) -> (u32, u32) {
-        self.window.get_inner_size().unwrap_or((800, 600))      // TODO: 800x600 ?
+        let (width, height) = self.window.get_inner_size().unwrap_or((800, 600));      // TODO: 800x600 ?
+        let scale = self.window.hidpi_factor();
+        (width * scale as u32, height * scale as u32)
     }
 
     fn is_current(&self) -> bool {


### PR DESCRIPTION
This fixes the incorrect viewport size when running on a retina screen in OS X.

When moving the window between retina/non-retina monitors the viewport is incorrect again, but resizing the window fixes it. I don't know why this is happening because `sync_viewport_scissor` calls `gl.Viewport` with the correct size every time. In any case, this is better than the current situation.