### PR TITLE
Use a GL_ELEMENT_ARRAY_BUFFER enum when creating an index buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  - `Display`/`GlutinFacade` now derefs to `Context`.
  - Mapping a buffer now simply calls `glMapBuffer` again, instead of writing to a temporary buffer.
  - `glutin` is now an optional dependency (enabled by default).
+ - Creating an index buffer now correctly uses a `GL_ELEMENT_ARRAY_BUFFER`.
 
 ## Version 0.4.1 (2015-02-22)
 

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -51,7 +51,7 @@ pub enum BufferType {
     ShaderStorageBuffer,
     TextureBuffer,
     //TransformFeedbackBuffer,
-    //ElementArrayBuffer,
+    ElementArrayBuffer,
 }
 
 impl BufferType {
@@ -70,7 +70,7 @@ impl BufferType {
             BufferType::ShaderStorageBuffer => gl::SHADER_STORAGE_BUFFER,
             BufferType::TextureBuffer => gl::TEXTURE_BUFFER,
             //BufferType::TransformFeedbackBuffer => gl::TRANSFORM_FEEDBACK_BUFFER,
-            //BufferType::ElementArrayBuffer => gl::ELEMENT_ARRAY_BUFFER,
+            BufferType::ElementArrayBuffer => gl::ELEMENT_ARRAY_BUFFER,
         }
     }
 }

--- a/src/index/buffer.rs
+++ b/src/index/buffer.rs
@@ -43,8 +43,8 @@ impl IndexBuffer {
         assert!(mem::align_of::<T>() <= mem::size_of::<T>(), "Buffer elements are not \
                                                               packed in memory");
         IndexBuffer {
-            buffer: SubBuffer::new(facade, data.as_ref(), BufferType::ArrayBuffer,
-                                   false).unwrap().into(),    // FIXME: ElementArrayBuffer
+            buffer: SubBuffer::new(facade, data.as_ref(), BufferType::ElementArrayBuffer,
+                                   false).unwrap().into(),
             data_type: <T as Index>::get_type(),
             primitives: prim,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,9 +208,6 @@ trait ContextExt {
     /// Returns the list of framebuffer objects.
     fn get_framebuffer_objects(&self) -> &fbo::FramebuffersContainer;
 
-    /// Returns the list of vertex array objects.
-    fn get_vertex_array_objects(&self) -> &vertex_array_object::VertexAttributesSystem;
-
     /// Returns the list of samplers.
     fn get_samplers(&self) -> &RefCell<HashMap<uniforms::SamplerBehavior,
                                                sampler_object::SamplerObject>>;

--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -23,6 +23,7 @@ use sampler_object::SamplerObject;
 use {Program, GlObject, ToGlEnum};
 use index::{self, IndicesSource};
 use vertex::{MultiVerticesSource, VerticesSource};
+use vertex_array_object::VertexAttributesSystem;
 
 use draw_parameters::DrawParameters;
 use draw_parameters::{BlendingFunction, BackfaceCullingMode};
@@ -91,7 +92,7 @@ pub fn draw<'a, U, V>(context: &Context, framebuffer: Option<&FramebufferAttachm
         };
 
         // object that is used to build the bindings
-        let mut binder = context.get_vertex_array_objects().start(&mut ctxt, program, ib_id);
+        let mut binder = VertexAttributesSystem::start(&mut ctxt, program, ib_id);
         // number of vertices in the vertices sources, or `None` if there is a mismatch
         let mut vertices_count: Option<usize> = None;
         // number of instances to draw

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -29,6 +29,8 @@ use program::reflection::{reflect_uniforms, reflect_attributes, reflect_uniform_
 use program::reflection::{reflect_transform_feedback};
 use program::shader::build_shader;
 
+use vertex_array_object::VertexAttributesSystem;
+
 /// Error that can be triggered when creating a `Program`.
 #[derive(Clone, Debug)]
 pub enum ProgramCreationError {
@@ -591,7 +593,7 @@ impl Drop for Program {
         let mut ctxt = self.context.make_current();
 
         // removing VAOs which contain this program
-        self.context.get_vertex_array_objects().purge_program(&mut ctxt, self.id);
+        VertexAttributesSystem::purge_program(&mut ctxt, self.id);
 
         // sending the destroy command
         unsafe {


### PR DESCRIPTION
- The vertex attributes system is no longer separate from the `CommandsContext`.
- Binding an element array buffer now "hijacks" the current VAO so that it calls `BindBuffer` again the next time it is used.
- Operations on an index buffer now correctly use the element array buffer.
