### PR TITLE
Calling .map() on a SubBuffer now calls glMapBuffer again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
  - `Display`/`GlutinFacade` now derefs to `Context`.
+ - Mapping a buffer now simply calls `glMapBuffer` again, instead of writing to a temporary buffer.
 
 ## Version 0.4.1 (2015-02-22)
 


### PR DESCRIPTION
Unless the SubBuffer is only a slice of a bigger buffer, in which case
it will create a temporary buffer as it's currently the case

Close #867 