### PR TITLE
Feature flag doc comments

### DIFF
--- a/build/textures.rs
+++ b/build/textures.rs
@@ -173,16 +173,16 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
         let format = match ty {
             TextureType::Integral | TextureType::Unsigned => {
                 "///
-                /// ## Features
+                /// # Features
                 ///
-                /// Only available if the \"gl_integral_textures\" feature is enabled.
+                /// Only available if the 'gl_integral_textures' feature is enabled.
                 #[cfg(feature = \"gl_integral_textures\")]"
             },
             TextureType::Depth | TextureType::DepthStencil => {
                 "///
-                /// ## Features
+                /// # Features
                 ///
-                /// Only available if the \"gl_depth_textures\" feature is enabled.
+                /// Only available if the 'gl_depth_textures' feature is enabled.
                 #[cfg(feature = \"gl_depth_textures\")]"
             },
             TextureType::Stencil => "#[cfg(feature = \"gl_stencil_textures\")]",
@@ -192,30 +192,30 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
         let dim = match dimensions {
             TextureDimensions::Texture1d => {
                 "///
-                /// ## Features
+                /// # Features
                 ///
-                /// Only available if the \"gl_texture_1d\" feature is enabled.
+                /// Only available if the 'gl_texture_1d' feature is enabled.
                 #[cfg(feature = \"gl_texture_1d\")]"
             },
             TextureDimensions::Texture2dArray | TextureDimensions::Texture3d => {
                 "///
-                /// ## Features
+                /// # Features
                 /// 
-                /// Only available if the \"gl_texture_3d\" feature is enabled.
+                /// Only available if the 'gl_texture_3d' feature is enabled.
                 #[cfg(feature = \"gl_texture_3d\")]"
             },
             TextureDimensions::Texture2dMultisample => {
                 "///
-                /// ## Features
+                /// # Features
                 /// 
-                /// Only available if the \"gl_texture_multisample\" feature is enabled.
+                /// Only available if the 'gl_texture_multisample' feature is enabled.
                 #[cfg(feature = \"gl_texture_multisample\")]"
             },
             TextureDimensions::Texture2dMultisampleArray => {
                 "///
-                /// ## Features
+                /// # Features
                 ///
-                /// Only available if the \"gl_texture_multisample_array\" feature is enabled.
+                /// Only available if the 'gl_texture_multisample_array' feature is enabled.
                 #[cfg(feature = \"gl_texture_multisample_array\")]"
             },
             _ => ""

--- a/src/backend/glutin_backend.rs
+++ b/src/backend/glutin_backend.rs
@@ -3,6 +3,10 @@
 
 Backend implementation for the glutin library
 
+# Features
+
+Only available if the 'glutin' feature is enabled.
+
 */
 extern crate glutin;
 

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -391,7 +391,7 @@ impl Program {
     /// You can store the result in a file, then reload it later. This avoids having to compile
     /// the source code every time.
     ///
-    /// ## Features
+    /// # Features
     ///
     /// Only available if the `gl_program_binary` feature is enabled.
     #[cfg(feature = "gl_program_binary")]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -30,7 +30,7 @@ pub struct SyncFence {
 impl SyncFence {
     /// Builds a new `SyncFence` that is injected in the server.
     ///
-    /// ## Features
+    /// # Features
     ///
     /// Only available if the `gl_sync` feature is enabled.
     #[cfg(feature = "gl_sync")]

--- a/src/uniforms/buffer.rs
+++ b/src/uniforms/buffer.rs
@@ -26,7 +26,7 @@ pub struct TypelessUniformBuffer {
 impl<T> UniformBuffer<T> where T: Copy + Send + 'static {
     /// Uploads data in the uniforms buffer.
     ///
-    /// ## Features
+    /// # Features
     ///
     /// Only available if the `gl_uniform_blocks` feature is enabled.
     #[cfg(feature = "gl_uniform_blocks")]
@@ -58,6 +58,10 @@ impl<T> UniformBuffer<T> where T: Copy + Send + 'static {
     }
 
     /// Reads the content of the buffer.
+    ///
+    /// # Features
+    ///
+    /// Only available if the 'gl_read_buffer' feature is enabled.
     #[cfg(feature = "gl_read_buffer")]
     pub fn read(&self) -> T {
         self.read_if_supported().unwrap()


### PR DESCRIPTION
* Standardized to just `# Features` -- A couple weren't, but the majority were.  There doesn't appear to be any differences on the website that I could tell, but it seems silly for it to be different anyway.
* Fixed the double quotes from another commit I did in `build/textures.rs` to be single quotes.
* Added some missing comments about feature flags being necessary.