### PR TITLE
[fix] framebuffer dimensions for non int scales

### DIFF
--- a/src/backend/glutin_backend.rs
+++ b/src/backend/glutin_backend.rs
@@ -230,7 +230,7 @@ unsafe impl Backend for GlutinWindowBackend {
     fn get_framebuffer_dimensions(&self) -> (u32, u32) {
         let (width, height) = self.window.get_inner_size().unwrap_or((800, 600));      // TODO: 800x600 ?
         let scale = self.window.hidpi_factor();
-        (width * scale as u32, height * scale as u32)
+        ((width as f32 * scale) as u32, (height as f32 * scale) as u32)
     }
 
     fn is_current(&self) -> bool {


### PR DESCRIPTION
It was broken for scales like ~2.608 (iphone 6 plus) producing x2 size.