### PR TITLE
[Breaking change] Add diagnostic message to assert_no_error.

### DIFF
--- a/src/backend/glutin_backend.rs
+++ b/src/backend/glutin_backend.rs
@@ -211,8 +211,8 @@ impl GlutinFacade {
     /// Asserts that there are no OpenGL errors pending.
     ///
     /// This function should be used in tests.
-    pub fn assert_no_error(&self) {
-        self.context.assert_no_error()
+    pub fn assert_no_error(&self, user_msg: Option<&str>) {
+        self.context.assert_no_error(user_msg)
     }
 
     /// Waits until all the previous commands have finished being executed.

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -292,12 +292,13 @@ impl Context {
     /// Asserts that there are no OpenGL errors pending.
     ///
     /// This function should be used in tests.
-    pub fn assert_no_error(&self) {
+    pub fn assert_no_error(&self, user_msg: Option<&str>) {
         let mut ctxt = self.make_current();
 
-        match ::get_gl_error(&mut ctxt) {
-            Some(msg) => panic!("{}", msg),
-            None => ()
+        match (::get_gl_error(&mut ctxt), user_msg) {
+            (Some(msg), None) => panic!("{}", msg),
+            (Some(msg), Some(user_msg)) => panic!("{} : {}", user_msg, msg),
+            (None, _) => ()
         };
     }
 
@@ -536,7 +537,7 @@ fn init_debug_callback(context: &Rc<Context>) {
         let user_param = user_param as *const Context;
         let user_param: &Context = unsafe { mem::transmute(user_param) };
 
-        if (severity == gl::DEBUG_SEVERITY_HIGH || severity == gl::DEBUG_SEVERITY_MEDIUM) && 
+        if (severity == gl::DEBUG_SEVERITY_HIGH || severity == gl::DEBUG_SEVERITY_MEDIUM) &&
            (ty == gl::DEBUG_TYPE_ERROR || ty == gl::DEBUG_TYPE_UNDEFINED_BEHAVIOR ||
             ty == gl::DEBUG_TYPE_PORTABILITY || ty == gl::DEBUG_TYPE_DEPRECATED_BEHAVIOR)
         {

--- a/tests/attrs.rs
+++ b/tests/attrs.rs
@@ -49,8 +49,8 @@ fn attribute_types_mismatch() {
     target.draw(&vertex_buffer, &index_buffer, &program, &glium::uniforms::EmptyUniforms,
                 &std::default::Default::default()).unwrap();
     target.finish();
-    
-    display.assert_no_error();
+
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -96,8 +96,8 @@ fn missing_attribute() {
     target.draw(&vertex_buffer, &index_buffer, &program, &glium::uniforms::EmptyUniforms,
                 &std::default::Default::default()).unwrap();
     target.finish();
-    
-    display.assert_no_error();
+
+    display.assert_no_error(None);
 }
 
 macro_rules! attribute_test(
@@ -143,8 +143,8 @@ macro_rules! attribute_test(
             target.draw(&vertex_buffer, &index_buffer, &program, &glium::uniforms::EmptyUniforms,
                         &std::default::Default::default()).unwrap();
             target.finish();
-            
-            display.assert_no_error();
+
+            display.assert_no_error(None);
         }
 
     )

--- a/tests/backface-culling.rs
+++ b/tests/backface-culling.rs
@@ -62,8 +62,8 @@ fn cull_clockwise() {
     let read_back: Vec<Vec<(f32, f32, f32, f32)>> = texture.read();
     assert_eq!(read_back[0].last().unwrap(), &(1.0, 0.0, 0.0, 1.0));
     assert_eq!(read_back.last().unwrap()[0], (0.0, 0.0, 0.0, 0.0));
-    
-    display.assert_no_error();
+
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -122,8 +122,8 @@ fn cull_counterclockwise() {
     let read_back: Vec<Vec<(f32, f32, f32, f32)>> = texture.read();
     assert_eq!(read_back[0].last().unwrap(), &(0.0, 0.0, 0.0, 0.0));
     assert_eq!(read_back.last().unwrap()[0], (1.0, 0.0, 0.0, 1.0));
-    
-    display.assert_no_error();
+
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -181,8 +181,8 @@ fn cull_clockwise_trianglestrip() {
     let read_back: Vec<Vec<(f32, f32, f32, f32)>> = texture.read();
     assert_eq!(read_back[0][0], (0.0, 0.0, 0.0, 0.0));
     assert_eq!(read_back.last().unwrap().last().unwrap(), &(0.0, 0.0, 0.0, 0.0));
-    
-    display.assert_no_error();
+
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -240,6 +240,6 @@ fn cull_counterclockwise_trianglestrip() {
     let read_back: Vec<Vec<(f32, f32, f32, f32)>> = texture.read();
     assert_eq!(read_back[0][0], (1.0, 0.0, 0.0, 1.0));
     assert_eq!(read_back.last().unwrap().last().unwrap(), &(1.0, 0.0, 0.0, 1.0));
-    
-    display.assert_no_error();
+
+    display.assert_no_error(None);
 }

--- a/tests/blending.rs
+++ b/tests/blending.rs
@@ -53,7 +53,7 @@ macro_rules! blending_test {
                 }
             }
 
-            display.assert_no_error();
+            display.assert_no_error(None);
         }
     )
 }

--- a/tests/blit.rs
+++ b/tests/blit.rs
@@ -62,6 +62,6 @@ fn blit_texture_to_window() {
     assert_eq!(data[1][3], (0.0, 0.0, 0.0));
 
     assert_eq!(data[3][3], (0.0, 0.0, 0.0));
-    
-    display.assert_no_error();
+
+    display.assert_no_error(None);
 }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -11,7 +11,7 @@ mod support;
 fn get_opengl_version() {
     let display = support::build_display();
     let version = display.get_opengl_version();
-    display.assert_no_error();
+    display.assert_no_error(None);
 
     assert!(version.1 >= 1);
 }
@@ -31,14 +31,14 @@ fn clear_color() {
         }
     }
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
 fn release_shader_compiler() {
     let display = support::build_display();
     display.release_shader_compiler();
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -56,13 +56,13 @@ fn viewport_too_large() {
     };
 
     let (vb, ib, program) = support::build_fullscreen_red_pipeline(&display);
-    
+
     match display.draw().draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params) {
         Err(glium::DrawError::ViewportTooLarge) => (),
         a => panic!("{:?}", a)
     };
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -80,7 +80,7 @@ fn timestamp_query() {
         _ => ()
     };
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -93,13 +93,13 @@ fn wrong_depth_range() {
     };
 
     let (vb, ib, program) = support::build_fullscreen_red_pipeline(&display);
-    
+
     match display.draw().draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params) {
         Err(glium::DrawError::InvalidDepthRange) => (),
         a => panic!("{:?}", a)
     };
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -135,17 +135,17 @@ fn scissor() {
         }
     }
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
-fn sync() {    
+fn sync() {
     let display = support::build_display();
 
     let fence = glium::SyncFence::new_if_supported(&display);
     fence.map(|f| f.wait());
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -177,7 +177,7 @@ fn scissor_followed_by_clear() {
         }
     }
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -209,7 +209,7 @@ fn viewport_followed_by_clear() {
         }
     }
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -245,7 +245,7 @@ fn viewport() {
         }
     }
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -274,7 +274,7 @@ fn dont_draw_primitives() {
         }
     }
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -304,7 +304,7 @@ fn dont_draw_primitives_then_draw() {
         }
     }
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -342,8 +342,8 @@ fn multiple_displays() {
         }
     }
 
