### PR TITLE
remove `use std::default::Default` and `std::default::*`

### DIFF
--- a/doc/tutorials/01-getting-started.md
+++ b/doc/tutorials/01-getting-started.md
@@ -210,7 +210,7 @@ Remember the `target` object? We will need to use it to start a draw operation.
 Starting a draw operation needs several things: a source of vertices (here we use our `vertex_buffer`), a source of indices (we use our `indices` variable), a program, the program's uniforms, and some draw parameters. We will explain what uniforms and draw parameters are in the next tutorials, but for the moment we will just ignore them by passing a `EmptyUniforms` marker and by building the default draw parameters.
 
     target.draw(&vertex_buffer, &indices, &program, &glium::uniforms::EmptyUniforms,
-                &std::default::Default::default()).unwrap();
+                &Default::default()).unwrap();
 
 The "draw command" designation could make you think that drawing is a heavy operation that takes a lot of time. In reality drawing a triangle takes less than a few microseconds, and if everything goes well you should see a nice little triangle:
 
@@ -270,7 +270,7 @@ Here is the final code of our `src/main.rs` file:
             let mut target = display.draw();
             target.clear_color(0.0, 0.0, 1.0, 1.0);
             target.draw(&vertex_buffer, &indices, &program, &glium::uniforms::EmptyUniforms,
-                        &std::default::Default::default()).unwrap();
+                        &Default::default()).unwrap();
             target.finish();
 
             if display.is_closed() {

--- a/doc/tutorials/02-animating-triangle.md
+++ b/doc/tutorials/02-animating-triangle.md
@@ -30,7 +30,7 @@ Our first approach will be to create a variable named `t` which represents the s
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 1.0, 1.0);
         target.draw(&vertex_buffer, &indices, &program, &glium::uniforms::EmptyUniforms,
-                    &std::default::Default::default()).unwrap();
+                    &Default::default()).unwrap();
         target.finish();
 
         if display.is_closed() {
@@ -70,7 +70,7 @@ Let's reset our program to what it was at the end of the first tutorial, but kee
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 1.0, 1.0);
         target.draw(&vertex_buffer, &indices, &program, &glium::uniforms::EmptyUniforms,
-                    &std::default::Default::default()).unwrap();
+                    &Default::default()).unwrap();
         target.finish();
 
         if display.is_closed() {
@@ -97,7 +97,7 @@ And instead we are going to do a small change in our vertex shader:
 You may notice that this is exactly the operation that we've been doing above, except that this time it is done on the GPU side. We have added a variable `t` in our shader, which is declared as a **uniform**. A uniform is a global variable whose value is set when we draw by passing its value to the `draw` function. The easiest way to do so is to use the `uniform!` macro:
 
     target.draw(&vertex_buffer, &indices, &program, &uniform! { t: t },
-                &std::default::Default::default()).unwrap();
+                &Default::default()).unwrap();
 
 Using uniform variables solves our two problems above. The CPU doesn't have to do any calculation, and all that it uploaded is the value of `t` (a single float) instead of the whole shape.
 
@@ -143,7 +143,7 @@ We also need to pass the matrix when calling the `draw` function:
     };
 
     target.draw(&vertex_buffer, &indices, &program, &uniforms,
-                &std::default::Default::default()).unwrap();
+                &Default::default()).unwrap();
 
 You should see exactly the same thing as previously, but what we now have is much more flexible. For example, if instead we want to rotate the triangle we can try this matrix instead:
 
@@ -230,7 +230,7 @@ Here is the final code of our `src/main.rs` file:
             };
 
             target.draw(&vertex_buffer, &indices, &program, &uniforms,
-                        &std::default::Default::default()).unwrap();
+                        &Default::default()).unwrap();
             target.finish();
 
             if display.is_closed() {

--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -327,7 +327,7 @@ fn main() {
             tex: &opengl_texture
         };
         framebuffer.clear_color(0.0, 0.0, 0.0, 0.0);
-        framebuffer.draw(&floor_vertex_buffer, &floor_index_buffer, &prepass_program, &uniforms, &std::default::Default::default()).unwrap();
+        framebuffer.draw(&floor_vertex_buffer, &floor_index_buffer, &prepass_program, &uniforms, &Default::default()).unwrap();
 
         // lighting
         let draw_params = glium::DrawParameters {
@@ -336,7 +336,7 @@ fn main() {
                 source: glium::LinearBlendingFactor::One,
                 destination: glium::LinearBlendingFactor::One
             }),
-            .. std::default::Default::default()
+            .. Default::default()
         };
         light_buffer.clear_color(0.0, 0.0, 0.0, 0.0);
         for light in lights.iter() {
@@ -360,7 +360,7 @@ fn main() {
         };
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 0.0, 0.0);
-        target.draw(&quad_vertex_buffer, &quad_index_buffer, &composition_program, &uniforms, &std::default::Default::default()).unwrap();
+        target.draw(&quad_vertex_buffer, &quad_index_buffer, &composition_program, &uniforms, &Default::default()).unwrap();
         target.finish();
 
         // polling and handling the events received by the window

