### PR TITLE
Add some buffer types

### DIFF
--- a/src/buffer/alloc.rs
+++ b/src/buffer/alloc.rs
@@ -849,6 +849,114 @@ unsafe fn bind_buffer(mut ctxt: &mut CommandContext, id: gl::types::GLuint, ty: 
 
             gl::COPY_WRITE_BUFFER
         },
+
+        BufferType::DispatchIndirectBuffer => {
+            if ctxt.state.dispatch_indirect_buffer_binding != id {
+                ctxt.state.dispatch_indirect_buffer_binding = id;
+
+                if ctxt.version >= &Version(Api::Gl, 1, 5) ||
+                    ctxt.version >= &Version(Api::GlEs, 2, 0)
+                {
+                    ctxt.gl.BindBuffer(gl::DISPATCH_INDIRECT_BUFFER, id);
+                } else if ctxt.extensions.gl_arb_vertex_buffer_object {
+                    ctxt.gl.BindBufferARB(gl::DISPATCH_INDIRECT_BUFFER, id);    // bind points are the same in the ext
+                } else {
+                    unreachable!();
+                }
+            }
+
+            gl::DISPATCH_INDIRECT_BUFFER
+        },
+
+        BufferType::DrawIndirectBuffer => {
+            if ctxt.state.draw_indirect_buffer_binding != id {
+                ctxt.state.draw_indirect_buffer_binding = id;
+
+                if ctxt.version >= &Version(Api::Gl, 1, 5) ||
+                    ctxt.version >= &Version(Api::GlEs, 2, 0)
+                {
+                    ctxt.gl.BindBuffer(gl::DRAW_INDIRECT_BUFFER, id);
+                } else if ctxt.extensions.gl_arb_vertex_buffer_object {
+                    ctxt.gl.BindBufferARB(gl::DRAW_INDIRECT_BUFFER, id);    // bind points are the same in the ext
+                } else {
+                    unreachable!();
+                }
+            }
+
+            gl::DRAW_INDIRECT_BUFFER
+        },
+
+        BufferType::QueryBuffer => {
+            if ctxt.state.query_buffer_binding != id {
+                ctxt.state.query_buffer_binding = id;
+
+                if ctxt.version >= &Version(Api::Gl, 1, 5) ||
+                    ctxt.version >= &Version(Api::GlEs, 2, 0)
+                {
+                    ctxt.gl.BindBuffer(gl::QUERY_BUFFER, id);
+                } else if ctxt.extensions.gl_arb_vertex_buffer_object {
+                    ctxt.gl.BindBufferARB(gl::QUERY_BUFFER, id);    // bind points are the same in the ext
+                } else {
+                    unreachable!();
+                }
+            }
+
+            gl::QUERY_BUFFER
+        },
+
+        BufferType::TextureBuffer => {
+            if ctxt.state.texture_buffer_binding != id {
+                ctxt.state.texture_buffer_binding = id;
+
+                if ctxt.version >= &Version(Api::Gl, 1, 5) ||
+                    ctxt.version >= &Version(Api::GlEs, 2, 0)
+                {
+                    ctxt.gl.BindBuffer(gl::TEXTURE_BUFFER, id);
+                } else if ctxt.extensions.gl_arb_vertex_buffer_object {
+                    ctxt.gl.BindBufferARB(gl::TEXTURE_BUFFER, id);    // bind points are the same in the ext
+                } else {
+                    unreachable!();
+                }
+            }
+
+            gl::TEXTURE_BUFFER
+        },
+
+        BufferType::AtomicCounterBuffer => {
+            if ctxt.state.atomic_counter_buffer_binding != id {
+                ctxt.state.atomic_counter_buffer_binding = id;
+
+                if ctxt.version >= &Version(Api::Gl, 1, 5) ||
+                    ctxt.version >= &Version(Api::GlEs, 2, 0)
+                {
+                    ctxt.gl.BindBuffer(gl::ATOMIC_COUNTER_BUFFER, id);
+                } else if ctxt.extensions.gl_arb_vertex_buffer_object {
+                    ctxt.gl.BindBufferARB(gl::ATOMIC_COUNTER_BUFFER, id);    // bind points are the same in the ext
+                } else {
+                    unreachable!();
+                }
+            }
+
+            gl::ATOMIC_COUNTER_BUFFER
+        },
+
+        BufferType::ShaderStorageBuffer => {
+            if ctxt.state.shader_storage_buffer_binding != id {
+                ctxt.state.shader_storage_buffer_binding = id;
+
+                if ctxt.version >= &Version(Api::Gl, 1, 5) ||
+                    ctxt.version >= &Version(Api::GlEs, 2, 0)
+                {
+                    ctxt.gl.BindBuffer(gl::SHADER_STORAGE_BUFFER, id);
+                } else if ctxt.extensions.gl_arb_vertex_buffer_object {
+                    ctxt.gl.BindBufferARB(gl::SHADER_STORAGE_BUFFER, id);    // bind points are the same in the ext
+                } else {
+                    unreachable!();
+                }
+            }
+
+            gl::SHADER_STORAGE_BUFFER
+        },
     }
 }
 

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -44,6 +44,14 @@ pub enum BufferType {
     UniformBuffer,
     CopyReadBuffer,
     CopyWriteBuffer,
+    AtomicCounterBuffer,
+    DispatchIndirectBuffer,
+    DrawIndirectBuffer,
+    QueryBuffer,
+    ShaderStorageBuffer,
+    TextureBuffer,
+    //TransformFeedbackBuffer,
+    //ElementArrayBuffer,
 }
 
 impl BufferType {
@@ -55,6 +63,14 @@ impl BufferType {
             BufferType::UniformBuffer => gl::UNIFORM_BUFFER,
             BufferType::CopyReadBuffer => gl::COPY_READ_BUFFER,
             BufferType::CopyWriteBuffer => gl::COPY_WRITE_BUFFER,
+            BufferType::AtomicCounterBuffer => gl::ATOMIC_COUNTER_BUFFER,
+            BufferType::DispatchIndirectBuffer => gl::DISPATCH_INDIRECT_BUFFER,
+            BufferType::DrawIndirectBuffer => gl::DRAW_INDIRECT_BUFFER,
+            BufferType::QueryBuffer => gl::QUERY_BUFFER,
+            BufferType::ShaderStorageBuffer => gl::SHADER_STORAGE_BUFFER,
+            BufferType::TextureBuffer => gl::TEXTURE_BUFFER,
+            //BufferType::TransformFeedbackBuffer => gl::TRANSFORM_FEEDBACK_BUFFER,
+            //BufferType::ElementArrayBuffer => gl::ELEMENT_ARRAY_BUFFER,
         }
     }
 }