-    display1.assert_no_error();
-    display2.assert_no_error();
+    display1.assert_no_error(None);
+    display2.assert_no_error(None);
 }
 
 #[test]

--- a/tests/framebuffer.rs
+++ b/tests/framebuffer.rs
@@ -27,7 +27,7 @@ fn no_depth_buffer_depth_test() {
         a => panic!("{:?}", a)
     };
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -51,7 +51,7 @@ fn no_depth_buffer_depth_write() {
         a => panic!("{:?}", a)
     };
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -65,7 +65,7 @@ fn simple_dimensions() {
     let framebuffer = glium::framebuffer::SimpleFrameBuffer::new(&display, &texture);
     assert_eq!(framebuffer.get_dimensions(), (128, 128));
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -87,8 +87,8 @@ fn simple_render_to_texture() {
     assert_eq!(read_back[0][0], (1.0, 0.0, 0.0, 1.0));
     assert_eq!(read_back[64][64], (1.0, 0.0, 0.0, 1.0));
     assert_eq!(read_back[127][127], (1.0, 0.0, 0.0, 1.0));
-    
-    display.assert_no_error();
+
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -167,7 +167,7 @@ fn depth_texture2d() {
     assert_eq!(read_back[0][0], (1.0, 1.0, 1.0, 1.0));
     assert_eq!(read_back[127][127], (0.0, 0.0, 0.0, 1.0));
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -238,5 +238,5 @@ fn multioutput() {
     }
 
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }

--- a/tests/indices.rs
+++ b/tests/indices.rs
@@ -56,7 +56,7 @@ struct Vertex {
 implement_vertex!(Vertex, position);
 
 #[test]
-fn triangles_list_cpu() {    
+fn triangles_list_cpu() {
     let display = support::build_display();
     let program = build_program(&display);
 
@@ -77,7 +77,7 @@ fn triangles_list_cpu() {
     assert_eq!(data[0][0], (255, 0, 0));
     assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0));
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn triangle_strip_cpu() {
     assert_eq!(data[0][0], (255, 0, 0));
     assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0));
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn triangle_fan_cpu() {
     assert_eq!(data[0][0], (255, 0, 0));
     assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0));
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -154,7 +154,7 @@ fn triangles_list_gpu() {
     assert_eq!(data[0][0], (255, 0, 0));
     assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0));
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -179,8 +179,8 @@ fn triangle_strip_gpu() {
 
     assert_eq!(data[0][0], (255, 0, 0));
     assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0));
-    
-    display.assert_no_error();
+
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -206,8 +206,8 @@ fn triangle_fan_gpu() {
 
     assert_eq!(data[0][0], (255, 0, 0));
     assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0));
