### PR TITLE
Do not allow transposing uniform matrices

### DIFF
--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -410,19 +410,19 @@ fn bind_uniform(ctxt: &mut context::CommandContext,
             uniform!(ctxt, Uniform1f, Uniform1fARB, location, val);
             Ok(())
         },
-        UniformValue::Mat2(val, transpose) => {
+        UniformValue::Mat2(val) => {
             uniform!(ctxt, UniformMatrix2fv, UniformMatrix2fvARB,
-                     location, 1, if transpose { 1 } else { 0 }, val.as_ptr() as *const f32);
+                     location, 1, gl::FALSE, val.as_ptr() as *const f32);
             Ok(())
         },
-        UniformValue::Mat3(val, transpose) => {
+        UniformValue::Mat3(val) => {
             uniform!(ctxt, UniformMatrix3fv, UniformMatrix3fvARB,
-                     location, 1, if transpose { 1 } else { 0 }, val.as_ptr() as *const f32);
+                     location, 1, gl::FALSE, val.as_ptr() as *const f32);
             Ok(())
         },
-        UniformValue::Mat4(val, transpose) => {
+        UniformValue::Mat4(val) => {
             uniform!(ctxt, UniformMatrix4fv, UniformMatrix4fvARB,
-                     location, 1, if transpose { 1 } else { 0 }, val.as_ptr() as *const f32);
+                     location, 1, gl::FALSE, val.as_ptr() as *const f32);
             Ok(())
         },
         UniformValue::Vec2(val) => {

--- a/src/uniforms/value.rs
+++ b/src/uniforms/value.rs
@@ -144,12 +144,12 @@ pub enum UniformValue<'a> {
     SignedInt(i32),
     UnsignedInt(u32),
     Float(f32),
-    /// 2x2 column-major matrix. The second parameter describes whether to transpose it.
-    Mat2([[f32; 2]; 2], bool),
-    /// 3x3 column-major matrix. The second parameter describes whether to transpose it.
-    Mat3([[f32; 3]; 3], bool),
-    /// 4x4 column-major matrix. The second parameter describes whether to transpose it.
-    Mat4([[f32; 4]; 4], bool),
+    /// 2x2 column-major matrix.
+    Mat2([[f32; 2]; 2]),
+    /// 3x3 column-major matrix.
+    Mat3([[f32; 3]; 3]),
+    /// 4x4 column-major matrix.
+    Mat4([[f32; 4]; 4]),
     Vec2([f32; 2]),
     Vec3([f32; 3]),
     Vec4([f32; 4]),
@@ -201,9 +201,9 @@ impl<'a> UniformValue<'a> {
             (&UniformValue::SignedInt(_), UniformType::Int) => true,
             (&UniformValue::UnsignedInt(_), UniformType::UnsignedInt) => true,
             (&UniformValue::Float(_), UniformType::Float) => true,
-            (&UniformValue::Mat2(_,_ ), UniformType::FloatMat2) => true,
-            (&UniformValue::Mat3(_, _), UniformType::FloatMat3) => true,
-            (&UniformValue::Mat4(_, _), UniformType::FloatMat4) => true,
+            (&UniformValue::Mat2(_), UniformType::FloatMat2) => true,
+            (&UniformValue::Mat3(_), UniformType::FloatMat3) => true,
+            (&UniformValue::Mat4(_), UniformType::FloatMat4) => true,
             (&UniformValue::Vec2(_), UniformType::FloatVec2) => true,
             (&UniformValue::Vec3(_), UniformType::FloatVec3) => true,
             (&UniformValue::Vec4(_), UniformType::FloatVec4) => true,
@@ -313,19 +313,19 @@ impl IntoUniformValue<'static> for f32 {
 
 impl IntoUniformValue<'static> for [[f32; 2]; 2] {
     fn into_uniform_value(self) -> UniformValue<'static> {
-        UniformValue::Mat2(self, false)
+        UniformValue::Mat2(self)
     }
 }
 
 impl IntoUniformValue<'static> for [[f32; 3]; 3] {
     fn into_uniform_value(self) -> UniformValue<'static> {
-        UniformValue::Mat3(self, false)
+        UniformValue::Mat3(self)
     }
 }
 
 impl IntoUniformValue<'static> for [[f32; 4]; 4] {
     fn into_uniform_value(self) -> UniformValue<'static> {
-        UniformValue::Mat4(self, false)
+        UniformValue::Mat4(self)
     }
 }
 


### PR DESCRIPTION
Fix #518 

OpenGL ES doesn't allow transposing matrices. We won't bother handling supported/not-supported for such a minor feature, and instead force the users to transpose themselves.