--- a/examples/displacement_mapping.rs
+++ b/examples/displacement_mapping.rs
@@ -223,7 +223,7 @@ fn main() {
                         vertices_per_patch: 3
                     }),
                     &program, &uniforms,
-                    &std::default::Default::default()).unwrap();
+                    &Default::default()).unwrap();
         target.finish();
 
         // polling and handling the events received by the window

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -95,7 +95,7 @@ fn main() {
                     [0.0, 0.0, 0.0, 1.0f32]
                 ],
                 tex: &opengl_texture
-            }, &std::default::Default::default()).unwrap();
+            }, &Default::default()).unwrap();
         target.finish();
 
         // polling and handling the events received by the window

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -159,7 +159,7 @@ fn main() {
         // drawing a frame
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 0.0, 0.0);
-        target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &std::default::Default::default()).unwrap();
+        target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &Default::default()).unwrap();
         target.finish();
 
         // polling and handling the events received by the window

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -86,7 +86,7 @@ fn main() {
         target.clear_color(0.0, 0.0, 0.0, 0.0);
         target.draw((&vertex_buffer, per_instance.per_instance_if_supported().unwrap()),
                     &index_buffer, &program, &uniform!{},
-                    &std::default::Default::default()).unwrap();
+                    &Default::default()).unwrap();
         target.finish();
 
         // polling and handling the events received by the window

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -119,7 +119,7 @@ fn main() {
     // drawing a frame
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
-    target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &std::default::Default::default()).unwrap();
+    target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &Default::default()).unwrap();
     target.finish();
 
     // reading the front buffer into an image