-    
-    display.assert_no_error();
+
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -219,7 +219,7 @@ fn get_primitives_type() {
 
     assert_eq!(indices.get_primitives_type(), glium::index::PrimitiveType::TriangleStrip);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -231,7 +231,7 @@ fn get_indices_type_u8() {
 
     assert_eq!(indices.get_indices_type(), glium::index::IndexType::U8);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -243,7 +243,7 @@ fn get_indices_type_u16() {
 
     assert_eq!(indices.get_indices_type(), glium::index::IndexType::U16);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -255,11 +255,11 @@ fn get_indices_type_u32() {
 
     assert_eq!(indices.get_indices_type(), glium::index::IndexType::U32);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
-fn triangles_list_noindices() {    
+fn triangles_list_noindices() {
     let display = support::build_display();
     let program = build_program(&display);
 
@@ -283,7 +283,7 @@ fn triangles_list_noindices() {
     assert_eq!(data[0][0], (255, 0, 0));
     assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0));
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -309,7 +309,7 @@ fn triangle_strip_noindices() {
     assert_eq!(data[0][0], (255, 0, 0));
     assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0));
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -337,7 +337,7 @@ fn triangle_fan_noindices() {
     assert_eq!(data[0][0], (255, 0, 0));
     assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0));
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -347,11 +347,11 @@ fn empty_index_buffer() {
     let indices = glium::index::TriangleFan(Vec::<u16>::new());
     let _indices = glium::IndexBuffer::new(&display, indices);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
-fn indexbuffer_slice_out_of_range() {    
+fn indexbuffer_slice_out_of_range() {
     let display = support::build_display();
 
     let indices = glium::index::TrianglesList(vec![0u16, 1, 2, 2, 1, 3]);
@@ -361,11 +361,11 @@ fn indexbuffer_slice_out_of_range() {
     assert!(indices.slice(2 .. 11).is_none());
     assert!(indices.slice(12 .. 13).is_none());
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
-fn indexbuffer_slice_draw() {    
+fn indexbuffer_slice_draw() {
     let display = support::build_display();
     let program = build_program(&display);
 
@@ -397,5 +397,5 @@ fn indexbuffer_slice_draw() {
     assert_eq!(data.last().unwrap().last().unwrap(), &(0, 0, 0));
 
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }

--- a/tests/instancing.rs
+++ b/tests/instancing.rs
@@ -19,7 +19,7 @@ fn instancing() {
 
         implement_vertex!(Vertex, position);
 
-        glium::VertexBuffer::new(&display, 
+        glium::VertexBuffer::new(&display,
             vec![
                 Vertex { position: [-1.0,  1.0] },
                 Vertex { position: [ 1.0,  1.0] },
@@ -37,7 +37,7 @@ fn instancing() {
 
         implement_vertex!(Vertex, color);
 
-        glium::vertex::VertexBuffer::new(&display, 
+        glium::vertex::VertexBuffer::new(&display,
             vec![
                 Vertex { color: [0.0, 0.0, 1.0] },
                 Vertex { color: [0.0, 0.0, 1.0] },
@@ -101,7 +101,7 @@ fn instancing() {
         }
     }
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn per_instance_length_mismatch() {
 
         implement_vertex!(Vertex, position);
 
-        glium::VertexBuffer::new(&display, 
+        glium::VertexBuffer::new(&display,
             vec![
                 Vertex { position: [-1.0,  1.0] },
                 Vertex { position: [ 1.0,  1.0] },
@@ -134,7 +134,7 @@ fn per_instance_length_mismatch() {
 
         implement_vertex!(Vertex, color);
 
-        glium::vertex::VertexBuffer::new(&display, 
+        glium::vertex::VertexBuffer::new(&display,
             vec![
                 Vertex { color: [0.0, 0.0, 1.0] },
                 Vertex { color: [0.0, 0.0, 1.0] },
@@ -157,7 +157,7 @@ fn per_instance_length_mismatch() {
 
         implement_vertex!(Vertex, color);
 
-        glium::vertex::VertexBuffer::new(&display, 
+        glium::vertex::VertexBuffer::new(&display,
             vec![
                 Vertex { color: [0.0, 0.0, 1.0] },
                 Vertex { color: [0.0, 0.0, 1.0] },
@@ -215,5 +215,5 @@ fn per_instance_length_mismatch() {
         a => panic!("{:?}", a)
     }
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }

--- a/tests/samplers.rs
+++ b/tests/samplers.rs
@@ -14,7 +14,7 @@ fn magnify_nearest_filtering() {
     if ::std::env::var("TRAVIS").is_ok() {
         return;
     }
-    
+
     let display = support::build_display();
     let (vb, ib) = support::build_rectangle_vb_ib(&display);
 
@@ -80,5 +80,5 @@ fn magnify_nearest_filtering() {
     let data: Vec<Vec<(u8, u8, u8)>> = output.read();
     assert_eq!(data[0][0], (255, 255, 255));
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }

--- a/tests/shaders.rs
+++ b/tests/shaders.rs
@@ -47,7 +47,7 @@ fn program_creation() {
         // geometry shader
         None).unwrap();
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -77,7 +77,7 @@ fn program_compilation_error() {
         _ => panic!()
     };
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 // This test is disabled because some OpenGL drivers don't catch
@@ -118,12 +118,12 @@ fn program_linking_error() {
         Err(glium::LinkingError(_)) => (),
         _ => panic!()
     };
-    
-    display.assert_no_error();
+
+    display.assert_no_error(None);
 }
 
 #[test]
-fn get_frag_data_location() {    
+fn get_frag_data_location() {
     let display = support::build_display();
 
     let program = glium::Program::from_source(&display,
@@ -153,12 +153,12 @@ fn get_frag_data_location() {
 
     assert!(program.get_frag_data_location("color").is_some());
     assert!(program.get_frag_data_location("unexisting").is_none());
-    
-    display.assert_no_error();
+
+    display.assert_no_error(None);
 }
 
 #[test]
-fn get_uniform_blocks() {    
+fn get_uniform_blocks() {
     let display = support::build_display();
 
     let program = glium::Program::from_source(&display,
@@ -213,7 +213,7 @@ fn get_uniform_blocks() {
     assert_eq!(members[1].size, Some(12));
     assert!(members[1].offset >= 4 * 3);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -254,7 +254,7 @@ fn get_program_binary() {
 
     assert!(binary.content.len() >= 1);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -295,7 +295,7 @@ fn program_binary_reload() {
 
     let _program2 = glium::Program::new(&display, binary).unwrap();
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -341,11 +341,11 @@ fn program_binary_working() {
         }
     }
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
-fn get_transform_feedback_varyings() {    
+fn get_transform_feedback_varyings() {
     let display = support::build_display();
 
     let source = glium::program::ProgramCreationInput::SourceCode {
@@ -414,5 +414,5 @@ fn get_transform_feedback_varyings() {
 
     assert_eq!(program.get_transform_feedback_buffers().len(), 2);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }

--- a/tests/texture_creation.rs
+++ b/tests/texture_creation.rs
@@ -14,13 +14,13 @@ fn empty_texture1d_u8u8u8u8() {
                                                        glium::texture::UncompressedFloatFormat::
                                                            U8U8U8U8, 128);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
     drop(texture);
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
-fn depth_texture_1d_creation() {    
+fn depth_texture_1d_creation() {
     let display = support::build_display();
 
     let texture = match glium::texture::DepthTexture1d::new_if_supported(&display, vec![0.0, 0.0, 0.0, 0.0f32]) {
@@ -33,11 +33,11 @@ fn depth_texture_1d_creation() {
     assert_eq!(texture.get_depth(), None);
     assert_eq!(texture.get_array_size(), None);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
-fn texture_2d_creation() {    
+fn texture_2d_creation() {
     let display = support::build_display();
 
     let texture = glium::texture::Texture2d::new(&display, vec![
@@ -51,7 +51,7 @@ fn texture_2d_creation() {
     assert_eq!(texture.get_depth(), None);
     assert_eq!(texture.get_array_size(), None);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -63,13 +63,13 @@ fn empty_texture2d_u8u8u8u8() {
                                                            U8U8U8U8,
                                                        128, 128);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
     drop(texture);
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
-fn depth_texture_2d_creation() {    
+fn depth_texture_2d_creation() {
     let display = support::build_display();
 
     let texture = glium::texture::DepthTexture2d::new_if_supported(&display, vec![
@@ -88,7 +88,7 @@ fn depth_texture_2d_creation() {
     assert_eq!(texture.get_depth(), None);
     assert_eq!(texture.get_array_size(), None);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -100,9 +100,9 @@ fn empty_depth_texture2d_f32() {
                                                             glium::texture::DepthFormat::F32,
                                                             128, 128);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
     drop(texture);
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -120,7 +120,7 @@ fn compressed_texture_2d_creation() {
     assert_eq!(texture.get_depth(), None);
     assert_eq!(texture.get_array_size(), None);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 macro_rules! empty_texture_test {
@@ -140,9 +140,9 @@ macro_rules! empty_texture_test {
 
             assert_eq!(texture.get_mipmap_levels(), 1);
 
-            display.assert_no_error();
+            display.assert_no_error(None);
             drop(texture);
-            display.assert_no_error();
+            display.assert_no_error(None);
         }
     );
 
@@ -165,9 +165,9 @@ macro_rules! empty_texture_test {
 
             assert_eq!(texture.get_mipmap_levels(), 1);
 
-            display.assert_no_error();
+            display.assert_no_error(None);
             drop(texture);
-            display.assert_no_error();
+            display.assert_no_error(None);
         }
     );
 }
@@ -217,7 +217,7 @@ empty_texture_test!(empty_unsignedtexture2darray, maybe UnsignedTexture2dArray, 
 empty_texture_test!(empty_unsignedtexture3d, maybe UnsignedTexture3d, [64, 32, 16], 64, Some(32), Some(16), None);
 
 #[test]
-fn zero_sized_texture_1d_creation() {    
+fn zero_sized_texture_1d_creation() {
     let display = support::build_display();
 
     let texture = match glium::texture::Texture1d::new_if_supported(&display, Vec::<(u8, u8, u8, u8)>::new()) {
@@ -230,11 +230,11 @@ fn zero_sized_texture_1d_creation() {
     assert_eq!(texture.get_depth(), None);
     assert_eq!(texture.get_array_size(), None);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
-fn zero_sized_texture_2d_creation() {    
+fn zero_sized_texture_2d_creation() {
     let display = support::build_display();
 
     let texture = glium::texture::Texture2d::new(&display, Vec::<Vec<(u8, u8, u8, u8)>>::new());
@@ -244,11 +244,11 @@ fn zero_sized_texture_2d_creation() {
     assert_eq!(texture.get_depth(), None);
     assert_eq!(texture.get_array_size(), None);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
-fn zero_sized_texture_3d_creation() {    
+fn zero_sized_texture_3d_creation() {
     let display = support::build_display();
 
     let texture = match glium::texture::Texture3d::new_if_supported(&display, Vec::<Vec<Vec<(u8, u8, u8, u8)>>>::new()) {
@@ -261,5 +261,5 @@ fn zero_sized_texture_3d_creation() {
     assert_eq!(texture.get_depth(), Some(0));
     assert_eq!(texture.get_array_size(), None);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }

--- a/tests/texture_draw.rs
+++ b/tests/texture_draw.rs
@@ -48,7 +48,7 @@ macro_rules! texture_draw_test {
             texture.as_surface().draw(&vb, &ib, &program, &uniform!{ texture: &texture },
                                      &Default::default()).unwrap();
 
-            display.assert_no_error();
+            display.assert_no_error(None);
 
             let data: Vec<Vec<(f32, f32, f32, f32)>> = texture.read();
             for row in data.iter() {
@@ -57,7 +57,7 @@ macro_rules! texture_draw_test {
                 }
             }
 
-            display.assert_no_error();
+            display.assert_no_error(None);
         }
     );
 }

--- a/tests/texture_read.rs
+++ b/tests/texture_read.rs
@@ -10,7 +10,7 @@ fn empty_pixel_buffer() {
     let display = support::build_display();
 
     let pixel_buffer = glium::pixel_buffer::PixelBuffer::new_empty(&display, 128 * 128);
-    display.assert_no_error();
+    display.assert_no_error(None);
 
     let _: Vec<Vec<(u8, u8, u8)>> = pixel_buffer.read_if_supported().unwrap();
 }
@@ -36,7 +36,7 @@ fn texture_2d_read_pixelbuffer() {
     assert_eq!(read_back[1][0], (32, 64, 128));
     assert_eq!(read_back[1][1], (32, 16, 4));
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 macro_rules! read_texture_test {
@@ -51,7 +51,7 @@ macro_rules! read_texture_test {
 
             assert_eq!(read_back, $data);
 
-            display.assert_no_error();
+            display.assert_no_error(None);
         }
     );
 
@@ -69,7 +69,7 @@ macro_rules! read_texture_test {
 
             assert_eq!(read_back, $data);
 
-            display.assert_no_error();
+            display.assert_no_error(None);
         }
     );
 }

--- a/tests/texture_sample.rs
+++ b/tests/texture_sample.rs
@@ -53,7 +53,7 @@ macro_rules! texture_sample_test {
                 }
             }
 
-            display.assert_no_error();
+            display.assert_no_error(None);
         }
     );
 }

--- a/tests/texture_write.rs
+++ b/tests/texture_write.rs
@@ -23,5 +23,5 @@ fn texture_2d_write() {
     assert_eq!(read_back[1][0], (32, 64, 128));
     assert_eq!(read_back[1][1], (128, 64, 2));
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }

--- a/tests/uniform_buffer.rs
+++ b/tests/uniform_buffer.rs
@@ -14,7 +14,7 @@ fn uniform_buffer_creation() {
 
     glium::uniforms::UniformBuffer::new_if_supported(&display, 12);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -29,7 +29,7 @@ fn uniform_buffer_mapping_read() {
     let mapping = vb.map();
     assert_eq!(*mapping, 12);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -49,7 +49,7 @@ fn uniform_buffer_mapping_write() {
     let mapping = vb.map();
     assert_eq!(*mapping, 15);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -68,7 +68,7 @@ fn uniform_buffer_read() {
 
     assert_eq!(data, 12);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -89,7 +89,7 @@ fn uniform_buffer_write() {
 
     assert_eq!(data, 24);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -148,7 +148,7 @@ fn block() {
         }
     }
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -198,14 +198,14 @@ fn block_wrong_type() {
 
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
-    
+
     match target.draw(&vb, &ib, &program, &uniforms, &Default::default()) {
         Err(glium::DrawError::UniformBlockLayoutMismatch { ref name })
             if name == &"MyBlock" => (),
         a => panic!("{:?}", a)
     }
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -225,7 +225,7 @@ fn buffer_write() {
     let mapping = buf.map();
     assert_eq!(*mapping, (5, 8));
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -308,7 +308,7 @@ fn persistent_block_race_condition() {
         }
     }
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -320,5 +320,5 @@ fn empty_uniform_buffer() {
         Some(b) => b
     };
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }

--- a/tests/uniforms.rs
+++ b/tests/uniforms.rs
@@ -15,7 +15,7 @@ struct Vertex {
 implement_vertex!(Vertex, position);
 
 #[test]
-fn uniforms_storage_single_value() {    
+fn uniforms_storage_single_value() {
     let display = support::build_display();
     let (vb, ib) = support::build_rectangle_vb_ib(&display);
 
@@ -50,11 +50,11 @@ fn uniforms_storage_single_value() {
     assert_eq!(data[0][0], (255, 0, 0));
     assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0));
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
-fn uniforms_storage_multiple_values() {    
+fn uniforms_storage_multiple_values() {
     let display = support::build_display();
     let (vb, ib) = support::build_rectangle_vb_ib(&display);
 
@@ -91,11 +91,11 @@ fn uniforms_storage_multiple_values() {
     assert_eq!(data[0][0], (255, 0, 0));
     assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0));
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
-fn uniforms_storage_ignore_inactive_uniforms() {    
+fn uniforms_storage_ignore_inactive_uniforms() {
     let display = support::build_display();
     let (vb, ib) = support::build_rectangle_vb_ib(&display);
 
@@ -131,12 +131,12 @@ fn uniforms_storage_ignore_inactive_uniforms() {
     let data: Vec<Vec<(u8, u8, u8)>> = texture.read();
     assert_eq!(data[0][0], (255, 0, 0));
     assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0));
-    
-    display.assert_no_error();
+
+    display.assert_no_error(None);
 }
 
 #[test]
-fn uniform_wrong_type() {    
+fn uniform_wrong_type() {
     let display = support::build_display();
     let (vb, ib) = support::build_rectangle_vb_ib(&display);
 
@@ -171,5 +171,5 @@ fn uniform_wrong_type() {
     };
     target.finish();
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }

--- a/tests/vertex_buffer.rs
+++ b/tests/vertex_buffer.rs
@@ -20,7 +20,7 @@ fn vertex_buffer_immutable_creation() {
 
     implement_vertex!(Vertex, field1, field2);
 
-    glium::VertexBuffer::new(&display, 
+    glium::VertexBuffer::new(&display,
         vec![
             Vertex { field1: [-0.5, -0.5, 0.0], field2: [0.0, 1.0, 0.0] },
             Vertex { field1: [ 0.0,  0.5, 1.0], field2: [0.0, 0.0, 1.0] },
@@ -28,7 +28,7 @@ fn vertex_buffer_immutable_creation() {
         ]
     );
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -43,7 +43,7 @@ fn vertex_buffer_dynamic_creation() {
 
     implement_vertex!(Vertex, field1, field2);
 
-    glium::VertexBuffer::dynamic(&display, 
+    glium::VertexBuffer::dynamic(&display,
         vec![
             Vertex { field1: [-0.5, -0.5, 0.0], field2: [0.0, 1.0, 0.0] },
             Vertex { field1: [ 0.0,  0.5, 1.0], field2: [0.0, 0.0, 1.0] },
@@ -51,7 +51,7 @@ fn vertex_buffer_dynamic_creation() {
         ]
     );
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn vertex_buffer_immutable_empty_creation() {
     let vb: glium::VertexBuffer<Vertex> = glium::VertexBuffer::empty(&display, 12);
     assert_eq!(vb.len(), 12);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -87,7 +87,7 @@ fn vertex_buffer_dynamic_empty_creation() {
     let vb: glium::VertexBuffer<Vertex> = glium::VertexBuffer::empty_dynamic(&display, 12);
     assert_eq!(vb.len(), 12);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn vertex_buffer_immutable_mapping_read() {
 
     implement_vertex!(Vertex, field1, field2);
 
-    let mut vb = glium::VertexBuffer::new(&display, 
+    let mut vb = glium::VertexBuffer::new(&display,
         vec![
             Vertex { field1: [ 2,  3], field2: [ 5,  7] },
             Vertex { field1: [12, 13], field2: [15, 17] },
@@ -113,7 +113,7 @@ fn vertex_buffer_immutable_mapping_read() {
     assert_eq!(mapping[0].field1, [2, 3]);
     assert_eq!(mapping[1].field2, [15, 17]);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn vertex_buffer_dynamic_mapping_read() {
 
     implement_vertex!(Vertex, field1, field2);
 
-    let mut vb = glium::VertexBuffer::dynamic(&display, 
+    let mut vb = glium::VertexBuffer::dynamic(&display,
         vec![
             Vertex { field1: [ 2,  3], field2: [ 5,  7] },
             Vertex { field1: [12, 13], field2: [15, 17] },
@@ -139,13 +139,13 @@ fn vertex_buffer_dynamic_mapping_read() {
     assert_eq!(mapping[0].field1, [2, 3]);
     assert_eq!(mapping[1].field2, [15, 17]);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
 fn vertex_buffer_immutable_mapping_write() {
     let display = support::build_display();
-    
+
     #[derive(Copy, Clone)]
     struct Vertex {
         field1: [u8; 2],
@@ -154,7 +154,7 @@ fn vertex_buffer_immutable_mapping_write() {
 
     implement_vertex!(Vertex, field1, field2);
 
-    let mut vb = glium::VertexBuffer::new(&display, 
+    let mut vb = glium::VertexBuffer::new(&display,
         vec![
             Vertex { field1: [ 2,  3], field2: [ 5,  7] },
             Vertex { field1: [12, 13], field2: [15, 17] },
@@ -170,13 +170,13 @@ fn vertex_buffer_immutable_mapping_write() {
     assert_eq!(mapping[0].field1, [0, 1]);
     assert_eq!(mapping[1].field2, [15, 17]);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
 fn vertex_buffer_dynamic_mapping_write() {
     let display = support::build_display();
-    
+
     #[derive(Copy, Clone)]
     struct Vertex {
         field1: [u8; 2],
@@ -185,7 +185,7 @@ fn vertex_buffer_dynamic_mapping_write() {
 
     implement_vertex!(Vertex, field1, field2);
 
-    let mut vb = glium::VertexBuffer::dynamic(&display, 
+    let mut vb = glium::VertexBuffer::dynamic(&display,
         vec![
             Vertex { field1: [ 2,  3], field2: [ 5,  7] },
             Vertex { field1: [12, 13], field2: [15, 17] },
@@ -201,14 +201,14 @@ fn vertex_buffer_dynamic_mapping_write() {
     assert_eq!(mapping[0].field1, [0, 1]);
     assert_eq!(mapping[1].field2, [15, 17]);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 // TODO: uncomment after std::thread::scoped has been stabilized
 /*#[test]
 fn vertex_buffer_mapping_multithread() {
     let display = support::build_display();
-    
+
     #[derive(Copy, Clone)]
     struct Vertex {
         field1: [u8; 2],
@@ -231,7 +231,7 @@ fn vertex_buffer_mapping_multithread() {
     assert_eq!(mapping[0].field1, [0, 1]);
     assert_eq!(mapping[1].field2, [15, 17]);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }*/
 
 #[test]
@@ -246,7 +246,7 @@ fn vertex_buffer_immutable_read() {
 
     implement_vertex!(Vertex, field1, field2);
 
-    let vb = glium::VertexBuffer::new(&display, 
+    let vb = glium::VertexBuffer::new(&display,
         vec![
             Vertex { field1: [ 2,  3], field2: [ 5,  7] },
             Vertex { field1: [12, 13], field2: [15, 17] },
@@ -261,7 +261,7 @@ fn vertex_buffer_immutable_read() {
     assert_eq!(data[0].field1, [2, 3]);
     assert_eq!(data[1].field2, [15, 17]);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -276,7 +276,7 @@ fn vertex_buffer_dynamic_read() {
 
     implement_vertex!(Vertex, field1, field2);
 
-    let vb = glium::VertexBuffer::dynamic(&display, 
+    let vb = glium::VertexBuffer::dynamic(&display,
         vec![
             Vertex { field1: [ 2,  3], field2: [ 5,  7] },
             Vertex { field1: [12, 13], field2: [15, 17] },
@@ -291,7 +291,7 @@ fn vertex_buffer_dynamic_read() {
     assert_eq!(data[0].field1, [2, 3]);
     assert_eq!(data[1].field2, [15, 17]);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -306,7 +306,7 @@ fn vertex_buffer_immutable_read_slice() {
 
     implement_vertex!(Vertex, field1, field2);
 
-    let vb = glium::VertexBuffer::new(&display, 
+    let vb = glium::VertexBuffer::new(&display,
         vec![
             Vertex { field1: [ 2,  3], field2: [ 5,  7] },
             Vertex { field1: [12, 13], field2: [15, 17] },
@@ -319,8 +319,8 @@ fn vertex_buffer_immutable_read_slice() {
     };
 
     assert_eq!(data[0].field2, [15, 17]);
-    
-    display.assert_no_error();
+
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -335,7 +335,7 @@ fn vertex_buffer_dynamic_read_slice() {
 
     implement_vertex!(Vertex, field1, field2);
 
-    let vb = glium::VertexBuffer::dynamic(&display, 
+    let vb = glium::VertexBuffer::dynamic(&display,
         vec![
             Vertex { field1: [ 2,  3], field2: [ 5,  7] },
             Vertex { field1: [12, 13], field2: [15, 17] },
@@ -348,8 +348,8 @@ fn vertex_buffer_dynamic_read_slice() {
     };
 
     assert_eq!(data[0].field2, [15, 17]);
-    
-    display.assert_no_error();
+
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -364,7 +364,7 @@ fn vertex_buffer_slice_out_of_bounds() {
 
     implement_vertex!(Vertex, field1, field2);
 
-    let vb = glium::VertexBuffer::new(&display, 
+    let vb = glium::VertexBuffer::new(&display,
         vec![
             Vertex { field1: [ 2,  3], field2: [ 5,  7] },
             Vertex { field1: [12, 13], field2: [15, 17] },
@@ -373,7 +373,7 @@ fn vertex_buffer_slice_out_of_bounds() {
 
     assert!(vb.slice(0 .. 3).is_none());
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -388,7 +388,7 @@ fn vertex_buffer_any() {
 
     implement_vertex!(Vertex, field1, field2);
 
-    glium::VertexBuffer::new(&display, 
+    glium::VertexBuffer::new(&display,
         vec![
             Vertex { field1: [-0.5, -0.5, 0.0], field2: [0.0, 1.0, 0.0] },
             Vertex { field1: [ 0.0,  0.5, 1.0], field2: [0.0, 0.0, 1.0] },
@@ -396,13 +396,13 @@ fn vertex_buffer_any() {
         ]
     ).into_vertex_buffer_any();
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
 fn vertex_buffer_immutable_write() {
     let display = support::build_display();
-    
+
     #[derive(Copy, Clone)]
     struct Vertex {
         field1: [u8; 2],
@@ -411,7 +411,7 @@ fn vertex_buffer_immutable_write() {
 
     implement_vertex!(Vertex, field1, field2);
 
-    let vb = glium::VertexBuffer::new(&display, 
+    let vb = glium::VertexBuffer::new(&display,
         vec![
             Vertex { field1: [ 2,  3], field2: [ 5,  7] },
             Vertex { field1: [ 0,  0], field2: [ 0,  0] },
@@ -433,13 +433,13 @@ fn vertex_buffer_immutable_write() {
     assert_eq!(data[1].field1, [12, 13]);
     assert_eq!(data[1].field2, [15, 17]);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
 fn vertex_buffer_dynamic_write() {
     let display = support::build_display();
-    
+
     #[derive(Copy, Clone)]
     struct Vertex {
         field1: [u8; 2],
@@ -448,7 +448,7 @@ fn vertex_buffer_dynamic_write() {
 
     implement_vertex!(Vertex, field1, field2);
 
-    let vb = glium::VertexBuffer::dynamic(&display, 
+    let vb = glium::VertexBuffer::dynamic(&display,
         vec![
             Vertex { field1: [ 2,  3], field2: [ 5,  7] },
             Vertex { field1: [ 0,  0], field2: [ 0,  0] },
@@ -470,13 +470,13 @@ fn vertex_buffer_dynamic_write() {
     assert_eq!(data[1].field1, [12, 13]);
     assert_eq!(data[1].field2, [15, 17]);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
 fn vertex_buffer_immutable_write_slice() {
     let display = support::build_display();
-    
+
     #[derive(Copy, Clone)]
     struct Vertex {
         field1: [u8; 2],
@@ -485,7 +485,7 @@ fn vertex_buffer_immutable_write_slice() {
 
     implement_vertex!(Vertex, field1, field2);
 
-    let vb = glium::VertexBuffer::new(&display, 
+    let vb = glium::VertexBuffer::new(&display,
         vec![
             Vertex { field1: [ 2,  3], field2: [ 5,  7] },
             Vertex { field1: [ 0,  0], field2: [ 0,  0] },
@@ -504,13 +504,13 @@ fn vertex_buffer_immutable_write_slice() {
     assert_eq!(data[1].field1, [12, 13]);
     assert_eq!(data[1].field2, [15, 17]);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
 fn vertex_buffer_dynamic_write_slice() {
     let display = support::build_display();
-    
+
     #[derive(Copy, Clone)]
     struct Vertex {
         field1: [u8; 2],
@@ -519,7 +519,7 @@ fn vertex_buffer_dynamic_write_slice() {
 
     implement_vertex!(Vertex, field1, field2);
 
-    let vb = glium::VertexBuffer::dynamic(&display, 
+    let vb = glium::VertexBuffer::dynamic(&display,
         vec![
             Vertex { field1: [ 2,  3], field2: [ 5,  7] },
             Vertex { field1: [ 0,  0], field2: [ 0,  0] },
@@ -538,7 +538,7 @@ fn vertex_buffer_dynamic_write_slice() {
     assert_eq!(data[1].field1, [12, 13]);
     assert_eq!(data[1].field2, [15, 17]);
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -555,7 +555,7 @@ fn zero_sized_immutable_vertex_buffer() {
 
     glium::VertexBuffer::new(&display, Vec::<Vertex>::new());
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -572,5 +572,5 @@ fn zero_sized_dynamic_vertex_buffer() {
 
     glium::VertexBuffer::new(&display, Vec::<Vertex>::new());
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }

--- a/tests/vertex_source.rs
+++ b/tests/vertex_source.rs
@@ -20,7 +20,7 @@ fn multiple_buffers_source() {
 
         implement_vertex!(Vertex, position);
 
-        glium::VertexBuffer::new(&display, 
+        glium::VertexBuffer::new(&display,
             vec![
                 Vertex { position: [-1.0,  1.0] },
                 Vertex { position: [ 1.0,  1.0] },
@@ -38,7 +38,7 @@ fn multiple_buffers_source() {
 
         implement_vertex!(Vertex, color);
 
-        glium::VertexBuffer::new(&display, 
+        glium::VertexBuffer::new(&display,
             vec![
                 Vertex { color: [1.0, 0.0, 0.0] },
                 Vertex { color: [1.0, 0.0, 0.0] },
@@ -110,8 +110,8 @@ fn multiple_buffers_source() {
             assert_eq!(pixel, &(1.0, 0.0, 0.0, 1.0));
         }
     }
-    
-    display.assert_no_error();
+
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -179,7 +179,7 @@ fn slice_draw_indices() {
     assert_eq!(data.last().unwrap()[0], (0, 0, 0));
     assert_eq!(data[0].last().unwrap(), &(255, 0, 0));
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -246,7 +246,7 @@ fn slice_draw_noindices() {
     assert_eq!(data.last().unwrap()[0], (0, 0, 0));
     assert_eq!(data[0].last().unwrap(), &(255, 0, 0));
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -342,7 +342,7 @@ fn slice_draw_multiple() {
     assert_eq!(data.last().unwrap()[0], (0, 0, 0));
     assert_eq!(data[0].last().unwrap(), &(255, 0, 0));
 
-    display.assert_no_error();
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -392,8 +392,8 @@ fn attributes_marker() {
             assert_eq!(pixel, &(1.0, 0.0, 0.0, 1.0));
         }
     }
-    
-    display.assert_no_error();
+
+    display.assert_no_error(None);
 }
 
 #[test]
@@ -444,6 +444,6 @@ fn attributes_marker_indices() {
             assert_eq!(pixel, &(1.0, 0.0, 0.0, 1.0));
         }
     }
-    
-    display.assert_no_error();
+
+    display.assert_no_error(None);
 }


### PR DESCRIPTION
This is useful when assert_no_error() fails and you are trying
to find out where in the codebase the error is coming from.

I've been using this change to place assertions in various places
like so:

```rust
display.assert_no_error(Some("error after display creation"));
...
display.assert_no_error(Some("error before draw"));
...

```