### PR TITLE
Uploading and downloading compressed texture data

### DIFF
--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -58,7 +58,7 @@ use Rect;
 use BlitTarget;
 use uniforms;
 
-use image_format::{TextureFormatRequest, FormatNotSupportedError};
+use image_format::{TextureFormatRequest, ClientFormatAny, FormatNotSupportedError};
 
 pub use image_format::{ClientFormat, TextureFormat};
 pub use image_format::{UncompressedFloatFormat, UncompressedIntFormat, UncompressedUintFormat};


### PR DESCRIPTION
Hopefully closes #326
**Don't merge** yet, things still left to do, I'll squash my commits later if necessary.

Please check if the approach I'm taking on this is the correct way to go!?!

Also a few questions I have came up with on the process:
 + At _std/ops/read.rs_ there is a function (`client_format_to_gl_enum`) that kinda of looks like a elder duplicate of one in _image_format.rs_?
 + Why does not `new_texture` seems to allow the generation of mipmaps for compressed textures? [This line](https://github.com/tomaka/glium/blob/db6fc9fce201999dc5996575a0a4f38a4ab0b349/src/texture/any.rs#L127).
 + The auto-generated method `with_format` is catching `NotSupported` as unreachable instead of `CreationError`, I suppose this is not correct?
