### PR TITLE
Remove the call to glFlush

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -217,9 +217,6 @@ impl Context {
             }
         }
 
-        // this is necessary on Windows 8, or nothing is being displayed
-        unsafe { self.gl.Flush(); }
-
         // swapping
         backend.swap_buffers();
     }


### PR DESCRIPTION
Apparently it was only necessary because of a bug in Intel drivers that has now been fixed.