### PR TITLE
[Small breaking change] Parametrize the type of error in DisplayBuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
  - Fixed the `Mapping` objects not implementing `Sync`.
  - Fixed rendering to an sRGB texture not possible.
+ - `GliumCreationError` now has a template parameter indicating the backend creation error type.
+ - The `DisplayBuild` trait has a new associated type indicating the error type.
 
 ## Version 0.3.1 (2015-04-18)
 

--- a/examples/manual-creation.rs
+++ b/examples/manual-creation.rs
@@ -73,7 +73,7 @@ fn main() {
         //
         // It is recommended to pass `true`, but you can pass `false` if you are sure that no
         // other OpenGL context will be made current in this thread.
-        glium::backend::Context::new(Backend { window: window.clone() }, true)
+        glium::backend::Context::new::<_, ()>(Backend { window: window.clone() }, true)
     }.unwrap();
 
     // drawing a frame to prove that it works

--- a/src/backend/glutin_backend.rs
+++ b/src/backend/glutin_backend.rs
@@ -229,8 +229,9 @@ impl GlutinFacade {
 
 impl DisplayBuild for glutin::WindowBuilder<'static> {
     type Facade = GlutinFacade;
+    type Err = GliumCreationError<glutin::CreationError>;
 
-    fn build_glium(self) -> Result<GlutinFacade, GliumCreationError> {
+    fn build_glium(self) -> Result<GlutinFacade, GliumCreationError<glutin::CreationError>> {
         let backend = Rc::new(try!(backend::glutin_backend::GlutinWindowBackend::new(self)));
         let context = try!(unsafe { context::Context::new(backend.clone(), true) });
 
@@ -242,7 +243,7 @@ impl DisplayBuild for glutin::WindowBuilder<'static> {
         Ok(display)
     }
 
-    unsafe fn build_glium_unchecked(self) -> Result<GlutinFacade, GliumCreationError> {
+    unsafe fn build_glium_unchecked(self) -> Result<GlutinFacade, GliumCreationError<glutin::CreationError>> {
         let backend = Rc::new(try!(backend::glutin_backend::GlutinWindowBackend::new(self)));
         let context = try!(context::Context::new(backend.clone(), false));
 
@@ -254,7 +255,7 @@ impl DisplayBuild for glutin::WindowBuilder<'static> {
         Ok(display)
     }
 
-    fn rebuild_glium(self, display: &GlutinFacade) -> Result<(), GliumCreationError> {
+    fn rebuild_glium(self, display: &GlutinFacade) -> Result<(), GliumCreationError<glutin::CreationError>> {
         let mut existing_window = display.backend.as_ref()
                                          .expect("can't rebuild a headless display").borrow_mut();
         let new_backend = Rc::new(try!(existing_window.rebuild(self)));
@@ -267,8 +268,9 @@ impl DisplayBuild for glutin::WindowBuilder<'static> {
 #[cfg(feature = "headless")]
 impl DisplayBuild for glutin::HeadlessRendererBuilder {
     type Facade = GlutinFacade;
+    type Err = GliumCreationError<glutin::CreationError>;
 
-    fn build_glium(self) -> Result<GlutinFacade, GliumCreationError> {
+    fn build_glium(self) -> Result<GlutinFacade, GliumCreationError<glutin::CreationError>> {
         let backend = Rc::new(try!(backend::glutin_backend::GlutinHeadlessBackend::new(self)));
         let context = try!(unsafe { context::Context::new(backend.clone(), true) });
 
@@ -280,7 +282,7 @@ impl DisplayBuild for glutin::HeadlessRendererBuilder {
         Ok(display)
     }
 
-    unsafe fn build_glium_unchecked(self) -> Result<GlutinFacade, GliumCreationError> {
+    unsafe fn build_glium_unchecked(self) -> Result<GlutinFacade, GliumCreationError<glutin::CreationError>> {
         let backend = Rc::new(try!(backend::glutin_backend::GlutinHeadlessBackend::new(self)));
         let context = try!(context::Context::new(backend.clone(), true));
 
@@ -292,7 +294,7 @@ impl DisplayBuild for glutin::HeadlessRendererBuilder {
         Ok(display)
     }
 
-    fn rebuild_glium(self, _: &GlutinFacade) -> Result<(), GliumCreationError> {
+    fn rebuild_glium(self, _: &GlutinFacade) -> Result<(), GliumCreationError<glutin::CreationError>> {
         unimplemented!()
     }
 }
@@ -330,7 +332,7 @@ unsafe impl Backend for GlutinWindowBackend {
 impl GlutinWindowBackend {
     /// Builds a new backend from the builder.
     pub fn new(builder: glutin::WindowBuilder)
-               -> Result<GlutinWindowBackend, GliumCreationError>
+               -> Result<GlutinWindowBackend, GliumCreationError<glutin::CreationError>>
     {
         let window = try!(builder.build());
 
@@ -356,7 +358,7 @@ impl GlutinWindowBackend {
     }
 
     pub fn rebuild(&self, builder: glutin::WindowBuilder)
-                   -> Result<GlutinWindowBackend, GliumCreationError>
+                   -> Result<GlutinWindowBackend, GliumCreationError<glutin::CreationError>>
     {
         let window = try!(builder.with_shared_lists(&self.window).build());
 
@@ -398,7 +400,7 @@ unsafe impl Backend for GlutinHeadlessBackend {
 impl GlutinHeadlessBackend {
     /// Builds a new backend from the builder.
     pub fn new(builder: glutin::HeadlessRendererBuilder)
-               -> Result<GlutinHeadlessBackend, GliumCreationError>
+               -> Result<GlutinHeadlessBackend, GliumCreationError<glutin::CreationError>>
     {
         let context = try!(builder.build());
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -74,9 +74,9 @@ impl Context {
     /// If you pass `false`, you must ensure that no other OpenGL context is going to be made
     /// current in the same thread as this context. Passing `true` makes things safe but
     /// is slightly slower.
-    pub unsafe fn new<B>(backend: B, check_current_context: bool)
-                         -> Result<Rc<Context>, GliumCreationError>
-                         where B: Backend + 'static
+    pub unsafe fn new<B, E>(backend: B, check_current_context: bool)
+                            -> Result<Rc<Context>, GliumCreationError<E>>
+                            where B: Backend + 'static
     {
         backend.make_current();
         let gl = gl::Gl::load_with(|symbol| backend.get_proc_address(symbol));
@@ -127,9 +127,9 @@ impl Context {
     /// Changes the OpenGL context associated with this context.
     ///
     /// The new context must have lists shared with the old one.
-    pub unsafe fn rebuild<B>(&self, new_backend: B)
-                             -> Result<(), GliumCreationError>
-                             where B: Backend + 'static
+    pub unsafe fn rebuild<B, E>(&self, new_backend: B)
+                                -> Result<(), GliumCreationError<E>>
+                                where B: Backend + 'static
     {
         {
             let mut ctxt = self.make_current();
@@ -380,7 +380,7 @@ impl Drop for Context {
     }
 }
 
-fn check_gl_compatibility(ctxt: &mut CommandContext) -> Result<(), GliumCreationError> {
+fn check_gl_compatibility<T>(ctxt: &mut CommandContext) -> Result<(), GliumCreationError<T>> {
     let mut result = Vec::new();
 
     if !(ctxt.version >= &Version(Api::Gl, 1, 5)) &&


### PR DESCRIPTION
- `GliumCreationError` no longer contains a `glutin::CreationError`. Instead it has a template parameter `GliumCreationError<T>` where `T` is the type of the error that can happen when creating the backend.
- The `DisplayBuild` trait has a new associated type `Err` that corresponds to the type of the error.

This PR will make it possible to turn `glutin` into an optional feature.