### PR TITLE
[Small breaking change] Allow clearing color/depth/stencil in a rect of the framebuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+ - Changed `Surface::clear` to take an additional optional `Rect` parameter that specifies the rectangle to clear.
  - Fixed the `program!` macro not usable with version numbers >= 256.
  - Moved the content of the `render_buffer` module to `framebuffer`. `render_buffer` still exists but is deprecated.
 

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -248,10 +248,10 @@ impl<'a> SimpleFrameBuffer<'a> {
 }
 
 impl<'a> Surface for SimpleFrameBuffer<'a> {
-    fn clear(&mut self, color: Option<(f32, f32, f32, f32)>, depth: Option<f32>,
-             stencil: Option<i32>)
+    fn clear(&mut self, rect: Option<&Rect>, color: Option<(f32, f32, f32, f32)>,
+             depth: Option<f32>, stencil: Option<i32>)
     {
-        ops::clear(&self.context, Some(&self.attachments), color, depth, stencil);
+        ops::clear(&self.context, Some(&self.attachments), rect, color, depth, stencil);
     }
 
     fn get_dimensions(&self) -> (u32, u32) {
@@ -477,10 +477,10 @@ impl<'a> MultiOutputFrameBuffer<'a> {
 }
 
 impl<'a> Surface for MultiOutputFrameBuffer<'a> {
-    fn clear(&mut self, color: Option<(f32, f32, f32, f32)>, depth: Option<f32>,
-             stencil: Option<i32>)
+    fn clear(&mut self, rect: Option<&Rect>, color: Option<(f32, f32, f32, f32)>,
+             depth: Option<f32>, stencil: Option<i32>)
     {
-        ops::clear(&self.context, Some(&self.build_attachments_any()),
+        ops::clear(&self.context, Some(&self.build_attachments_any()), rect,
                    color, depth, stencil);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,42 +506,42 @@ pub struct BlitTarget {
 ///
 pub trait Surface: Sized {
     /// Clears some attachments of the target.
-    fn clear(&mut self, color: Option<(f32, f32, f32, f32)>, depth: Option<f32>,
-             stencil: Option<i32>);
+    fn clear(&mut self, rect: Option<&Rect>, color: Option<(f32, f32, f32, f32)>,
+             depth: Option<f32>, stencil: Option<i32>);
 
     /// Clears the color attachment of the target.
     fn clear_color(&mut self, red: f32, green: f32, blue: f32, alpha: f32) {
-        self.clear(Some((red, green, blue, alpha)), None, None);
+        self.clear(None, Some((red, green, blue, alpha)), None, None);
     }
 
     /// Clears the depth attachment of the target.
     fn clear_depth(&mut self, value: f32) {
-        self.clear(None, Some(value), None);
+        self.clear(None, None, Some(value), None);
     }
 
     /// Clears the stencil attachment of the target.
     fn clear_stencil(&mut self, value: i32) {
-        self.clear(None, None, Some(value));
+        self.clear(None, None, None, Some(value));
     }
 
     /// Clears the color and depth attachments of the target.
     fn clear_color_and_depth(&mut self, color: (f32, f32, f32, f32), depth: f32) {
-        self.clear(Some(color), Some(depth), None);
+        self.clear(None, Some(color), Some(depth), None);
     }
 
     /// Clears the color and stencil attachments of the target.
     fn clear_color_and_stencil(&mut self, color: (f32, f32, f32, f32), stencil: i32) {
-        self.clear(Some(color), None, Some(stencil));
+        self.clear(None, Some(color), None, Some(stencil));
     }
 
     /// Clears the depth and stencil attachments of the target.
     fn clear_depth_and_stencil(&mut self, depth: f32, stencil: i32) {
-        self.clear(None, Some(depth), Some(stencil));
+        self.clear(None, None, Some(depth), Some(stencil));
     }
 
     /// Clears the color, depth and stencil attachments of the target.
     fn clear_all(&mut self, color: (f32, f32, f32, f32), depth: f32, stencil: i32) {
-        self.clear(Some(color), Some(depth), Some(stencil));
+        self.clear(None, Some(color), Some(depth), Some(stencil));
     }
 
     /// Returns the dimensions in pixels of the target.
@@ -786,10 +786,10 @@ impl Frame {
 }
 
 impl Surface for Frame {
-    fn clear(&mut self, color: Option<(f32, f32, f32, f32)>, depth: Option<f32>,
-             stencil: Option<i32>)
+    fn clear(&mut self, rect: Option<&Rect>, color: Option<(f32, f32, f32, f32)>,
+             depth: Option<f32>, stencil: Option<i32>)
     {
-        ops::clear(&self.context, None, color, depth, stencil);
+        ops::clear(&self.context, None, None, color, depth, stencil);
     }
 
     fn get_dimensions(&self) -> (u32, u32) {

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -395,10 +395,10 @@ impl<P> Texture3dDataSink for Vec<Vec<Vec<P>>> where P: PixelValue + Clone {
 pub struct TextureSurface<'a>(framebuffer::SimpleFrameBuffer<'a>);
 
 impl<'a> Surface for TextureSurface<'a> {
-    fn clear(&mut self, color: Option<(f32, f32, f32, f32)>, depth: Option<f32>,
-             stencil: Option<i32>)
+    fn clear(&mut self, rect: Option<&Rect>, color: Option<(f32, f32, f32, f32)>,
+             depth: Option<f32>, stencil: Option<i32>)
     {
-        self.0.clear(color, depth, stencil)
+        self.0.clear(rect, color, depth, stencil)
     }
 
     fn get_dimensions(&self) -> (u32, u32) {

--- a/tests/blending.rs
+++ b/tests/blending.rs
@@ -40,7 +40,7 @@ macro_rules! blending_test {
                 None).unwrap();
 
             let texture = support::build_renderable_texture(&display);
-            texture.as_surface().clear(Some($source), None, None);
+            texture.as_surface().clear(None, Some($source), None, None);
             texture.as_surface().draw(&vb, &ib, &program, &uniform!{ color: $dest },
                                       &params).unwrap();
 

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -34,6 +34,31 @@ fn clear_color() {
 }
 
 #[test]
+fn clear_color_rect() {
+    let display = support::build_display();
+
+    let texture = support::build_renderable_texture(&display);
+    texture.as_surface().clear_color(1.0, 0.0, 0.0, 1.0);
+
+    let rect = glium::Rect { left: 512, bottom: 0, width: 512, height: 1024 };
+    texture.as_surface().clear(Some(&rect), Some((0.0, 1.0, 0.0, 1.0)), None, None);
+
+    let data: Vec<Vec<(f32, f32, f32)>> = texture.read();
+
+    for row in data.iter() {
+        for (col, pixel) in row.iter().enumerate() {
+            if col >= 512 {
+                assert_eq!(pixel, &(0.0, 1.0, 0.0));
+            } else {
+                assert_eq!(pixel, &(1.0, 0.0, 0.0));
+            }
+        }
+    }
+
+    display.assert_no_error(None);
+}
+
+#[test]
 fn release_shader_compiler() {
     let display = support::build_display();
     display.release_shader_compiler();


### PR DESCRIPTION
Technically a breaking change, but I don't think it's worth bumping the minor version.