--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -85,6 +85,24 @@ pub struct GlState {
     /// The latest buffer bound to `GL_COPY_WRITE_BUFFER`.
     pub copy_write_buffer_binding: gl::types::GLuint,
 
+    /// The latest buffer bound to `GL_DISPATCH_INDIRECT_BUFFER`.
+    pub dispatch_indirect_buffer_binding: gl::types::GLuint,
+
+    /// The latest buffer bound to `GL_DRAW_INDIRECT_BUFFER`.
+    pub draw_indirect_buffer_binding: gl::types::GLuint,
+
+    /// The latest buffer bound to `GL_QUERY_BUFFER`.
+    pub query_buffer_binding: gl::types::GLuint,
+
+    /// The latest buffer bound to `GL_TEXTURE_BUFFER`.
+    pub texture_buffer_binding: gl::types::GLuint,
+
+    /// The latest buffer bound to `GL_ATOMIC_COUNTER_BUFFER`.
+    pub atomic_counter_buffer_binding: gl::types::GLuint,
+
+    /// The latest buffer bound to `GL_SHADER_STORAGE_BUFFER`.
+    pub shader_storage_buffer_binding: gl::types::GLuint,
+
     /// The latest buffer bound to `GL_READ_FRAMEBUFFER`.
     pub read_framebuffer: gl::types::GLuint,
 
@@ -232,6 +250,12 @@ impl Default for GlState {
             uniform_buffer_binding: 0,
             copy_read_buffer_binding: 0,
             copy_write_buffer_binding: 0,
+            dispatch_indirect_buffer_binding: 0,
+            draw_indirect_buffer_binding: 0,
+            query_buffer_binding: 0,
+            texture_buffer_binding: 0,
+            atomic_counter_buffer_binding: 0,
+            shader_storage_buffer_binding: 0,
             read_framebuffer: 0,
             draw_framebuffer: 0,
             default_framebuffer_read: None,


### PR DESCRIPTION
Added all buffer types except element array buffers (because of the VAO ownership problem) and transform feedback buffer (because binding a transform feedback buffer is equivalent to binding the indexed transform feedback buffer 0).