--- a/examples/teapot.rs
+++ b/examples/teapot.rs
@@ -141,7 +141,7 @@ fn main() {
         let params = glium::DrawParameters {
             depth_test: glium::DepthTest::IfLess,
             depth_write: true,
-            .. std::default::Default::default()
+            .. Default::default()
         };
 
         // drawing a frame

--- a/examples/tessellation.rs
+++ b/examples/tessellation.rs
@@ -143,7 +143,7 @@ fn main() {
         // drawing a frame
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 0.0, 0.0);
-        target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &std::default::Default::default()).unwrap();
+        target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &Default::default()).unwrap();
         target.finish();
 
         // polling and handling the events received by the window

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -24,7 +24,7 @@ fn main() {
 
         implement_vertex!(Vertex, position, color);
 
-        glium::VertexBuffer::new(&display, 
+        glium::VertexBuffer::new(&display,
             vec![
                 Vertex { position: [-0.5, -0.5], color: [0.0, 1.0, 0.0] },
                 Vertex { position: [ 0.0,  0.5], color: [0.0, 0.0, 1.0] },
@@ -67,7 +67,7 @@ fn main() {
             "
         },
 
-        110 => {  
+        110 => {
             vertex: "
                 #version 110
 
@@ -94,7 +94,7 @@ fn main() {
             ",
         },
 
-        100 => {  
+        100 => {
             vertex: "
                 #version 100
 
@@ -121,7 +121,7 @@ fn main() {
             ",
         },
     ).unwrap();
-    
+
     // the main loop
     support::start_loop(|| {
         // building the uniforms
@@ -137,7 +137,7 @@ fn main() {
         // drawing a frame
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 0.0, 0.0);
-        target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &std::default::Default::default()).unwrap();
+        target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &Default::default()).unwrap();
         target.finish();
 
         // polling and handling the events received by the window

--- a/examples/tutorial-01.rs
+++ b/examples/tutorial-01.rs
@@ -46,7 +46,7 @@ fn main() {
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 1.0, 1.0);
         target.draw(&vertex_buffer, &indices, &program, &glium::uniforms::EmptyUniforms,
-                    &std::default::Default::default()).unwrap();
+                    &Default::default()).unwrap();
         target.finish();
 
         if display.is_closed() {

--- a/examples/tutorial-02.rs
+++ b/examples/tutorial-02.rs
@@ -66,7 +66,7 @@ fn main() {
         };
 
         target.draw(&vertex_buffer, &indices, &program, &uniforms,
-                    &std::default::Default::default()).unwrap();
+                    &Default::default()).unwrap();
         target.finish();
 
         if display.is_closed() {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -7,7 +7,6 @@ use std::env;
 use std::mem;
 use std::ptr;
 use std::collections::HashMap;
-use std::default::Default;
 use std::cell::{Cell, RefCell, RefMut};
 use std::marker::PhantomData;
 use std::ffi::CStr;

--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -1,8 +1,6 @@
 use Handle;
 use gl;
 
-use std::default::Default;
-
 /// Represents the current OpenGL state.
 ///
 /// The current state is passed to each function and can be freely updated.

--- a/src/draw_parameters/mod.rs
+++ b/src/draw_parameters/mod.rs
@@ -8,7 +8,6 @@ use DrawError;
 use Rect;
 use ToGlEnum;
 
-use std::default::Default;
 use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 
@@ -437,7 +436,7 @@ impl ToGlEnum for PolygonMode {
 /// let params = glium::DrawParameters {
 ///     depth_test: glium::DepthTest::IfLess,
 ///     depth_write: true,
-///     .. std::default::Default::default()
+///     .. Default::default()
 /// };
 /// ```
 ///

--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -2,7 +2,6 @@ use std::ptr;
 use std::mem;
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::default::Default;
 
 use BufferExt;
 use ProgramExt;
@@ -64,7 +63,7 @@ pub fn draw<'a, I, U, V>(context: &Context, framebuffer: Option<&FramebufferAtta
 
             // TODO: programs created from binaries have the wrong value
             // for `has_tessellation_shaders`
-            /*if !program.has_tessellation_shaders() {    // TODO: 
+            /*if !program.has_tessellation_shaders() {    // TODO:
                 panic!("Default tessellation level is not supported yet");
             }*/
 
@@ -1260,7 +1259,7 @@ fn sync_conditional_render(ctxt: &mut context::CommandContext,
             } else {
                 unreachable!();
             }
-            
+
             *cur = None;
         },
 
@@ -1275,7 +1274,7 @@ fn sync_conditional_render(ctxt: &mut context::CommandContext,
             } else {
                 unreachable!();
             }
-            
+
             *cur = Some((id, mode));
         },
 

--- a/src/uniforms/mod.rs
+++ b/src/uniforms/mod.rs
@@ -1,6 +1,6 @@
 /*!
 A uniform is a global variable in your program. In order to draw something, you will need to
-give `glium` the values of all your uniforms. Objects that implement the `Uniform` trait are 
+give `glium` the values of all your uniforms. Objects that implement the `Uniform` trait are
 here to do that.
 
 There are two primarly ways to do this. The first one is to create your own structure and put
@@ -34,7 +34,6 @@ In order to customize the way a texture is being sampled, you must use a `Sample
 extern crate glium;
 
 # fn main() {
-use std::default::Default;
 # let display: glium::Display = unsafe { std::mem::uninitialized() };
 # let texture: glium::texture::Texture2d = unsafe { std::mem::uninitialized() };
 let uniforms = uniform! {

--- a/src/uniforms/sampler.rs
+++ b/src/uniforms/sampler.rs
@@ -1,4 +1,3 @@
-use std::default::Default;
 use ToGlEnum;
 use gl;
 

--- a/src/uniforms/value.rs
+++ b/src/uniforms/value.rs
@@ -4,8 +4,6 @@ use uniforms::UniformBlock;
 use uniforms::SamplerBehavior;
 use uniforms::buffer::TypelessUniformBuffer;
 
-use std::default::Default;
-
 #[cfg(feature = "cgmath")]
 use cgmath;
 #[cfg(feature = "nalgebra")]

--- a/src/vertex/mod.rs
+++ b/src/vertex/mod.rs
@@ -73,7 +73,6 @@ Each source can be:
  - A marker indicating a number of instances, with `glium::vertex::EmptyInstanceAttributes`.
 
 ```no_run
-# use std::default::Default;
 # use glium::Surface;
 # let display: glium::Display = unsafe { ::std::mem::uninitialized() };
 # #[derive(Copy, Clone)]

--- a/tests/attrs.rs
+++ b/tests/attrs.rs
@@ -46,7 +46,7 @@ fn attribute_types_mismatch() {
     // drawing a frame
     let mut target = display.draw();
     target.draw(&vertex_buffer, &index_buffer, &program, &glium::uniforms::EmptyUniforms,
-                &std::default::Default::default()).unwrap();
+                &Default::default()).unwrap();
     target.finish();
 
     display.assert_no_error(None);
@@ -93,7 +93,7 @@ fn missing_attribute() {
     // drawing a frame
     let mut target = display.draw();
     target.draw(&vertex_buffer, &index_buffer, &program, &glium::uniforms::EmptyUniforms,
-                &std::default::Default::default()).unwrap();
+                &Default::default()).unwrap();
     target.finish();
 
     display.assert_no_error(None);
@@ -140,7 +140,7 @@ macro_rules! attribute_test(
             // drawing a frame
             let mut target = display.draw();
             target.draw(&vertex_buffer, &index_buffer, &program, &glium::uniforms::EmptyUniforms,
-                        &std::default::Default::default()).unwrap();
+                        &Default::default()).unwrap();
             target.finish();
 
             display.assert_no_error(None);

--- a/tests/backface-culling.rs
+++ b/tests/backface-culling.rs
@@ -55,7 +55,7 @@ fn cull_clockwise() {
     texture.as_surface().draw(&vertex_buffer, &index_buffer, &program, &glium::uniforms::EmptyUniforms,
         &glium::DrawParameters {
             backface_culling: glium::BackfaceCullingMode::CullClockWise,
-            .. std::default::Default::default()
+            .. Default::default()
         }).unwrap();
 
     let read_back: Vec<Vec<(f32, f32, f32, f32)>> = texture.read();
@@ -115,7 +115,7 @@ fn cull_counterclockwise() {
     texture.as_surface().draw(&vertex_buffer, &index_buffer, &program, &glium::uniforms::EmptyUniforms,
         &glium::DrawParameters {
             backface_culling: glium::BackfaceCullingMode::CullCounterClockWise,
-            .. std::default::Default::default()
+            .. Default::default()
         }).unwrap();
 
     let read_back: Vec<Vec<(f32, f32, f32, f32)>> = texture.read();
@@ -174,7 +174,7 @@ fn cull_clockwise_trianglestrip() {
     texture.as_surface().draw(&vertex_buffer, &index_buffer, &program, &glium::uniforms::EmptyUniforms,
         &glium::DrawParameters {
             backface_culling: glium::BackfaceCullingMode::CullClockWise,
-            .. std::default::Default::default()
+            .. Default::default()
         }).unwrap();
 
     let read_back: Vec<Vec<(f32, f32, f32, f32)>> = texture.read();
@@ -233,7 +233,7 @@ fn cull_counterclockwise_trianglestrip() {
     texture.as_surface().draw(&vertex_buffer, &index_buffer, &program, &glium::uniforms::EmptyUniforms,
         &glium::DrawParameters {
             backface_culling: glium::BackfaceCullingMode::CullCounterClockWise,
-            .. std::default::Default::default()
+            .. Default::default()
         }).unwrap();
 
     let read_back: Vec<Vec<(f32, f32, f32, f32)>> = texture.read();

--- a/tests/blending.rs
+++ b/tests/blending.rs
@@ -13,7 +13,7 @@ macro_rules! blending_test {
 
             let params = glium::DrawParameters {
                 blending_function: Some($func),
-                .. std::default::Default::default()
+                .. Default::default()
             };
 
             let (vb, ib) = support::build_rectangle_vb_ib(&display);

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate glium;
 
-use std::default::Default;
 use glium::Surface;
 
 mod support;

--- a/tests/draw_parameters.rs
+++ b/tests/draw_parameters.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate glium;
 
-use std::default::Default;
 use glium::Surface;
 
 mod support;

--- a/tests/framebuffer.rs
+++ b/tests/framebuffer.rs
@@ -16,7 +16,7 @@ fn no_depth_buffer_depth_test() {
 
     let parameters = glium::DrawParameters {
         depth_test: glium::DepthTest::IfLess,
-        .. std::default::Default::default()
+        .. Default::default()
     };
 
     match framebuffer.draw(&vertex_buffer, &index_buffer, &program,
@@ -40,7 +40,7 @@ fn no_depth_buffer_depth_write() {
 
     let parameters = glium::DrawParameters {
         depth_write: true,
-        .. std::default::Default::default()
+        .. Default::default()
     };
 
     match framebuffer.draw(&vertex_buffer, &index_buffer, &program,
@@ -69,8 +69,6 @@ fn simple_dimensions() {
 
 #[test]
 fn simple_render_to_texture() {
-    use std::default::Default;
-
     let display = support::build_display();
     let (vb, ib, program) = support::build_fullscreen_red_pipeline(&display);
 
@@ -154,7 +152,7 @@ fn depth_texture2d() {
                                                                                    &color, &depth);
     let params = glium::DrawParameters {
         depth_test: glium::DepthTest::IfLess,
-        .. std::default::Default::default()
+        .. Default::default()
     };
 
     framebuffer.clear_color(0.0, 0.0, 0.0, 1.0);
@@ -218,7 +216,7 @@ fn multioutput() {
                                              &[("color1", &color1), ("color2", &color2)]);
 
     framebuffer.draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms,
-                     &std::default::Default::default()).unwrap();
+                     &Default::default()).unwrap();
 
     // checking color1
     let read_back1: Vec<Vec<(f32, f32, f32, f32)>> = color1.read();

--- a/tests/indices.rs
+++ b/tests/indices.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate glium;
 
-use std::default::Default;
 use glium::{index, Surface};
 
 mod support;

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate glium;
 
-use std::default::Default;
 use glium::Surface;
 
 mod support;

--- a/tests/samplers.rs
+++ b/tests/samplers.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate glium;
 
-use std::default::Default;
 use glium::Surface;
 
 mod support;

--- a/tests/shaders.rs
+++ b/tests/shaders.rs
@@ -4,7 +4,6 @@
 #[macro_use]
 extern crate glium;
 
-use std::default::Default;
 use glium::Surface;
 
 mod support;

--- a/tests/texture_draw.rs
+++ b/tests/texture_draw.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate glium;
 
-use std::default::Default;
 use glium::Surface;
 
 mod support;

--- a/tests/texture_sample.rs
+++ b/tests/texture_sample.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate glium;
 
-use std::default::Default;
 use glium::Surface;
 
 mod support;

--- a/tests/uniform_buffer.rs
+++ b/tests/uniform_buffer.rs
@@ -3,7 +3,6 @@ extern crate glium;
 extern crate rand;
 
 use glium::Surface;
-use std::default::Default;
 
 mod support;
 

--- a/tests/uniforms.rs
+++ b/tests/uniforms.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate glium;
 
-use std::default::Default;
 use glium::Surface;
 
 mod support;

--- a/tests/vertex_source.rs
+++ b/tests/vertex_source.rs
@@ -2,7 +2,6 @@
 extern crate glium;
 
 use glium::Surface;
-use std::default::Default;
 
 mod support;
 
@@ -100,7 +99,7 @@ fn multiple_buffers_source() {
     let texture = support::build_renderable_texture(&display);
     texture.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
     texture.as_surface().draw((&buffer1, &buffer2), &index_buffer, &program, &uniform!{},
-                              &std::default::Default::default()).unwrap();
+                              &Default::default()).unwrap();
 
     let data: Vec<Vec<(f32, f32, f32, f32)>> = texture.read();
     for row in data.iter() {
@@ -382,7 +381,7 @@ fn attributes_marker() {
     texture.as_surface().draw(glium::vertex::EmptyVertexAttributes { len: 4 },
                               &glium::index::NoIndices(glium::index::PrimitiveType::TriangleStrip),
                               &program, &uniform!{},
-                              &std::default::Default::default()).unwrap();
+                              &Default::default()).unwrap();
 
     let data: Vec<Vec<(f32, f32, f32, f32)>> = texture.read();
     for row in data.iter() {
@@ -434,7 +433,7 @@ fn attributes_marker_indices() {
     texture.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
     texture.as_surface().draw(glium::vertex::EmptyVertexAttributes { len: 4 },
                               &indices, &program, &uniform!{},
-                              &std::default::Default::default()).unwrap();
+                              &Default::default()).unwrap();
 
     let data: Vec<Vec<(f32, f32, f32, f32)>> = texture.read();
     for row in data.iter() {
@@ -531,7 +530,7 @@ fn instancing() {
     let texture = support::build_renderable_texture(&display);
     texture.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
     texture.as_surface().draw((&buffer1, buffer2), &index_buffer, &program, &uniform!{},
-                              &std::default::Default::default()).unwrap();
+                              &Default::default()).unwrap();
 
     let data: Vec<Vec<(f32, f32, f32, f32)>> = texture.read();
     for row in data.iter() {
@@ -648,7 +647,7 @@ fn per_instance_length_mismatch() {
         }).unwrap();
 
     match display.draw().draw((&buffer1, buffer2, buffer3), &index_buffer, &program, &uniform!{},
-                              &std::default::Default::default())
+                              &Default::default())
     {
         Err(glium::DrawError::InstancesCountMismatch) => (),
         a => panic!("{:?}", a)


### PR DESCRIPTION
Default is in the prelude so we don't need to import or include the full path.