### PR TITLE
Put framebuffer objects and samplers as part of the CommandContext

### DIFF
--- a/src/framebuffer/render_buffer.rs
+++ b/src/framebuffer/render_buffer.rs
@@ -21,6 +21,7 @@ use image_format;
 
 use gl;
 use GlObject;
+use fbo::FramebuffersContainer;
 use backend::Facade;
 use context::Context;
 use ContextExt;
@@ -295,8 +296,7 @@ impl Drop for RenderBufferAny {
             let mut ctxt = self.context.make_current();
 
             // removing FBOs which contain this buffer
-            self.context.get_framebuffer_objects()
-                        .purge_renderbuffer(self.id, &mut ctxt);
+            FramebuffersContainer::purge_renderbuffer(&mut ctxt, self.id);
 
             if ctxt.version >= &Version(Api::Gl, 3, 0) ||
                ctxt.version >= &Version(Api::GlEs, 2, 0)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,13 +241,6 @@ trait ContextExt {
     /// Start executing OpenGL commands by checking the current context.
     fn make_current(&self) -> context::CommandContext;
 
-    /// Returns the list of framebuffer objects.
-    fn get_framebuffer_objects(&self) -> &fbo::FramebuffersContainer;
-
-    /// Returns the list of samplers.
-    fn get_samplers(&self) -> &RefCell<HashMap<uniforms::SamplerBehavior,
-                                               sampler_object::SamplerObject>>;
-
     /// Returns the capabilities of the backend.
     fn capabilities(&self) -> &context::Capabilities;
 
@@ -317,11 +310,9 @@ trait UniformsExt {
     /// Binds the uniforms to a given program.
     ///
     /// Will replace texture and buffer bind points.
-    // TODO: put the samplers inside the CommandContext
     fn bind_uniforms<'a, P>(&'a self, &mut CommandContext, &P,
-                        &mut Vec<&'a RefCell<Option<sync::LinearSyncFence>>>,
-                        &mut HashMap<uniforms::SamplerBehavior, sampler_object::SamplerObject>)
-                        -> Result<(), DrawError> where P: ProgramExt;
+                            &mut Vec<&'a RefCell<Option<sync::LinearSyncFence>>>)
+                            -> Result<(), DrawError> where P: ProgramExt;
 }
 
 

--- a/src/ops/blit.rs
+++ b/src/ops/blit.rs
@@ -4,6 +4,7 @@ use Rect;
 use context::Context;
 use ContextExt;
 
+use fbo::FramebuffersContainer;
 use fbo::ValidatedAttachments;
 
 use gl;
@@ -18,10 +19,8 @@ pub fn blit(context: &Context, source: Option<&ValidatedAttachments>,
         let mut ctxt = context.make_current();
 
         // FIXME: we don't draw on it
-        let source = context.get_framebuffer_objects()
-                            .get_framebuffer_for_drawing(source, &mut ctxt);
-        let target = context.get_framebuffer_objects()
-                            .get_framebuffer_for_drawing(target, &mut ctxt);
+        let source = FramebuffersContainer::get_framebuffer_for_drawing(&mut ctxt, source);
+        let target = FramebuffersContainer::get_framebuffer_for_drawing(&mut ctxt, target);
 
         // scissor testing influences blitting
         if ctxt.state.enabled_scissor_test {

--- a/src/ops/clear.rs
+++ b/src/ops/clear.rs
@@ -18,9 +18,7 @@ pub fn clear(context: &Context, framebuffer: Option<&ValidatedAttachments>,
     unsafe {
         let mut ctxt = context.make_current();
 
-        let fbo_id = context.get_framebuffer_objects()
-                            .get_framebuffer_for_drawing(framebuffer, &mut ctxt);
-
+        let fbo_id = fbo::FramebuffersContainer::get_framebuffer_for_drawing(&mut ctxt, framebuffer);
         fbo::bind_framebuffer(&mut ctxt, fbo_id, true, false);
 
         if ctxt.state.enabled_rasterizer_discard {

--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -158,15 +158,13 @@ pub fn draw<'a, U, V>(context: &Context, framebuffer: Option<&ValidatedAttachmen
 
     // binding the FBO to draw upon
     {
-        let fbo_id = context.get_framebuffer_objects()
-                            .get_framebuffer_for_drawing(framebuffer, &mut ctxt);
+        let fbo_id = fbo::FramebuffersContainer::get_framebuffer_for_drawing(&mut ctxt, framebuffer);
         fbo::bind_framebuffer(&mut ctxt, fbo_id, true, false);
     };
 
     // binding the program and uniforms
     program.use_program(&mut ctxt);
-    try!(uniforms.bind_uniforms(&mut ctxt, program, &mut fences,
-                                &mut context.get_samplers().borrow_mut()));
+    try!(uniforms.bind_uniforms(&mut ctxt, program, &mut fences));
 
     // sync-ing draw_parameters
     unsafe {

--- a/src/ops/read.rs
+++ b/src/ops/read.rs
@@ -5,6 +5,7 @@ use texture::ClientFormat;
 use texture::PixelValue;
 
 use fbo;
+use fbo::FramebuffersContainer;
 
 use BufferViewExt;
 use Rect;
@@ -49,11 +50,10 @@ impl<'a, P> From<&'a PixelBuffer<P>> for Destination<'a, P> where P: PixelValue 
 /// Panicks if the destination is not large enough.
 ///
 /// The `(u8, u8, u8, u8)` format is guaranteed to be supported.
-pub fn read<'a, S, D>(mut ctxt: &mut CommandContext, fbos: &fbo::FramebuffersContainer, source: S,
-                      rect: &Rect, dest: D)
+pub fn read<'a, S, D>(mut ctxt: &mut CommandContext, source: S, rect: &Rect, dest: D)
                       where S: Into<Source<'a>>, D: Into<Destination<'a, (u8, u8, u8, u8)>>
 {
-    match read_if_supported(ctxt, fbos, source, rect, dest) {
+    match read_if_supported(ctxt, source, rect, dest) {
         Ok(_) => (),
         Err(_) => unreachable!(),
     }
@@ -62,8 +62,7 @@ pub fn read<'a, S, D>(mut ctxt: &mut CommandContext, fbos: &fbo::FramebuffersCon
 /// Reads pixels from the source into the destination.
 ///
 /// Panicks if the destination is not large enough.
-pub fn read_if_supported<'a, S, D, T>(mut ctxt: &mut CommandContext,
-                                      fbos: &fbo::FramebuffersContainer, source: S, rect: &Rect,
+pub fn read_if_supported<'a, S, D, T>(mut ctxt: &mut CommandContext, source: S, rect: &Rect,
                                       dest: D) -> Result<(), ()>
                                       where S: Into<Source<'a>>, D: Into<Destination<'a, T>>,
                                             T: PixelValue
@@ -79,10 +78,10 @@ pub fn read_if_supported<'a, S, D, T>(mut ctxt: &mut CommandContext,
 
     match source {
         Source::Attachment(attachment) => {
-            unsafe { fbos.bind_framebuffer_for_reading(&mut ctxt, attachment) };
+            unsafe { FramebuffersContainer::bind_framebuffer_for_reading(&mut ctxt, attachment) };
         },
         Source::DefaultFramebuffer(read_buffer) => {
-            fbos.bind_default_framebuffer_for_reading(&mut ctxt, read_buffer);
+            FramebuffersContainer::bind_default_framebuffer_for_reading(&mut ctxt, read_buffer);
         },
     };
 

--- a/src/program/raw.rs
+++ b/src/program/raw.rs
@@ -472,8 +472,7 @@ impl RawProgram {
         let mut fences = Vec::with_capacity(0);
 
         self.use_program(&mut ctxt);
-        try!(uniforms.bind_uniforms(&mut ctxt, self, &mut fences,
-                                    &mut self.context.get_samplers().borrow_mut()));
+        try!(uniforms.bind_uniforms(&mut ctxt, self, &mut fences));
         ctxt.gl.DispatchCompute(x, y, z);
 
         for fence in fences {

--- a/src/sampler_object.rs
+++ b/src/sampler_object.rs
@@ -2,8 +2,6 @@ use DrawError;
 
 use uniforms::SamplerBehavior;
 
-use std::collections::HashMap;
-
 use gl;
 use context::CommandContext;
 use version::Version;
@@ -86,9 +84,7 @@ impl Drop for SamplerObject {
 
 /// Returns the sampler corresponding to the given behavior, or a draw error if
 /// samplers are not supported.
-pub fn get_sampler(ctxt: &mut CommandContext,
-                   samplers: &mut HashMap<SamplerBehavior, SamplerObject>,
-                   behavior: &SamplerBehavior)
+pub fn get_sampler(ctxt: &mut CommandContext, behavior: &SamplerBehavior)
                    -> Result<gl::types::GLuint, DrawError>
 {
     // checking for compatibility
@@ -97,7 +93,7 @@ pub fn get_sampler(ctxt: &mut CommandContext,
     }
 
     // looking for an existing sampler
-    match samplers.get(behavior) {
+    match ctxt.samplers.get(behavior) {
         Some(obj) => return Ok(obj.get_id()),
         None => ()
     };
@@ -105,6 +101,6 @@ pub fn get_sampler(ctxt: &mut CommandContext,
     // builds a new sampler
     let sampler = SamplerObject::new(ctxt, behavior);
     let id = sampler.get_id();
-    samplers.insert(behavior.clone(), sampler);
+    ctxt.samplers.insert(behavior.clone(), sampler);
     Ok(id)
 }

--- a/src/texture/any.rs
+++ b/src/texture/any.rs
@@ -517,7 +517,7 @@ impl TextureAny {
         let mut ctxt = self.context.make_current();
 
         let mut data = Vec::with_capacity(0);
-        ops::read(&mut ctxt, &self.context.get_framebuffer_objects(), &attachment, &rect, &mut data);
+        ops::read(&mut ctxt, &attachment, &rect, &mut data);
         T::from_raw(Cow::Owned(data), self.width, self.height.unwrap_or(1))
     }
 
@@ -545,7 +545,7 @@ impl TextureAny {
         let pb = PixelBuffer::new_empty(&self.context, size);
 
         let mut ctxt = self.context.make_current();
-        ops::read(&mut ctxt, &self.context.get_framebuffer_objects(), &attachment, &rect, &pb);
+        ops::read(&mut ctxt, &attachment, &rect, &pb);
         pb
     }
 
@@ -645,8 +645,7 @@ impl Drop for TextureAny {
         let mut ctxt = self.context.make_current();
 
         // removing FBOs which contain this texture
-        self.context.get_framebuffer_objects()
-                    .purge_texture(self.id, &mut ctxt);
+        fbo::FramebuffersContainer::purge_texture(&mut ctxt, self.id);
 
         // resetting the bindings
         for tex_unit in &mut ctxt.state.texture_units {

--- a/src/uniforms/bind.rs
+++ b/src/uniforms/bind.rs
@@ -7,7 +7,6 @@ use gl;
 use sync;
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 
 use BufferViewExt;
 use BufferViewSliceExt;
@@ -26,7 +25,6 @@ use QueryExt;
 
 use utils::bitsfield::Bitsfield;
 
-use sampler_object::SamplerObject;
 use GlObject;
 use vertex::MultiVerticesSource;
 
@@ -37,9 +35,9 @@ use version::Api;
 
 impl<U> UniformsExt for U where U: Uniforms {
     fn bind_uniforms<'a, P>(&'a self, mut ctxt: &mut CommandContext, program: &P,
-                        fences: &mut Vec<&'a RefCell<Option<sync::LinearSyncFence>>>,
-                        samplers: &mut HashMap<SamplerBehavior, SamplerObject>) -> Result<(), DrawError>
-                        where P: ProgramExt
+                            fences: &mut Vec<&'a RefCell<Option<sync::LinearSyncFence>>>)
+                            -> Result<(), DrawError>
+                            where P: ProgramExt
     {
         let mut texture_bind_points = Bitsfield::new();
         let mut uniform_buffer_bind_points = Bitsfield::new();
@@ -60,7 +58,7 @@ impl<U> UniformsExt for U where U: Uniforms {
                     return;
                 }
 
-                match bind_uniform(&mut ctxt, samplers, &value, program, uniform.location,
+                match bind_uniform(&mut ctxt, &value, program, uniform.location,
                                    &mut texture_bind_points, name)
                 {
                     Ok(_) => (),
@@ -168,7 +166,6 @@ fn bind_shared_storage_block<'a, P>(ctxt: &mut context::CommandContext, value: &
 }
 
 fn bind_uniform<P>(ctxt: &mut context::CommandContext,
-                   samplers: &mut HashMap<SamplerBehavior, SamplerObject>,
                    value: &UniformValue, program: &P, location: gl::types::GLint,
                    texture_bind_points: &mut Bitsfield, name: &str)
                    -> Result<(), DrawError> where P: ProgramExt
@@ -219,189 +216,188 @@ fn bind_uniform<P>(ctxt: &mut context::CommandContext,
         },
         UniformValue::Texture1d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
         },
         UniformValue::CompressedTexture1d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
         },
         UniformValue::SrgbTexture1d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
         },
         UniformValue::CompressedSrgbTexture1d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
         },
         UniformValue::IntegralTexture1d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
         },
         UniformValue::UnsignedTexture1d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
         },
         UniformValue::DepthTexture1d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
         },
         UniformValue::Texture2d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
         },
         UniformValue::CompressedTexture2d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
         },
         UniformValue::SrgbTexture2d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
         },
         UniformValue::CompressedSrgbTexture2d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
         },
         UniformValue::IntegralTexture2d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
         },
         UniformValue::UnsignedTexture2d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
         },
         UniformValue::DepthTexture2d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
         },
         UniformValue::Texture2dMultisample(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE)
         },
         UniformValue::SrgbTexture2dMultisample(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE)
         },
         UniformValue::IntegralTexture2dMultisample(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE)
         },
         UniformValue::UnsignedTexture2dMultisample(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE)
         },
         UniformValue::DepthTexture2dMultisample(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE)
         },
         UniformValue::Texture3d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
         },
         UniformValue::CompressedTexture3d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
         },
         UniformValue::SrgbTexture3d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
         },
         UniformValue::CompressedSrgbTexture3d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
         },
         UniformValue::IntegralTexture3d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
         },
         UniformValue::UnsignedTexture3d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
         },
         UniformValue::DepthTexture3d(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
         },
         UniformValue::Texture1dArray(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
         },
         UniformValue::CompressedTexture1dArray(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
         },
         UniformValue::SrgbTexture1dArray(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
         },
         UniformValue::CompressedSrgbTexture1dArray(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
         },
         UniformValue::IntegralTexture1dArray(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
         },
         UniformValue::UnsignedTexture1dArray(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
         },
         UniformValue::DepthTexture1dArray(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
         },
         UniformValue::Texture2dArray(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
         },
         UniformValue::CompressedTexture2dArray(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
         },
         UniformValue::SrgbTexture2dArray(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
         },
         UniformValue::CompressedSrgbTexture2dArray(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
         },
         UniformValue::IntegralTexture2dArray(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
         },
         UniformValue::UnsignedTexture2dArray(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
         },
         UniformValue::DepthTexture2dArray(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
         },
         UniformValue::Texture2dMultisampleArray(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE_ARRAY)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE_ARRAY)
         },
         UniformValue::SrgbTexture2dMultisampleArray(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE_ARRAY)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE_ARRAY)
         },
         UniformValue::IntegralTexture2dMultisampleArray(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE_ARRAY)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE_ARRAY)
         },
         UniformValue::UnsignedTexture2dMultisampleArray(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE_ARRAY)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE_ARRAY)
         },
         UniformValue::DepthTexture2dMultisampleArray(texture, sampler) => {
             let texture = texture.get_id();
-            bind_texture_uniform(ctxt, samplers, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE_ARRAY)
+            bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE_ARRAY)
         },
     }
 }
 
 fn bind_texture_uniform<P>(mut ctxt: &mut context::CommandContext,
-                           samplers: &mut HashMap<SamplerBehavior, SamplerObject>,
                            texture: gl::types::GLuint,
                            sampler: Option<SamplerBehavior>, location: gl::types::GLint,
                            program: &P,
@@ -410,7 +406,7 @@ fn bind_texture_uniform<P>(mut ctxt: &mut context::CommandContext,
                            -> Result<(), DrawError> where P: ProgramExt
 {
     let sampler = if let Some(sampler) = sampler {
-        Some(try!(::sampler_object::get_sampler(ctxt, samplers, &sampler)))
+        Some(try!(::sampler_object::get_sampler(ctxt, &sampler)))
     } else {
         None
     };


### PR DESCRIPTION
Before: the CommandContext didn't contain any reference to framebuffer objects nor samplers. They have to be queried from the context separately. This lead to some extra parameters passed to functions.

After: a reference to the framebuffers and samplers is passed as part of the CommandContext. They can no longer be queried alone to avoid possible refcells being borrowed twice.
