### PR TITLE
Fix multithreading-related issues in glium's tests

### DIFF
--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -158,6 +158,8 @@ impl Program {
                            -> Result<Program, ProgramCreationError>
                            where F: Facade
     {
+        let _lock = COMPILER_GLOBAL_LOCK.lock();
+
         let mut has_tessellation_shaders = false;
 
         // getting an array of the source codes and their type
@@ -280,8 +282,6 @@ impl Program {
 
             // linking
             {
-                let _lock = COMPILER_GLOBAL_LOCK.lock();
-
                 ctxt.report_debug_output_errors.set(false);
 
                 match id {

--- a/src/program/shader.rs
+++ b/src/program/shader.rs
@@ -93,8 +93,6 @@ pub fn build_shader<F>(facade: &F, shader_type: gl::types::GLenum, source_code: 
 
         // compiling
         {
-            let _lock = COMPILER_GLOBAL_LOCK.lock();
-
             ctxt.report_debug_output_errors.set(false);
 
             match id {


### PR DESCRIPTION
The AMD driver no longer crashes on my machine with this change.