### PR TITLE
[Breaking change] Modify transform feedback reflection to be compatible with GL 4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+ - Changed transform feedback reflection API to be compatible with what OpenGL 4.4 or ARB_enhanced_layouts allow.
+
 ## Version 0.2.2 (2015-04-10)
 
  - Added support for backends that don't have vertex array objects (like OpenGL ES 2/WebGL).

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -2,7 +2,7 @@ use std::sync::Mutex;
 
 pub use self::program::{Program, ProgramCreationError};
 pub use self::reflection::{Uniform, UniformBlock, UniformBlockMember};
-pub use self::reflection::{Attribute, TransformFeedbackVarying, TransformFeedbackMode};
+pub use self::reflection::{Attribute, TransformFeedbackVarying, TransformFeedbackBuffer, TransformFeedbackMode};
 
 mod program;
 mod reflection;

--- a/tests/shaders.rs
+++ b/tests/shaders.rs
@@ -388,24 +388,31 @@ fn get_transform_feedback_varyings() {
         Err(e) => panic!("{:?}", e)
     };
 
-    assert_eq!(program.get_transform_feedback_varyings()[0],
-                glium::program::TransformFeedbackVarying {
-                    name: "normal".to_string(),
-                    size: 2 * 4,
-                    ty: glium::vertex::AttributeType::F32F32,
+    assert_eq!(program.get_transform_feedback_buffers()[0],
+                glium::program::TransformFeedbackBuffer {
+                    id: 0,
+                    stride: 2 * 4,
+                    elements: vec![glium::program::TransformFeedbackVarying {
+                        name: "normal".to_string(),
+                        offset: 0,
+                        size: 2 * 4,
+                        ty: glium::vertex::AttributeType::F32F32,
+                    }]
                 });
 
-    assert_eq!(program.get_transform_feedback_varyings()[1],
-                glium::program::TransformFeedbackVarying {
-                    name: "color".to_string(),
-                    size: 4,
-                    ty: glium::vertex::AttributeType::U32,
+    assert_eq!(program.get_transform_feedback_buffers()[1],
+                glium::program::TransformFeedbackBuffer {
+                    id: 0,
+                    stride: 4,
+                    elements: vec![glium::program::TransformFeedbackVarying {
+                        name: "color".to_string(),
+                        offset: 0,
+                        size: 4,
+                        ty: glium::vertex::AttributeType::U32,
+                    }]
                 });
 
-    assert_eq!(program.get_transform_feedback_varyings().len(), 2);
+    assert_eq!(program.get_transform_feedback_buffers().len(), 2);
 
-    assert_eq!(program.get_transform_feedback_mode(),
-               Some(glium::program::TransformFeedbackMode::Separate));
-    
     display.assert_no_error();
 }


### PR DESCRIPTION
The current API matches what OpenGL 3 proposes: either each variable is a different buffer, or each variable one behind another in one single buffer.
This PR changes the API so that it becomes compatible with what OpenGL 4.4 (or `ARB_enhanced_layouts`) allows: putting any variable at any offset in any number of buffers you want.

This is technically a breaking change. However since transform feedback itself doesn't work yet, it is very unlikely that anyone was using these functions, and I will consider this as a backward-compatible change in term of versionning.