### PR TITLE
Allow trailing commas in macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - Glium now has basic support for OpenGL ES 2/WebGL.
  - Added stencil operations in `DrawParameters`.
  - Fixed `GL_FRAMEBUFFER_SRGB` not being enabled, leading to different brightness depending on the target.
+ - Fixed trailing commas not working in `implement_vertex!` and `uniform!`.
 
 ## Version 0.2.1 (2015-04-03)
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -33,6 +33,10 @@ macro_rules! uniform {
             uniforms
         }
     };
+
+    ($($field:ident: $value:expr),*,) => {
+        uniform!($($field: $value),*)
+    };
 }
 
 /// Implements the `glium::vertex::Vertex` trait for the given type.
@@ -86,5 +90,27 @@ macro_rules! implement_vertex {
                 ]
             }
         }
-    )
+    );
+
+    ($struct_name:ident, $($field_name:ident),+,) => (
+        implement_vertex!($struct_name, $($field_name),+);
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn trailing_comma_impl_uniforms() {
+        let u = uniform!{ a: 5, b: 6, };
+    }
+
+    #[test]
+    fn trailing_comma_impl_vertex() {
+        #[derive(Copy, Clone)]
+        struct Foo {
+            pos: [f32; 2],
+        }
+
+        implement_vertex!(Foo, pos,);
+    }
 }


### PR DESCRIPTION
Fix #728 