### PR TITLE
Add get_texture_type() function

### DIFF
--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -64,7 +64,7 @@ pub use image_format::{ClientFormat, TextureFormat};
 pub use image_format::{UncompressedFloatFormat, UncompressedIntFormat, UncompressedUintFormat};
 pub use image_format::{CompressedFormat, DepthFormat, DepthStencilFormat, StencilFormat};
 pub use image_format::{CompressedSrgbFormat, SrgbFormat};
-pub use self::any::TextureAny;
+pub use self::any::{TextureAny, TextureType};
 pub use self::get_format::{InternalFormat, InternalFormatType};
 pub use self::pixel::PixelValue;
 


### PR DESCRIPTION
I'd like to change the internal workings of uniforms and FBOs so that they take a `&TextureAny`. This changes is thus required beforehand.