### PR TITLE
Preliminary implementation of multidraw indirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+ - Added `index::DrawCommandsNoIndicesBuffer` for multidraw indirect drawing.
+
 ## Version 0.5.0 (2015-05-27)
 
  - `IndexBuffer` now takes the type of indices as template parameter.

--- a/build/main.rs
+++ b/build/main.rs
@@ -43,6 +43,7 @@ fn generate_gl_bindings<W>(dest: &mut W) where W: Write {
                 "GL_ARB_framebuffer_sRGB".to_string(),
                 "GL_ARB_geometry_shader4".to_string(),
                 "GL_ARB_invalidate_subdata".to_string(),
+                "GL_ARB_multi_draw_indirect".to_string(),
                 "GL_ARB_occlusion_query".to_string(),
                 "GL_ARB_pixel_buffer_object".to_string(),
                 "GL_ARB_shader_objects".to_string(),
@@ -86,6 +87,7 @@ fn generate_gl_bindings<W>(dest: &mut W) where W: Write {
             api: gl_generator::registry::Ns::Gles2.to_string(),
             extensions: vec![
                 "GL_EXT_disjoint_timer_query".to_string(),
+                "GL_EXT_multi_draw_indirect".to_string(),
                 "GL_EXT_occlusion_query_boolean".to_string(),
                 "GL_KHR_debug".to_string(),
                 "GL_NV_copy_buffer".to_string(),

--- a/src/buffer/alloc.rs
+++ b/src/buffer/alloc.rs
@@ -758,6 +758,14 @@ fn is_buffer_type_supported(ctxt: &mut CommandContext, ty: BufferType) -> bool {
             ctxt.version >= &Version(Api::GlEs, 3, 0) || ctxt.extensions.gl_nv_copy_buffer
         },
 
+        BufferType::DrawIndirectBuffer => {
+            // TODO: draw indirect buffers are actually supported in OpenGL 4.0 or
+            //       with GL_ARB_draw_indirect, but restricting to multidraw is more convenient
+            //       for index/multidraw.rs
+            ctxt.version >= &Version(Api::Gl, 4, 3) || ctxt.extensions.gl_arb_multi_draw_indirect ||
+            ctxt.extensions.gl_ext_multi_draw_indirect
+        },
+
         _ => false,     // FIXME: 
     }
 }

--- a/src/context/extensions.rs
+++ b/src/context/extensions.rs
@@ -42,6 +42,8 @@ pub struct ExtensionsList {
     pub gl_arb_invalidate_subdata: bool,
     /// GL_ARB_map_buffer_range
     pub gl_arb_map_buffer_range: bool,
+    /// GL_ARB_multi_draw_indirect
+    pub gl_arb_multi_draw_indirect: bool,
     /// GL_ARB_occlusion_query
     pub gl_arb_occlusion_query: bool,
     /// GL_ARB_occlusion_query2
@@ -98,6 +100,8 @@ pub struct ExtensionsList {
     pub gl_ext_geometry_shader4: bool,
     /// GL_EXT_gpu_shader4
     pub gl_ext_gpu_shader4: bool,
+    /// GL_EXT_multi_draw_indirect
+    pub gl_ext_multi_draw_indirect: bool,
     /// GL_EXT_occlusion_query_boolean
     pub gl_ext_occlusion_query_boolean: bool,
     /// GL_EXT_packed_depth_stencil
@@ -167,6 +171,7 @@ pub unsafe fn get_extensions(gl: &gl::Gl, version: &Version) -> ExtensionsList {
         gl_arb_occlusion_query: false,
         gl_arb_occlusion_query2: false,
         gl_arb_map_buffer_range: false,
+        gl_arb_multi_draw_indirect: false,
         gl_arb_pixel_buffer_object: false,
         gl_arb_sampler_objects: false,
         gl_arb_shader_objects: false,
@@ -193,6 +198,7 @@ pub unsafe fn get_extensions(gl: &gl::Gl, version: &Version) -> ExtensionsList {
         gl_ext_framebuffer_srgb: false,
         gl_ext_geometry_shader4: false,
         gl_ext_gpu_shader4: false,
+        gl_ext_multi_draw_indirect: false,
         gl_ext_occlusion_query_boolean: false,
         gl_ext_packed_depth_stencil: false,
         gl_ext_texture_compression_s3tc: false,
@@ -234,6 +240,7 @@ pub unsafe fn get_extensions(gl: &gl::Gl, version: &Version) -> ExtensionsList {
             "GL_ARB_occlusion_query2" => extensions.gl_arb_occlusion_query2 = true,
             "GL_ARB_pixel_buffer_object" => extensions.gl_arb_pixel_buffer_object = true,
             "GL_ARB_map_buffer_range" => extensions.gl_arb_map_buffer_range = true,
+            "GL_ARB_multi_draw_indirect" => extensions.gl_arb_multi_draw_indirect = true,
             "GL_ARB_sampler_objects" => extensions.gl_arb_sampler_objects = true,
             "GL_ARB_shader_objects" => extensions.gl_arb_shader_objects = true,
             "GL_ARB_sync" => extensions.gl_arb_sync = true,
@@ -259,6 +266,7 @@ pub unsafe fn get_extensions(gl: &gl::Gl, version: &Version) -> ExtensionsList {
             "GL_EXT_framebuffer_sRGB" => extensions.gl_ext_framebuffer_srgb = true,
             "GL_EXT_geometry_shader4" => extensions.gl_ext_geometry_shader4 = true,
             "GL_EXT_gpu_shader4" => extensions.gl_ext_gpu_shader4 = true,
+            "GL_EXT_multi_draw_indirect" => extensions.gl_ext_multi_draw_indirect = true,
             "GL_EXT_occlusion_query_boolean" => extensions.gl_ext_occlusion_query_boolean = true,
             "GL_EXT_packed_depth_stencil" => extensions.gl_ext_packed_depth_stencil = true,
             "GL_EXT_texture_compression_s3tc" => extensions.gl_ext_texture_compression_s3tc = true,

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -40,8 +40,10 @@ use std::mem;
 use buffer::BufferViewAnySlice;
 
 pub use self::buffer::{IndexBuffer, IndexBufferSlice, IndexBufferAny};
+pub use self::multidraw::{DrawCommandsNoIndicesBuffer, DrawCommandNoIndices};
 
 mod buffer;
+mod multidraw;
 
 /// Describes a source of indices used for drawing.
 #[derive(Clone)]
@@ -52,6 +54,14 @@ pub enum IndicesSource<'a> {
         buffer: BufferViewAnySlice<'a>,
         /// Type of indices in the buffer.
         data_type: IndexType,
+        /// Type of primitives contained in the vertex source.
+        primitives: PrimitiveType,
+    },
+
+    /// Use a multidraw indirect buffer without indices.
+    MultidrawArray {
+        /// The buffer.
+        buffer: BufferViewAnySlice<'a>,
         /// Type of primitives contained in the vertex source.
         primitives: PrimitiveType,
     },
@@ -69,6 +79,7 @@ impl<'a> IndicesSource<'a> {
     pub fn get_primitives_type(&self) -> PrimitiveType {
         match self {
             &IndicesSource::IndexBuffer { primitives, .. } => primitives,
+            &IndicesSource::MultidrawArray { primitives, .. } => primitives,
             &IndicesSource::NoIndices { primitives } => primitives,
         }
     }

--- a/src/index/multidraw.rs
+++ b/src/index/multidraw.rs
@@ -1,0 +1,97 @@
+//! Allows one to draw multiple geometry located in the same buffer.
+//!
+use libc;
+
+use std::ops::Deref;
+use std::ops::DerefMut;
+
+use backend::Facade;
+use buffer::{BufferCreationError, BufferType, BufferView};
+use index::{IndicesSource, PrimitiveType};
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[allow(missing_docs)]      // TODO: remove this
+pub struct DrawCommandNoIndices {
+    /// Number of vertices to draw.
+    pub count: libc::c_uint,
+    /// Number of instances to draw. If it's `0`, nothing will be drawn.
+    pub instance_count: libc::c_uint,
+    /// First vertex to draw in the vertices source.
+    pub first_index: libc::c_uint,
+    /// Numero of the first instance to draw.
+    pub base_instance: libc::c_uint,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[allow(missing_docs)]      // TODO: remove this
+pub struct DrawCommandIndices {
+    pub count: libc::c_uint,
+    pub instance_count: libc::c_uint,
+    pub first_index: libc::c_uint,
+    pub base_vertex: libc::c_uint,
+    pub base_instance: libc::c_uint,
+}
+
+/// A buffer containing a list of draw commands.
+pub struct DrawCommandsNoIndicesBuffer {
+    buffer: BufferView<DrawCommandNoIndices>,
+}
+
+impl DrawCommandsNoIndicesBuffer {
+    /// Builds an empty buffer.
+    ///
+    /// The parameter indicates the number of elements.
+    pub fn empty_if_supported<F>(facade: &F, elements: usize)
+                                 -> Option<DrawCommandsNoIndicesBuffer>
+                                 where F: Facade
+    {
+        match BufferView::empty(facade, BufferType::DrawIndirectBuffer,
+                                elements, false)
+        {
+            Ok(buf) => Some(DrawCommandsNoIndicesBuffer { buffer: buf }),
+            Err(BufferCreationError::BufferTypeNotSupported) => None,
+            Err(_) => panic!()
+        }
+    }
+
+    /// Builds an empty buffer.
+    ///
+    /// The parameter indicates the number of elements.
+    pub fn empty_dynamic_if_supported<F>(facade: &F, elements: usize)
+                                         -> Option<DrawCommandsNoIndicesBuffer>
+                                         where F: Facade
+    {
+        match BufferView::empty(facade, BufferType::DrawIndirectBuffer,
+                                elements, true)
+        {
+            Ok(buf) => Some(DrawCommandsNoIndicesBuffer { buffer: buf }),
+            Err(BufferCreationError::BufferTypeNotSupported) => None,
+            Err(_) => panic!()
+        }
+    }
+
+    /// Builds an indices source from this buffer and a primitives type. This indices source can
+    /// be passed to the `draw()` function.
+    pub fn with_primitive_type(&self, primitives: PrimitiveType) -> IndicesSource {
+        IndicesSource::MultidrawArray {
+            buffer: self.buffer.as_slice_any(),
+            primitives: primitives,
+        }
+    }
+}
+
+impl Deref for DrawCommandsNoIndicesBuffer {
+    type Target = BufferView<DrawCommandNoIndices>;
+
+    fn deref(&self) -> &BufferView<DrawCommandNoIndices> {
+        &self.buffer
+    }
+}
+
+impl DerefMut for DrawCommandsNoIndicesBuffer {
+    fn deref_mut(&mut self) -> &mut BufferView<DrawCommandNoIndices> {
+        &mut self.buffer
+    }
+}


### PR DESCRIPTION
cc #244 

 - Adds a `DrawCommandsNoIndicesBuffer` buffer type in `index`.
 - To draw with it, call `draw(&vertex_buffer, &draw_commands_buffer.with_primitive_type(TrianglesList), ...)`