### PR TITLE
Re-export glutin from glium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+ - Glium now reexports glutin. You can access glutin with `glium::glutin`.
+
 ## Version 0.3.4 (2015-04-28)
 
  - Added caching some uniform values in the `Program` struct to avoid calls to `glUniform`.

--- a/doc/tutorials/01-getting-started.md
+++ b/doc/tutorials/01-getting-started.md
@@ -15,17 +15,15 @@ To start this tutorial, we will create a new project from scratch. Even though i
 
 The directory you have just created should contain a `Cargo.toml` file which contains our project's metadata, plus a `src/main.rs` file which contains the Rust source code. If you have `src/lib.rs` file instead, that means that you forgot the `--bin` flag ; just rename the file.
 
-In order to use the glutin and glium libraries, we need to add them as dependencies in our `Cargo.toml` file:
+In order to use the glium library, we need to add them as dependencies in our `Cargo.toml` file:
 
     [dependencies]
     glium = "*"
-    glutin = "*"
 
-Before we can use them, we also need to import these libraries in our `src/main.rs` file, like this:
+Before we can use them, we also need to import this library in our `src/main.rs` file, like this:
 
     #[macro_use]
     extern crate glium;
-    extern crate glutin;
 
     fn main() {
     }
@@ -36,11 +34,11 @@ It is now time to start filling the `main` function!
 
 The first step when creating a graphical application is to create a window. If you have ever worked with OpenGL before, you know how hard it is to do this correctly. Both window creation and context creation are platform-specific, and they are sometimes weird and tedious. Fortunately, this is where the **glutin** library shines.
 
-Initializing a window with glutin can be done by calling `glutin::WindowBuilder()::new().build().unwrap()`. However we don't want to create a *glutin* window but a *glium* window. Instead of calling `build()` we going to call `build_glium()`, which is defined in the `glium::DisplayBuild` trait.
+Initializing a window with glutin can be done by calling `glium::glutin::WindowBuilder()::new().build().unwrap()`. However we don't want to create a *glutin* window but a *glium* window. Instead of calling `build()` we going to call `build_glium()`, which is defined in the `glium::DisplayBuild` trait.
 
     fn main() {
         use glium::DisplayBuild;
-        let display = glutin::WindowBuilder::new().build_glium().unwrap();
+        let display = glium::glutin::WindowBuilder::new().build_glium().unwrap();
     }
 
 But there is a problem: as soon as the window has been created, our main function exits and `display`'s destructor closes the window. To prevent this, we are just going to add an infinite loop until we detect that the window has been closed:
