### PR TITLE
Add event processing to tutorial loops

### DIFF
--- a/doc/tutorials/01-getting-started.md
+++ b/doc/tutorials/01-getting-started.md
@@ -44,6 +44,9 @@ Initializing a window with glutin can be done by calling `glium::glutin::WindowB
 But there is a problem: as soon as the window has been created, our main function exits and `display`'s destructor closes the window. To prevent this, we are just going to add an infinite loop until we detect that the window has been closed:
 
     loop {
+        // process all events, otherwise the window may become unresponsive
+        for _ in display.poll_events() {}
+
         if display.is_closed() {
             break;
         }
@@ -90,6 +93,8 @@ Here is our full `main` function after this step:
             let mut target = display.draw();
             target.clear_color(0.0, 0.0, 1.0, 1.0);
             target.finish();
+
+            for _ in display.poll_events() {}
 
             if display.is_closed() {
                 break;
@@ -272,6 +277,8 @@ Here is the final code of our `src/main.rs` file:
             target.draw(&vertex_buffer, &indices, &program, &glium::uniforms::EmptyUniforms,
                         &Default::default()).unwrap();
             target.finish();
+
+            for _ in display.poll_events() {}
 
             if display.is_closed() {
                 break;

--- a/doc/tutorials/02-animating-triangle.md
+++ b/doc/tutorials/02-animating-triangle.md
@@ -33,6 +33,8 @@ Our first approach will be to create a variable named `t` which represents the s
                     &Default::default()).unwrap();
         target.finish();
 
+        for _ in display.poll_events() {}
+
         if display.is_closed() {
             break;
         }
@@ -72,6 +74,8 @@ Let's reset our program to what it was at the end of the first tutorial, but kee
         target.draw(&vertex_buffer, &indices, &program, &glium::uniforms::EmptyUniforms,
                     &Default::default()).unwrap();
         target.finish();
+
+        for _ in display.poll_events() {}
 
         if display.is_closed() {
             break;
@@ -234,6 +238,8 @@ Here is the final code of our `src/main.rs` file:
             target.draw(&vertex_buffer, &indices, &program, &uniforms,
                         &Default::default()).unwrap();
             target.finish();
+
+            for _ in display.poll_events() {}
 
             if display.is_closed() {
                 break;

--- a/doc/tutorials/03-colors.md
+++ b/doc/tutorials/03-colors.md
@@ -231,6 +231,8 @@ Here is the final code of our `src/main.rs` file:
                         &Default::default()).unwrap();
             target.finish();
 
+            for _ in display.poll_events() {}
+
             if display.is_closed() {
                 break;
             }


### PR DESCRIPTION
Add the line `for _ in display.poll_events() {}` in each main loop of the tutorial code. Without this line the window is unresponsive (on OS X).