### PR TITLE
Add support for GL_OES_depth_texture and GL_OES_packed_depth_stencil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  - Buffers are no longer mapped with `GL_MAP_COHERENT_BIT`. Flushing is handled by glium.
  - Changed `Surface::clear` to take an additional optional `Rect` parameter that specifies the rectangle to clear.
  - Fixed the `program!` macro not usable with version numbers >= 256.
+ - Added support for `GL_OES_depth_texture` and `GL_OES_packed_depth_stencil`.
  - Moved the content of the `render_buffer` module to `framebuffer`. `render_buffer` still exists but is deprecated.
 
 ## Version 0.3.5 (2015-05-02)

--- a/build/main.rs
+++ b/build/main.rs
@@ -85,6 +85,8 @@ fn generate_gl_bindings<W>(dest: &mut W) where W: Write {
                 "GL_EXT_disjoint_timer_query".to_string(),
                 "GL_KHR_debug".to_string(),
                 "GL_NV_copy_buffer".to_string(),
+                "GL_OES_depth_texture".to_string(),
+                "GL_OES_packed_depth_stencil".to_string(),
                 "GL_OES_texture_npot".to_string(),
                 "GL_OES_vertex_array_object".to_string(),
             ],

--- a/src/context/extensions.rs
+++ b/src/context/extensions.rs
@@ -110,6 +110,10 @@ pub struct ExtensionsList {
     pub gl_nv_copy_buffer: bool,
     /// GL_NVX_gpu_memory_info
     pub gl_nvx_gpu_memory_info: bool,
+    /// GL_OES_depth_texture
+    pub gl_oes_depth_texture: bool,
+    /// GL_OES_packed_depth_stencil
+    pub gl_oes_packed_depth_stencil: bool,
     /// GL_OES_vertex_array_object
     pub gl_oes_vertex_array_object: bool,
 }
@@ -181,6 +185,8 @@ pub unsafe fn get_extensions(gl: &gl::Gl, version: &Version) -> ExtensionsList {
         gl_khr_debug: false,
         gl_nv_copy_buffer: false,
         gl_nvx_gpu_memory_info: false,
+        gl_oes_depth_texture: false,
+        gl_oes_packed_depth_stencil: false,
         gl_oes_vertex_array_object: false,
     };
 
@@ -238,6 +244,8 @@ pub unsafe fn get_extensions(gl: &gl::Gl, version: &Version) -> ExtensionsList {
             "GL_KHR_debug" => extensions.gl_khr_debug = true,
             "GL_NV_copy_buffer" => extensions.gl_nv_copy_buffer = true,
             "GL_NVX_gpu_memory_info" => extensions.gl_nvx_gpu_memory_info = true,
+            "GL_OES_depth_texture" => extensions.gl_oes_depth_texture = true,
+            "GL_OES_packed_depth_stencil" => extensions.gl_oes_packed_depth_stencil = true,
             "GL_OES_vertex_array_object" => extensions.gl_oes_vertex_array_object = true,
             _ => ()
         }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -541,7 +541,8 @@ fn check_gl_compatibility<T>(ctxt: &mut CommandContext) -> Result<(), GliumCreat
     }
 
     if cfg!(feature = "gl_depth_textures") && !(ctxt.version >= &Version(Api::Gl, 3, 0)) &&
-        (!ctxt.extensions.gl_arb_depth_texture || !ctxt.extensions.gl_ext_packed_depth_stencil)
+        (!ctxt.extensions.gl_arb_depth_texture || !ctxt.extensions.gl_ext_packed_depth_stencil) &&
+        (!ctxt.extensions.gl_oes_depth_texture || !ctxt.extensions.gl_oes_packed_depth_stencil)
     {
         result.push("OpenGL implementation doesn't support depth or depth-stencil textures");
     }

--- a/src/image_format.rs
+++ b/src/image_format.rs
@@ -1383,9 +1383,9 @@ pub fn format_request_to_glenum(context: &Context, client: Option<ClientFormat>,
         TextureFormatRequest::AnyDepth => {
             if version >= &Version(Api::Gl, 2, 0) {
                 (gl::DEPTH_COMPONENT, Some(gl::DEPTH_COMPONENT24))
-            } else if version >= &Version(Api::Gl, 1, 4) {
-                (gl::DEPTH_COMPONENT, None)     // TODO: sized format?
-            } else if extensions.gl_arb_depth_texture {
+            } else if version >= &Version(Api::Gl, 1, 4) || extensions.gl_arb_depth_texture ||
+                      extensions.gl_oes_depth_texture
+            {
                 (gl::DEPTH_COMPONENT, None)     // TODO: sized format?
             } else {
                 return Err(FormatNotSupportedError);
@@ -1451,13 +1451,17 @@ pub fn format_request_to_glenum(context: &Context, client: Option<ClientFormat>,
                 (gl::DEPTH_STENCIL, Some(gl::DEPTH24_STENCIL8))
             } else if extensions.gl_ext_packed_depth_stencil {
                 (gl::DEPTH_STENCIL_EXT, Some(gl::DEPTH24_STENCIL8_EXT))
+            } else if extensions.gl_oes_packed_depth_stencil {
+                (gl::DEPTH_STENCIL_OES, Some(gl::DEPTH24_STENCIL8_OES))
             } else {
                 return Err(FormatNotSupportedError);
             }
         },
 
         TextureFormatRequest::Specific(TextureFormat::DepthStencilFormat(DepthStencilFormat::I24I8)) => {
-            if version >= &Version(Api::Gl, 3, 0) || extensions.gl_ext_packed_depth_stencil {
+            if version >= &Version(Api::Gl, 3, 0) || extensions.gl_ext_packed_depth_stencil ||
+               extensions.gl_oes_packed_depth_stencil
+            {
                 (gl::DEPTH24_STENCIL8, Some(gl::DEPTH24_STENCIL8))
             } else {
                 return Err(FormatNotSupportedError);


### PR DESCRIPTION
Creating an OpenGL ES 2.0 context with glium usually fails because depth/depth-stencil textures are not supported by the device.
But in fact they are supported in ~90% of the devices, it's just glium that didn't support it properly.