@@ -86,7 +84,7 @@ Here is our full `main` function after this step:
 
     fn main() {
         use glium::{DisplayBuild, Surface};
-        let display = glutin::WindowBuilder::new().build_glium().unwrap();
+        let display = glium::glutin::WindowBuilder::new().build_glium().unwrap();
 
         loop {
             let mut target = display.draw();
@@ -226,11 +224,10 @@ Here is the final code of our `src/main.rs` file:
 
     #[macro_use]
     extern crate glium;
-    extern crate glutin;
 
     fn main() {
         use glium::{DisplayBuild, Surface};
-        let display = glutin::WindowBuilder::new().build_glium().unwrap();
+        let display = glium::glutin::WindowBuilder::new().build_glium().unwrap();
 
         #[derive(Copy, Clone)]
         struct Vertex {

--- a/doc/tutorials/02-animating-triangle.md
+++ b/doc/tutorials/02-animating-triangle.md
@@ -164,11 +164,10 @@ Here is the final code of our `src/main.rs` file:
 
     #[macro_use]
     extern crate glium;
-    extern crate glutin;
 
     fn main() {
         use glium::{DisplayBuild, Surface};
-        let display = glutin::WindowBuilder::new().build_glium().unwrap();
+        let display = glium::glutin::WindowBuilder::new().build_glium().unwrap();
 
         #[derive(Copy, Clone)]
         struct Vertex {

--- a/examples/blitting.rs
+++ b/examples/blitting.rs
@@ -1,4 +1,3 @@
-extern crate glutin;
 extern crate rand;
 
 #[macro_use]
@@ -12,6 +11,8 @@ use std::io::Cursor;
 
 #[cfg(feature = "image")]
 use glium::{DisplayBuild, Texture, Surface};
+
+use glium::glutin;
 
 mod support;
 

--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -1,4 +1,3 @@
-extern crate glutin;
 #[macro_use]
 extern crate glium;
 #[cfg(feature = "cgmath")]
@@ -6,6 +5,7 @@ extern crate cgmath;
 #[cfg(feature = "image")]
 extern crate image;
 
+use glium::glutin;
 use glium::Surface;
 use glium::DisplayBuild;
 #[cfg(feature = "cgmath")]

--- a/examples/displacement_mapping.rs
+++ b/examples/displacement_mapping.rs
@@ -1,11 +1,10 @@
-extern crate glutin;
-
 #[cfg(feature = "image")]
 extern crate image;
 
 #[macro_use]
 extern crate glium;
 
+use glium::glutin;
 #[cfg(feature = "image")]
 use std::io::Cursor;
 #[cfg(feature = "image")]

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -1,5 +1,3 @@
-extern crate glutin;
-
 #[macro_use]
 extern crate glium;
 
@@ -11,6 +9,7 @@ use std::io::Cursor;
 
 #[cfg(feature = "image")]
 use glium::{DisplayBuild, Surface};
+use glium::glutin;
 
 mod support;
 

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -1,5 +1,3 @@
-extern crate glutin;
-
 #[macro_use]
 extern crate glium;
 
@@ -11,6 +9,7 @@ use std::io::Cursor;
 
 #[cfg(feature = "image")]
 use glium::{DisplayBuild, Surface};
+use glium::glutin;
 
 mod support;
 

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -1,9 +1,8 @@
-extern crate glutin;
-
 #[macro_use]
 extern crate glium;
 
 use glium::Surface;
+use glium::glutin;
 
 mod support;
 

--- a/examples/manual-creation.rs
+++ b/examples/manual-creation.rs
@@ -17,10 +17,10 @@ There are three concepts in play:
 
 */
 extern crate libc;
-extern crate glutin;
 extern crate glium;
 
 use glium::Surface;
+use glium::glutin;
 use std::rc::Rc;
 
 fn main() {

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -1,5 +1,3 @@
-extern crate glutin;
-
 #[macro_use]
 extern crate glium;
 
@@ -7,6 +5,7 @@ extern crate glium;
 extern crate image;
 
 use glium::Surface;
+use glium::glutin;
 use std::path::Path;
 
 #[cfg(not(feature = "image"))]

--- a/examples/teapot.rs
+++ b/examples/teapot.rs
@@ -1,9 +1,8 @@
-extern crate glutin;
-
 #[macro_use]
 extern crate glium;
 
 use glium::Surface;
+use glium::glutin;
 
 mod support;
 

--- a/examples/tessellation.rs
+++ b/examples/tessellation.rs
@@ -1,9 +1,8 @@
-extern crate glutin;
-
 #[macro_use]
 extern crate glium;
 
 use glium::Surface;
+use glium::glutin;
 
 mod support;
 

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -1,11 +1,10 @@
-extern crate glutin;
-
 #[macro_use]
 extern crate glium;
 
 mod support;
 
 use glium::Surface;
+use glium::glutin;
 
 fn main() {
     use glium::DisplayBuild;

--- a/examples/tutorial-01.rs
+++ b/examples/tutorial-01.rs
@@ -1,10 +1,9 @@
 #[macro_use]
 extern crate glium;
-extern crate glutin;
 
 fn main() {
     use glium::{DisplayBuild, Surface};
-    let display = glutin::WindowBuilder::new().build_glium().unwrap();
+    let display = glium::glutin::WindowBuilder::new().build_glium().unwrap();
 
     #[derive(Copy, Clone)]
     struct Vertex {

--- a/examples/tutorial-02.rs
+++ b/examples/tutorial-02.rs
@@ -1,10 +1,9 @@
 #[macro_use]
 extern crate glium;
-extern crate glutin;
 
 fn main() {
     use glium::{DisplayBuild, Surface};
-    let display = glutin::WindowBuilder::new().build_glium().unwrap();
+    let display =glium:: glutin::WindowBuilder::new().build_glium().unwrap();
 
     #[derive(Copy, Clone)]
     struct Vertex {

--- a/src/backend/glutin_backend.rs
+++ b/src/backend/glutin_backend.rs
@@ -3,9 +3,9 @@
 Backend implementation for the glutin library
 
 */
-use libc;
+extern crate glutin;
 
-use glutin;
+use libc;
 
 use DisplayBuild;
 use Frame;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,13 +166,13 @@ extern crate lazy_static;
 
 #[cfg(feature = "cgmath")]
 extern crate cgmath;
-extern crate glutin;
 #[cfg(feature = "image")]
 extern crate image;
 extern crate libc;
 #[cfg(feature = "nalgebra")]
 extern crate nalgebra;
 
+pub use backend::glutin_backend::glutin;
 pub use draw_parameters::{BlendingFunction, LinearBlendingFactor, BackfaceCullingMode};
 pub use draw_parameters::{DepthTest, PolygonMode, DrawParameters, StencilTest, StencilOperation};
 pub use index::IndexBuffer;

--- a/tests/attrs.rs
+++ b/tests/attrs.rs
@@ -1,6 +1,5 @@
 #[macro_use]
 extern crate glium;
-extern crate glutin;
 
 use glium::Surface;
 

--- a/tests/backface-culling.rs
+++ b/tests/backface-culling.rs
@@ -1,4 +1,3 @@
-extern crate glutin;
 #[macro_use]
 extern crate glium;
 

--- a/tests/blending.rs
+++ b/tests/blending.rs
@@ -1,5 +1,3 @@
-extern crate glutin;
-
 #[macro_use]
 extern crate glium;
 

--- a/tests/blit.rs
+++ b/tests/blit.rs
@@ -1,4 +1,3 @@
-extern crate glutin;
 #[macro_use]
 extern crate glium;
 

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -1,4 +1,3 @@
-extern crate glutin;
 #[macro_use]
 extern crate glium;
 

--- a/tests/framebuffer.rs
+++ b/tests/framebuffer.rs
@@ -1,4 +1,3 @@
-extern crate glutin;
 #[macro_use]
 extern crate glium;
 

--- a/tests/indices.rs
+++ b/tests/indices.rs
@@ -1,4 +1,3 @@
-extern crate glutin;
 #[macro_use]
 extern crate glium;
 

--- a/tests/instancing.rs
+++ b/tests/instancing.rs
@@ -1,5 +1,3 @@
-extern crate glutin;
-
 #[macro_use]
 extern crate glium;
 

--- a/tests/samplers.rs
+++ b/tests/samplers.rs
@@ -1,4 +1,3 @@
-extern crate glutin;
 #[macro_use]
 extern crate glium;
 

--- a/tests/shaders.rs
+++ b/tests/shaders.rs
@@ -1,8 +1,6 @@
 //! This file is not named `program.rs`, because executables that contain the string `program`
 //! are treated in a special way by Windows.
 
-extern crate glutin;
-
 #[macro_use]
 extern crate glium;
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -5,8 +5,7 @@ Test supports module.
 
 #![allow(dead_code)]
 
-use glutin;
-use glium::{self, DisplayBuild};
+use glium::{self, glutin, DisplayBuild};
 use glium::backend::Facade;
 
 use std::env;

--- a/tests/texture_creation.rs
+++ b/tests/texture_creation.rs
@@ -1,4 +1,3 @@
-extern crate glutin;
 #[macro_use]
 extern crate glium;
 

--- a/tests/texture_draw.rs
+++ b/tests/texture_draw.rs
@@ -1,5 +1,3 @@
-extern crate glutin;
-
 #[macro_use]
 extern crate glium;
 

--- a/tests/texture_read.rs
+++ b/tests/texture_read.rs
@@ -1,4 +1,3 @@
-extern crate glutin;
 #[macro_use]
 extern crate glium;
 

--- a/tests/texture_sample.rs
+++ b/tests/texture_sample.rs
@@ -1,5 +1,3 @@
-extern crate glutin;
-
 #[macro_use]
 extern crate glium;
 

--- a/tests/texture_write.rs
+++ b/tests/texture_write.rs
@@ -1,4 +1,3 @@
-extern crate glutin;
 #[macro_use]
 extern crate glium;
 

--- a/tests/uniform_buffer.rs
+++ b/tests/uniform_buffer.rs
@@ -1,4 +1,3 @@
-extern crate glutin;
 #[macro_use]
 extern crate glium;
 extern crate rand;

--- a/tests/uniforms.rs
+++ b/tests/uniforms.rs
@@ -1,4 +1,3 @@
-extern crate glutin;
 #[macro_use]
 extern crate glium;
 

--- a/tests/vertex_buffer.rs
+++ b/tests/vertex_buffer.rs
@@ -1,5 +1,3 @@
-extern crate glutin;
-
 #[macro_use]
 extern crate glium;
 

--- a/tests/vertex_source.rs
+++ b/tests/vertex_source.rs
@@ -1,5 +1,3 @@
-extern crate glutin;
-
 #[macro_use]
 extern crate glium;
 


### PR DESCRIPTION
Doesn't break anything, but you can now access glutin with `glium::glutin`.