### PR TITLE
Eliminate warnings

### DIFF
--- a/src/draw_parameters.rs
+++ b/src/draw_parameters.rs
@@ -279,8 +279,10 @@ impl ToGlEnum for DepthTest {
     }
 }
 
-/// Specifies which comparaison the GPU will do to determine whether a sample passes the stencil
-/// test.
+/// Specifies which comparison the GPU will do to determine whether a sample passes the stencil
+/// test. The general equation is `(ref & mask) CMP (stencil & mask)`, where `ref` is the reference
+/// value (`stencil_reference_value_clockwise` or `stencil_reference_value_counter_clockwise`),
+/// `CMP` is the comparison chosen, and `stencil` is the current value in the stencil buffer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum StencilTest {
     /// The stencil test always passes.
@@ -289,35 +291,41 @@ pub enum StencilTest {
     /// The stencil test always fails.
     AlwaysFail,
 
-    /// Applies the mask as a bitfield to both the value currently in the stencil buffer and
-    /// the reference value (`stencil_reference_value_clockwise` or
-    /// `stencil_reference_value_counter_clockwise`), then compares them.
-    IfLess { mask: u32 },
+    /// `(ref & mask) < (stencil & mask)`
+    IfLess {
+        /// The mask that is and'ed with the reference value and stencil buffer.
+        mask: u32
+    },
 
-    /// Applies the mask as a bitfield to both the value currently in the stencil buffer and
-    /// the reference value (`stencil_reference_value_clockwise` or
-    /// `stencil_reference_value_counter_clockwise`), then compares them.
-    IfLessOrEqual { mask: u32 },
+    /// `(ref & mask) <= (stencil & mask)`
+    IfLessOrEqual {
+        /// The mask that is and'ed with the reference value and stencil buffer.
+        mask: u32,
+    },
 
-    /// Applies the mask as a bitfield to both the value currently in the stencil buffer and
-    /// the reference value (`stencil_reference_value_clockwise` or
-    /// `stencil_reference_value_counter_clockwise`), then compares them.
-    IfMore { mask: u32 },
+    /// `(ref & mask) > (stencil & mask)`
+    IfMore {
+        /// The mask that is and'ed with the reference value and stencil buffer.
+        mask: u32,
+    },
 
-    /// Applies the mask as a bitfield to both the value currently in the stencil buffer and
-    /// the reference value (`stencil_reference_value_clockwise` or
-    /// `stencil_reference_value_counter_clockwise`), then compares them.
-    IfMoreOrEqual { mask: u32 },
+    /// `(ref & mask) >= (stencil & mask)`
+    IfMoreOrEqual {
+        /// The mask that is and'ed with the reference value and stencil buffer.
+        mask: u32,
+    },
 
-    /// Applies the mask as a bitfield to both the value currently in the stencil buffer and
-    /// the reference value (`stencil_reference_value_clockwise` or
-    /// `stencil_reference_value_counter_clockwise`), then compares them.
-    IfEqual { mask: u32 },
+    /// `(ref & mask) == (stencil & mask)`
+    IfEqual {
+        /// The mask that is and'ed with the reference value and stencil buffer.
+        mask: u32,
+    },
 
-    /// Applies the mask as a bitfield to both the value currently in the stencil buffer and
-    /// the reference value (`stencil_reference_value_clockwise` or
-    /// `stencil_reference_value_counter_clockwise`), then compares them.
-    IfNotEqual { mask: u32 },
+    /// `(ref & mask) != (stencil & mask)`
+    IfNotEqual {
+        /// The mask that is and'ed with the reference value and stencil buffer.
+        mask: u32,
+    },
 }
 
 /// Specificies which operation the GPU will do depending on the result of the stencil test.
