### PR TITLE
[Breaking change] Use Range objects in slice()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+ - Changed the `slice()` functions to take a `Range` instead of two parameters.
+
+## Unreleased
+
  - Fixed drawing with offsets in vertex buffers different than 0 not permitted.
  - Changed transform feedback reflection API to be compatible with what OpenGL 4.4 or ARB_enhanced_layouts allow.
 

--- a/src/index/buffer.rs
+++ b/src/index/buffer.rs
@@ -15,6 +15,7 @@ use index::IndexType;
 use index::PrimitiveType;
 
 use std::mem;
+use std::ops::Range;
 use std::sync::mpsc::Sender;
 
 /// A list of indices loaded in the graphics card's memory.
@@ -62,16 +63,18 @@ impl IndexBuffer {
     }
 
     /// Returns `None` if out of range.
-    pub fn slice(&self, offset: usize, len: usize) -> Option<IndexBufferSlice> {
-        if offset > self.buffer.get_elements_count() ||
-            offset + len > self.buffer.get_elements_count()
+    pub fn slice(&self, Range { start, end }: Range<usize>) -> Option<IndexBufferSlice> {
+        let len = end - start;
+
+        if start > self.buffer.get_elements_count() ||
+            start + len > self.buffer.get_elements_count()
         {
             return None;
         }
 
         Some(IndexBufferSlice {
             buffer: self,
-            offset: offset,
+            offset: start,
             len: len,
         })
     }

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use std::ops::{Deref, DerefMut};
+use std::ops::{Range, Deref, DerefMut};
 use std::sync::mpsc::Sender;
 
 use buffer::{self, Buffer, BufferFlags, BufferType, BufferCreationError};
@@ -179,14 +179,16 @@ impl<T: Send + Copy + 'static> VertexBuffer<T> {
     /// Accesses a slice of the buffer.
     ///
     /// Returns `None` if the slice is out of range.
-    pub fn slice(&self, offset: usize, len: usize) -> Option<VertexBufferSlice<T>> {
-        if offset > self.len() || offset + len > self.len() {
+    pub fn slice(&self, Range { start, end }: Range<usize>) -> Option<VertexBufferSlice<T>> {
+        let len = end - start;
+
+        if start > self.len() || start + len > self.len() {
             return None;
         }
 
         Some(VertexBufferSlice {
             buffer: self,
-            offset: offset,
+            offset: start,
             length: len
         })
     }
@@ -405,14 +407,16 @@ impl VertexBufferAny {
     /// Accesses a slice of the buffer.
     ///
     /// Returns `None` if the slice is out of range.
-    pub fn slice(&self, offset: usize, len: usize) -> Option<VertexBufferAnySlice> {
-        if offset >= self.len() || offset + len >= self.len() {
+    pub fn slice(&self, Range { start, end }: Range<usize>) -> Option<VertexBufferAnySlice> {
+        let len = end - start;
+
+        if start >= self.len() || start + len >= self.len() {
             return None;
         }
 
         Some(VertexBufferAnySlice {
             buffer: self,
-            offset: offset,
+            offset: start,
             length: len
         })
     }

--- a/tests/indices.rs
+++ b/tests/indices.rs
@@ -337,9 +337,9 @@ fn indexbuffer_slice_out_of_range() {
     let indices = glium::index::TrianglesList(vec![0u16, 1, 2, 2, 1, 3]);
     let indices = glium::IndexBuffer::new(&display, indices);
 
-    assert!(indices.slice(5, 3).is_none());
-    assert!(indices.slice(2, 9).is_none());
-    assert!(indices.slice(12, 1).is_none());
+    assert!(indices.slice(5 .. 8).is_none());
+    assert!(indices.slice(2 .. 11).is_none());
+    assert!(indices.slice(12 .. 13).is_none());
 
     display.assert_no_error();
 }
@@ -359,7 +359,7 @@ fn indexbuffer_slice_draw() {
 
     let texture1 = support::build_renderable_texture(&display);
     texture1.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
-    texture1.as_surface().draw(&vb, &indices.slice(3, 3).unwrap(), &program,
+    texture1.as_surface().draw(&vb, &indices.slice(3 .. 6).unwrap(), &program,
                 &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
 
     let data: Vec<Vec<(u8, u8, u8)>> = texture1.read();
@@ -369,7 +369,7 @@ fn indexbuffer_slice_draw() {
 
     let texture2 = support::build_renderable_texture(&display);
     texture2.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
-    texture2.as_surface().draw(&vb, &indices.slice(0, 3).unwrap(), &program,
+    texture2.as_surface().draw(&vb, &indices.slice(0 .. 3).unwrap(), &program,
                 &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
 
     let data: Vec<Vec<(u8, u8, u8)>> = texture2.read();

--- a/tests/vertex_buffer.rs
+++ b/tests/vertex_buffer.rs
@@ -137,7 +137,7 @@ fn vertex_buffer_read_slice() {
         ]
     );
 
-    let data = match vb.slice(1, 1).unwrap().read_if_supported() {
+    let data = match vb.slice(1 .. 2).unwrap().read_if_supported() {
         Some(d) => d,
         None => return
     };
@@ -166,7 +166,7 @@ fn vertex_buffer_slice_out_of_bounds() {
         ]
     );
 
-    assert!(vb.slice(0, 3).is_none());
+    assert!(vb.slice(0 .. 3).is_none());
 
     display.assert_no_error();
 }
@@ -250,7 +250,7 @@ fn vertex_buffer_write_slice() {
         ]
     );
 
-    vb.slice(1, 1).unwrap().write(vec![Vertex { field1: [12, 13], field2: [15, 17] }]);
+    vb.slice(1 .. 2).unwrap().write(vec![Vertex { field1: [12, 13], field2: [15, 17] }]);
 
     let data = match vb.read_if_supported() {
         Some(d) => d,
@@ -404,7 +404,7 @@ fn slice_draw_indices() {
 
     let texture = support::build_renderable_texture(&display);
     texture.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
-    texture.as_surface().draw(vb.slice(1, 3).unwrap(), &indices, &program,
+    texture.as_surface().draw(vb.slice(1 .. 4).unwrap(), &indices, &program,
                 &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
 
     let data: Vec<Vec<(u8, u8, u8)>> = texture.read();
@@ -452,7 +452,7 @@ fn slice_draw_noindices() {
 
     let texture = support::build_renderable_texture(&display);
     texture.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
-    texture.as_surface().draw(vb.slice(1, 3).unwrap(), &indices, &program,
+    texture.as_surface().draw(vb.slice(1 .. 4).unwrap(), &indices, &program,
                 &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
 
     let data: Vec<Vec<(u8, u8, u8)>> = texture.read();
@@ -523,7 +523,7 @@ fn slice_draw_multiple() {
 
     let texture = support::build_renderable_texture(&display);
     texture.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
-    texture.as_surface().draw((vb1.slice(1, 3).unwrap(), vb2.slice(3, 3).unwrap()), &indices,
+    texture.as_surface().draw((vb1.slice(1 .. 4).unwrap(), vb2.slice(3 .. 6).unwrap()), &indices,
                 &program, &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
 
     let data: Vec<Vec<(u8, u8, u8)>> = texture.read();


### PR DESCRIPTION
Merging into the `v0.3` branch, so does not take effect immediatly.

Replaces `vb.slice(1, 3)` by `vb.slice(1 .. 4)`.
The `slice` function currently expects a length, while the new syntax expects an end element.
