### PR TITLE
Revert "Now calling glEnable(GL_FRAMEBUFFER_SRGB)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - Fixed drawing with offsets in vertex buffers different than 0 not permitted.
  - Changed transform feedback reflection API to be compatible with what OpenGL 4.4 or ARB_enhanced_layouts allow.
  - `VertexBuffer::new` can now take a slice as parameter.
+ - Revert the fix for sRGB. `GL_FRAMEBUFFER_SRGB` is no longer enabled.
 
 ## Version 0.2.2 (2015-04-10)
 

--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -25,9 +25,6 @@ pub struct GLState {
     /// Whether GL_DITHER is enabled
     pub enabled_dither: bool,
 
-    /// Whether GL_FRAMEBUFFER_SRGB is enabled
-    pub enabled_framebuffer_srgb: bool,
-
     /// Whether GL_MULTISAMPLE is enabled
     pub enabled_multisample: bool,
 
@@ -165,7 +162,6 @@ impl Default for GLState {
             enabled_debug_output_synchronous: false,
             enabled_depth_test: false,
             enabled_dither: false,
-            enabled_framebuffer_srgb: false,
             enabled_multisample: true,
             enabled_polygon_offset_fill: false,
             enabled_rasterizer_discard: false,

--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -246,13 +246,6 @@ pub fn draw<'a, I, U, V>(context: &Context, framebuffer: Option<&FramebufferAtta
                               dimensions);
         sync_rasterizer_discard(&mut ctxt, draw_parameters.draw_primitives);
         sync_vertices_per_patch(&mut ctxt, vertices_per_patch);
-
-        if ctxt.version >= &Version(Api::Gl, 3, 0) {        // TODO: extensions?
-            if !ctxt.state.enabled_framebuffer_srgb {
-                ctxt.gl.Enable(gl::FRAMEBUFFER_SRGB);
-                ctxt.state.enabled_framebuffer_srgb = true;
-            }
-        }
     }
 
     // drawing


### PR DESCRIPTION
This reverts commit 69fd8c8c2e09e6b37a1f59102dd6ddd32813e5d8.

Conflicts:
	CHANGELOG.md