@@ -434,7 +442,7 @@ pub struct DrawParameters {
     ///
     /// The default is `Overwrite`.
     pub depth_test: DepthTest,
-    
+
     /// Sets whether the GPU will write the depth values on the depth buffer if they pass the
     /// depth test.
     ///
@@ -573,7 +581,7 @@ pub struct DrawParameters {
     /// `None` means "don't care". Use this when you don't draw lines.
     pub line_width: Option<f32>,
 
-    /// Diameter in pixels of the points to draw when drawing points. 
+    /// Diameter in pixels of the points to draw when drawing points.
     ///
     /// `None` means "don't care". Use this when you don't draw points.
     pub point_size: Option<f32>,

--- a/src/image_format.rs
+++ b/src/image_format.rs
@@ -20,7 +20,7 @@ pub enum TextureFormatRequest {
     /// Request any floating-point format, normalized or not.
     AnyFloatingPoint,
 
-    // TODO: 
+    // TODO:
     // /// Request any floating-point format represented with floats.
     //AnyFloatingPointFloat,
 
@@ -191,117 +191,117 @@ impl ClientFormat {
 /// is not supported by the backend, it will automatically fall back to a larger format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UncompressedFloatFormat {
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for both textures and renderbuffers.
     U8,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for textures.
     I8,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for both textures and renderbuffers.
     U16,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for textures.
     I16,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for both textures and renderbuffers.
     U8U8,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for textures.
     I8I8,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for both textures and renderbuffers.
     U16U16,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for textures.
     I16I16,
-    /// 
+    ///
     U3U32U,
-    /// 
+    ///
     U4U4U4,
-    /// 
+    ///
     U5U5U5,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for textures.
     U8U8U8,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for textures.
     I8I8I8,
-    /// 
+    ///
     U10U10U10,
-    /// 
+    ///
     U12U12U12,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for textures.
     I16I16I16,
-    /// 
+    ///
     U2U2U2U2,
-    /// 
+    ///
     U4U4U4U4,
-    /// 
+    ///
     U5U5U5U1,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for both textures and renderbuffers.
     U8U8U8U8,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for textures.
     I8I8I8I8,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for both textures and renderbuffers.
     U10U10U10U2,
-    /// 
+    ///
     U12U12U12U12,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for both textures and renderbuffers.
     U16U16U16U16,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for both textures and renderbuffers.
     F16,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for both textures and renderbuffers.
     F16F16,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for textures.
     F16F16F16,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for both textures and renderbuffers.
     F16F16F16F16,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for both textures and renderbuffers.
     F32,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for both textures and renderbuffers.
     F32F32,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for textures.
     F32F32F32,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for both textures and renderbuffers.
     F32F32F32F32,
-    /// 
+    ///
     ///
     /// Guaranteed to be supported for both textures and renderbuffers.
     F11F11F10,
@@ -411,9 +411,13 @@ pub enum CompressedFormat {
     /// BPTC format with three components (no alpha) represented as unsigned floats.
     BptcUnsignedFloat3,
 
+    /// S3TC DXT1 without alpha, see https://www.opengl.org/wiki/S3_Texture_Compression.
     S3tcDxt1NoAlpha,
+    /// S3TC DXT1 with 1-bit alpha, see https://www.opengl.org/wiki/S3_Texture_Compression.
     S3tcDxt1Alpha,
+    /// S3TC DXT3, see https://www.opengl.org/wiki/S3_Texture_Compression.
     S3tcDxt3Alpha,
+    /// S3TC DXT5, see https://www.opengl.org/wiki/S3_Texture_Compression.
     S3tcDxt5Alpha,
 }
 

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -350,5 +350,5 @@ fn debug_string() {
     use glium::backend::Facade;
 
     let display = support::build_display();
-    display.get_context().insert_debug_marker("Hello world").unwrap();
+    display.get_context().insert_debug_marker("Hello world").ok();
 }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -350,5 +350,5 @@ fn debug_string() {
     use glium::backend::Facade;
 
     let display = support::build_display();
-    display.get_context().insert_debug_marker("Hello world");
+    display.get_context().insert_debug_marker("Hello world").unwrap();
 }

--- a/tests/vertex_buffer.rs
+++ b/tests/vertex_buffer.rs
@@ -1,9 +1,6 @@
 #[macro_use]
 extern crate glium;
 
-use glium::Surface;
-use std::default::Default;
-
 mod support;
 
 #[test]


### PR DESCRIPTION
Update glium so that there are no warnings with the latest nightly. Still need to add doc strings #792. 