### PR TITLE
Now calling glEnable(GL_FRAMEBUFFER_SRGB)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+ - Fixed `GL_FRAMEBUFFER_SRGB` not being enabled, leading to different brightness depending on the target.
+
 ## Version 0.2.1 (2015-04-03)
 
  - Creating a texture with a specific format now properly checks for available extensions.

--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -25,6 +25,9 @@ pub struct GLState {
     /// Whether GL_DITHER is enabled
     pub enabled_dither: bool,
 
+    /// Whether GL_FRAMEBUFFER_SRGB is enabled
+    pub enabled_framebuffer_srgb: bool,
+
     /// Whether GL_MULTISAMPLE is enabled
     pub enabled_multisample: bool,
 
@@ -144,6 +147,7 @@ impl Default for GLState {
             enabled_debug_output_synchronous: false,
             enabled_depth_test: false,
             enabled_dither: false,
+            enabled_framebuffer_srgb: false,
             enabled_multisample: true,
             enabled_polygon_offset_fill: false,
             enabled_rasterizer_discard: false,

--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -244,6 +244,13 @@ pub fn draw<'a, I, U, V>(context: &Context, framebuffer: Option<&FramebufferAtta
                               dimensions);
         sync_rasterizer_discard(&mut ctxt, draw_parameters.draw_primitives);
         sync_vertices_per_patch(&mut ctxt, vertices_per_patch);
+
+        if ctxt.version >= &Version(Api::Gl, 3, 0) {        // TODO: extensions?
+            if !ctxt.state.enabled_framebuffer_srgb {
+                ctxt.gl.Enable(gl::FRAMEBUFFER_SRGB);
+                ctxt.state.enabled_framebuffer_srgb = true;
+            }
+        }
     }
 
     // drawing


### PR DESCRIPTION
After this change, there are two possibilities:
 - Either the window has sRGB disabled, and the output of the fragment shader is directly copied to the window.
 - Or the window has sRGB enabled, and a conversion is performed from linear color space (ie. non-srgb) to sRGB.

Before this PR the conversion was not performed, which means that the output was different depending on the machine.

cc #55 
