### PR TITLE
Implemented Texture2dArray

### DIFF
--- a/build/textures.rs
+++ b/build/textures.rs
@@ -643,17 +643,11 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
                 ")).unwrap(),   // TODO: panic if dimensions are inconsistent
 
             TextureDimensions::Texture2dArray => (write!(dest, "
-                    let array_size = 0;
-                    let internal_data: Cow<'a, [u8]>  = Cow::Owned(Vec::<u8>::new());
-                    let width = 0;
-                    let height = 0;
-                    let client_format: ClientFormat = unsafe {{ ::std::mem::uninitialized() }};
-                    let mut vec_raw = Vec::new();
-                    for ite in data {{
-                        vec_raw.push(ite.into_raw());
-                    }}
-                    let RawImage3d {{data: internal_data, width, height, depth: array_size, format: client_format }} = RawImage3d::from_vec_raw2d(&vec_raw);
-                    let data = internal_data;
+                    let mut vec_raw = data.into_iter().map(|e| e.into_raw()).collect();
+                    let RawImage3d {{data, width, height, depth: array_size, format: client_format }} = match RawImage3d::from_vec_raw2d(&vec_raw) {{
+                        Ok(var)  => var,
+                        Err(reason) => {{return Err(reason);}}
+                    }};
                 ")).unwrap(),   // TODO: panic if dimensions are inconsistent
 
             _ => unreachable!()

--- a/build/textures.rs
+++ b/build/textures.rs
@@ -643,7 +643,7 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
                 ")).unwrap(),   // TODO: panic if dimensions are inconsistent
 
             TextureDimensions::Texture2dArray => (write!(dest, "
-                    let mut vec_raw = data.into_iter().map(|e| e.into_raw()).collect();
+                    let vec_raw = data.into_iter().map(|e| e.into_raw()).collect();
                     let RawImage3d {{data, width, height, depth: array_size, format: client_format }} = match RawImage3d::from_vec_raw2d(&vec_raw) {{
                         Ok(var)  => var,
                         Err(reason) => {{return Err(reason);}}

--- a/build/textures.rs
+++ b/build/textures.rs
@@ -644,10 +644,7 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
 
             TextureDimensions::Texture2dArray => (write!(dest, "
                     let vec_raw = data.into_iter().map(|e| e.into_raw()).collect();
-                    let RawImage3d {{data, width, height, depth: array_size, format: client_format }} = match RawImage3d::from_vec_raw2d(&vec_raw) {{
-                        Ok(var)  => var,
-                        Err(reason) => {{return Err(reason);}}
-                    }};
+                    let RawImage3d {{data, width, height, depth: array_size, format: client_format }} = RawImage3d::from_vec_raw2d(&vec_raw);
                 ")).unwrap(),   // TODO: panic if dimensions are inconsistent
 
             _ => unreachable!()

--- a/build/textures.rs
+++ b/build/textures.rs
@@ -644,11 +644,16 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
 
             TextureDimensions::Texture2dArray => (write!(dest, "
                     let array_size = 0;
-                    let data = Cow::Owned(Vec::<u8>::new());
+                    let internal_data: Cow<'a, [u8]>  = Cow::Owned(Vec::<u8>::new());
                     let width = 0;
                     let height = 0;
-                    let client_format = unsafe {{ ::std::mem::uninitialized() }};
-                    unimplemented!();
+                    let client_format: ClientFormat = unsafe {{ ::std::mem::uninitialized() }};
+                    let mut vec_raw = Vec::new();
+                    for ite in data {{
+                        vec_raw.push(ite.into_raw());
+                    }}
+                    let RawImage3d {{data: internal_data, width, height, depth: array_size, format: client_format }} = RawImage3d::from_vec_raw2d(&vec_raw);
+                    let data = internal_data;
                 ")).unwrap(),   // TODO: panic if dimensions are inconsistent
 
             _ => unreachable!()

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -358,6 +358,35 @@ pub struct RawImage3d<'a, T: Clone + 'a> {
     pub format: ClientFormat,
 }
 
+impl<'a, T: Clone + 'a> RawImage3d<'a, T> {
+    ///Transforms a Vec<RawImage2d> into a RawImage3d
+    pub fn from_vec_raw2d(arr: &Vec<RawImage2d<'a, T>>) -> RawImage3d<'a, T> {
+        let depth   = arr.len();
+        let width   = arr[0].width;
+        let height  = arr[0].height;
+        let format  = arr[0].format;
+        let clo = |v, w, h, d, f| {
+            let mut vec = Vec::<T>::new();
+            for i in arr {
+                if width != i.width || height != i.height || format != i.format {
+                    panic!("Varying dimensions or formats were found.");
+                }
+                for j in i.data.iter() {
+                    vec.push(j.clone());
+                }
+            }
+            vec
+        };
+        RawImage3d {
+            data: Cow::Owned(clo(arr, width, height, depth, format)),
+            width: width,
+            height: height,
+            depth: depth as u32,
+            format: format,
+        }
+    }
+}
+
 impl<'a, P: PixelValue + Clone> Texture3dDataSource<'a> for Vec<Vec<Vec<P>>> {
     type Data = P;
 

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -366,7 +366,7 @@ impl<'a, T: Clone + 'a> RawImage3d<'a, T> {
         let height  = arr[0].height;
         let format  = arr[0].format;
         let raw_data = {
-            let mut vec = Vec::<T>::new();
+            let mut vec = Vec::<T>::with_capacity((width * height * depth as u32) as usize);
             for i in arr {
                 if width != i.width || height != i.height {
                     return Err(TextureMaybeSupportedCreationError::CreationError(TextureCreationError::DimensionsNotSupported));

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -360,7 +360,7 @@ pub struct RawImage3d<'a, T: Clone + 'a> {
 
 impl<'a, T: Clone + 'a> RawImage3d<'a, T> {
     ///Transforms a Vec<RawImage2d> into a RawImage3d
-    pub fn from_vec_raw2d(arr: &Vec<RawImage2d<'a, T>>) -> Result<RawImage3d<'a, T>, TextureMaybeSupportedCreationError> {
+    pub fn from_vec_raw2d(arr: &Vec<RawImage2d<'a, T>>) -> RawImage3d<'a, T> {
         let depth   = arr.len();
         let width   = arr[0].width;
         let height  = arr[0].height;
@@ -369,10 +369,9 @@ impl<'a, T: Clone + 'a> RawImage3d<'a, T> {
             let mut vec = Vec::<T>::with_capacity((width * height * depth as u32) as usize);
             for i in arr {
                 if width != i.width || height != i.height {
-                    return Err(TextureMaybeSupportedCreationError::CreationError(TextureCreationError::DimensionsNotSupported));
-                }
-                if format != i.format {
-                    return Err(TextureMaybeSupportedCreationError::CreationError(TextureCreationError::UnsupportedFormat));
+                    panic!("Varying dimensions were found.");
+                } else if format != i.format {
+                    panic!("Varying formats were found.");
                 }
                 for j in i.data.iter() {
                     vec.push(j.clone());
@@ -380,13 +379,13 @@ impl<'a, T: Clone + 'a> RawImage3d<'a, T> {
             }
             vec
         };
-        Ok(RawImage3d {
+        RawImage3d {
             data: Cow::Owned(raw_data),
             width: width,
             height: height,
             depth: depth as u32,
             format: format,
-        })
+        }
     }
 }
 


### PR DESCRIPTION
Implements a Vec<RawImage2d> to RawImage3d functions and uses it in the build/textures.rs bit.

This probably isn't the best way, but it works.