### PR TITLE
Fix most documentation warnings

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -221,6 +221,7 @@ impl Context {
     }
 
     // TODO: make me private
+    #[allow(missing_docs)]
     pub fn capabilities(&self) -> &Capabilities {
         &self.capabilities
     }
@@ -231,6 +232,7 @@ impl Context {
     }
 
     // TODO: make me private
+    #[allow(missing_docs)]
     pub fn get_extensions(&self) -> &ExtensionsList {
         &self.extensions
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -662,7 +662,7 @@ pub enum DrawError {
     /// You requested not to draw primitives, but this is not supported by the backend.
     TransformFeedbackNotSupported,
 
-    // TODO: document me
+    /// See the documentation of the `draw_parameters` module for infos.
     WrongQueryOperation,
 }
 

--- a/src/vertex/mod.rs
+++ b/src/vertex/mod.rs
@@ -144,7 +144,14 @@ pub enum VerticesSource<'a> {
     /// "per vertex" (false).
     VertexBuffer(SubBufferAnySlice<'a>, &'a VertexFormat, bool),
 
-    Marker { len: usize, per_instance: bool },
+    /// A marker indicating a "phantom list of attributes".
+    Marker {
+        /// Number of attributes.
+        len: usize,
+
+        /// Whether or not this buffer is "per instance" (true) or "per vertex" (false).
+        per_instance: bool,
+    },
 }
 
 /// Objects that can be used as vertex sources.
@@ -160,7 +167,10 @@ impl<'a> IntoVerticesSource<'a> for VerticesSource<'a> {
 }
 
 /// Marker that can be passed instead of a buffer to indicate an empty list of buffers.
-pub struct EmptyVertexAttributes { pub len: usize }
+pub struct EmptyVertexAttributes {
+    /// Number of phantom vertices.
+    pub len: usize,
+}
 
 impl<'a> IntoVerticesSource<'a> for EmptyVertexAttributes {
     fn into_vertices_source(self) -> VerticesSource<'a> {
@@ -169,7 +179,10 @@ impl<'a> IntoVerticesSource<'a> for EmptyVertexAttributes {
 }
 
 /// Marker that can be passed instead of a buffer to indicate an empty list of buffers.
-pub struct EmptyInstanceAttributes { pub len: usize }
+pub struct EmptyInstanceAttributes {
+    /// Number of phantom vertices.
+    pub len: usize,
+}
 
 impl<'a> IntoVerticesSource<'a> for EmptyInstanceAttributes {
     fn into_vertices_source(self) -> VerticesSource<'a> {


### PR DESCRIPTION
Close #792 

Only the `program` module remains undocumented.
