### PR TITLE
Remove the usage of Mutex/Sender for sync fences

### DIFF
--- a/src/index/buffer.rs
+++ b/src/index/buffer.rs
@@ -16,7 +16,7 @@ use index::PrimitiveType;
 
 use std::mem;
 use std::ops::Range;
-use std::sync::mpsc::Sender;
+use std::cell::RefCell;
 
 /// A list of indices loaded in the graphics card's memory.
 #[derive(Debug)]
@@ -81,7 +81,7 @@ impl IndexBuffer {
 }
 
 impl BufferExt for IndexBuffer {
-    fn add_fence(&self) -> Option<Sender<sync::LinearSyncFence>> {
+    fn add_fence(&self) -> Option<&RefCell<Option<sync::LinearSyncFence>>> {
         self.buffer.add_fence()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ pub use sync::{LinearSyncFence, SyncFence};
 pub use texture::{Texture, Texture2d};
 pub use version::{Api, Version, get_supported_glsl_version};
 
-use std::sync::mpsc::Sender;
+use std::cell::RefCell;
 use std::rc::Rc;
 
 use context::Context;
@@ -252,8 +252,10 @@ trait ToGlEnum {
 
 /// Internal trait for buffers.
 trait BufferExt {
-    /// 
-    fn add_fence(&self) -> Option<Sender<sync::LinearSyncFence>>;
+    /// Tries to get a reference to a `RefCell` where to write a fence.
+    ///
+    /// If this function returns `None`, no fence will be created nor written.
+    fn add_fence(&self) -> Option<&RefCell<Option<sync::LinearSyncFence>>>;
 }
 
 /// Internal trait for contexts.

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -151,3 +151,9 @@ pub unsafe fn wait_linear_sync_fence_and_drop(mut fence: LinearSyncFence,
                            365 * 24 * 3600 * 1000 * 1000 * 1000);
     ctxt.gl.DeleteSync(fence);
 }
+
+/// Destroys a fence, from within the commands context.
+pub unsafe fn destroy_linear_sync_fence(ctxt: &mut CommandContext, mut fence: LinearSyncFence) {
+    let fence = fence.id.take().unwrap();
+    ctxt.gl.DeleteSync(fence);
+}

--- a/src/uniforms/buffer.rs
+++ b/src/uniforms/buffer.rs
@@ -3,7 +3,7 @@ use uniforms::{AsUniformValue, UniformValue, UniformBlock};
 
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
-use std::sync::mpsc::Sender;
+use std::cell::RefCell;
 
 use backend::Facade;
 
@@ -105,13 +105,13 @@ impl GlObject for TypelessUniformBuffer {
 }
 
 impl<T> BufferExt for UniformBuffer<T> {
-    fn add_fence(&self) -> Option<Sender<sync::LinearSyncFence>> {
+    fn add_fence(&self) -> Option<&RefCell<Option<sync::LinearSyncFence>>> {
         self.buffer.add_fence()
     }
 }
 
 impl BufferExt for TypelessUniformBuffer {
-    fn add_fence(&self) -> Option<Sender<sync::LinearSyncFence>> {
+    fn add_fence(&self) -> Option<&RefCell<Option<sync::LinearSyncFence>>> {
         self.buffer.add_fence()
     }
 }

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 use std::ops::{Range, Deref, DerefMut};
-use std::sync::mpsc::Sender;
+use std::cell::RefCell;
 use std::mem;
 
 use buffer::{self, Buffer, BufferType};
@@ -333,7 +333,7 @@ impl<T> GlObject for VertexBuffer<T> {
 }
 
 impl<T> BufferExt for VertexBuffer<T> {
-    fn add_fence(&self) -> Option<Sender<sync::LinearSyncFence>> {
+    fn add_fence(&self) -> Option<&RefCell<Option<sync::LinearSyncFence>>> {
         self.buffer.add_fence()
     }
 }
@@ -379,7 +379,7 @@ impl<'b, T> VertexBufferSlice<'b, T> where T: Send + Copy + 'static {
 }
 
 impl<'a, T> BufferExt for VertexBufferSlice<'a, T> {
-    fn add_fence(&self) -> Option<Sender<sync::LinearSyncFence>> {
+    fn add_fence(&self) -> Option<&RefCell<Option<sync::LinearSyncFence>>> {
         self.buffer.add_fence()
     }
 }
@@ -454,7 +454,7 @@ impl VertexBufferAny {
 }
 
 impl BufferExt for VertexBufferAny {
-    fn add_fence(&self) -> Option<Sender<sync::LinearSyncFence>> {
+    fn add_fence(&self) -> Option<&RefCell<Option<sync::LinearSyncFence>>> {
         self.buffer.add_fence()
     }
 }


### PR DESCRIPTION
Was still a reliquate from when everything was multithreaded.

We also only use one fence per buffer instead of accumulating them.
If a buffer already contains a fence, destroy it and replace it by a new one.