### PR TITLE
Frame::finish now returns a Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ## Unreleased
 
+ - `Frame::finish` now returns a `Result`. `Frame`'s destrutor will panic if `finish` has not been called.
  - `with_compressed_data` and `with_compressed_data_if_supported` now have an additional parameter for mipmaps.
  - All the texture constructors that used to take a boolean as parameter for mipmaps now takes an enum.
  - `empty_with_format` and `empty_with_format_if_supported` are now allowed for compressed textures.
  - `write`, `write_compressed_data`, `write_compressed_data_if_supported` and `read_compressed_data` are now available for mipmap objects.
  - Removed the `is_closed()` function.
  - Removed the deprecated `render_buffer` module.
+ - The `Backend::swap_buffers` function must now return a `Result`.
 
 ## Version 0.5.6
 

--- a/doc/tutorials/01-getting-started.md
+++ b/doc/tutorials/01-getting-started.md
@@ -80,7 +80,7 @@ The four values that we pass to `clear_color` represent the four components of o
 
 Like I explained above, the user doesn't immediatly see the blue color on the screen. At this point if we were in a real application, we would most likely draw our characters, their weapons, the ground, the sky, etc. But in this tutorial we will just stop here:
 
-    target.finish();
+    target.finish().unwrap();
 
 This call to `finish()` means that we have finished drawing. It destroys the `Frame` object and copies our background image to the window. Our window is now filled with blue.
 
@@ -93,7 +93,7 @@ Here is our full `main` function after this step:
         loop {
             let mut target = display.draw();
             target.clear_color(0.0, 0.0, 1.0, 1.0);
-            target.finish();
+            target.finish().unwrap();
 
             for ev in display.poll_events() {
                 match ev {
@@ -212,7 +212,7 @@ Remember the `target` object? We will need to use it to start a draw operation.
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 1.0, 1.0);
     // draw the triangle here
-    target.finish();
+    target.finish().unwrap();
 
 Starting a draw operation needs several things: a source of vertices (here we use our `vertex_buffer`), a source of indices (we use our `indices` variable), a program, the program's uniforms, and some draw parameters. We will explain what uniforms and draw parameters are in the next tutorials, but for the moment we will just ignore them by passing a `EmptyUniforms` marker and by building the default draw parameters.
 
@@ -278,7 +278,7 @@ Here is the final code of our `src/main.rs` file:
             target.clear_color(0.0, 0.0, 1.0, 1.0);
             target.draw(&vertex_buffer, &indices, &program, &glium::uniforms::EmptyUniforms,
                         &Default::default()).unwrap();
-            target.finish();
+            target.finish().unwrap();
 
             for ev in display.poll_events() {
                 match ev {

--- a/doc/tutorials/02-animating-triangle.md
+++ b/doc/tutorials/02-animating-triangle.md
@@ -31,7 +31,7 @@ Our first approach will be to create a variable named `t` which represents the s
         target.clear_color(0.0, 0.0, 1.0, 1.0);
         target.draw(&vertex_buffer, &indices, &program, &glium::uniforms::EmptyUniforms,
                     &Default::default()).unwrap();
-        target.finish();
+        target.finish().unwrap();
 
         for ev in display.poll_events() {
             match ev {
@@ -74,7 +74,7 @@ Let's reset our program to what it was at the end of the first tutorial, but kee
         target.clear_color(0.0, 0.0, 1.0, 1.0);
         target.draw(&vertex_buffer, &indices, &program, &glium::uniforms::EmptyUniforms,
                     &Default::default()).unwrap();
-        target.finish();
+        target.finish().unwrap();
 
         for ev in display.poll_events() {
             match ev {
@@ -237,7 +237,7 @@ Here is the final code of our `src/main.rs` file:
 
             target.draw(&vertex_buffer, &indices, &program, &uniforms,
                         &Default::default()).unwrap();
-            target.finish();
+            target.finish().unwrap();
 
             for ev in display.poll_events() {
                 match ev {

--- a/doc/tutorials/03-colors.md
+++ b/doc/tutorials/03-colors.md
@@ -229,7 +229,7 @@ Here is the final code of our `src/main.rs` file:
 
             target.draw(&vertex_buffer, &indices, &program, &uniforms,
                         &Default::default()).unwrap();
-            target.finish();
+            target.finish().unwrap();
 
             for ev in display.poll_events() {
                 match ev {

--- a/examples/blitting.rs
+++ b/examples/blitting.rs
@@ -59,7 +59,7 @@ fn main() {
         // drawing a frame
         let target = display.draw();
         dest_texture.as_surface().fill(&target, glium::uniforms::MagnifySamplerFilter::Linear);
-        target.finish();
+        target.finish().unwrap();
 
         // polling and handling the events received by the window
         for event in display.poll_events() {

--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -362,7 +362,7 @@ fn main() {
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 0.0, 0.0);
         target.draw(&quad_vertex_buffer, &quad_index_buffer, &composition_program, &uniforms, &Default::default()).unwrap();
-        target.finish();
+        target.finish().unwrap();
 
         // polling and handling the events received by the window
         for event in display.poll_events() {

--- a/examples/displacement_mapping.rs
+++ b/examples/displacement_mapping.rs
@@ -224,7 +224,7 @@ fn main() {
                     }),
                     &program, &uniforms,
                     &Default::default()).unwrap();
-        target.finish();
+        target.finish().unwrap();
 
         // polling and handling the events received by the window
         for event in display.poll_events() {

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -97,7 +97,7 @@ fn main() {
                 ],
                 tex: &opengl_texture
             }, &Default::default()).unwrap();
-        target.finish();
+        target.finish().unwrap();
 
         // polling and handling the events received by the window
         for event in display.poll_events() {

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -161,7 +161,7 @@ fn main() {
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 0.0, 0.0);
         target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &Default::default()).unwrap();
-        target.finish();
+        target.finish().unwrap();
 
         // polling and handling the events received by the window
         for event in display.poll_events() {

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -119,7 +119,7 @@ fn main() {
                         matrix: camera.get_perspective()
                     },
                     &params).unwrap();
-        target.finish();
+        target.finish().unwrap();
 
         // polling and handling the events received by the window
         for event in display.poll_events() {

--- a/examples/manual-creation.rs
+++ b/examples/manual-creation.rs
@@ -36,8 +36,12 @@ fn main() {
     }
 
     unsafe impl glium::backend::Backend for Backend {
-        fn swap_buffers(&self) {
-            self.window.swap_buffers();
+        fn swap_buffers(&self) -> Result<(), glium::SwapBuffersError> {
+            match self.window.swap_buffers() {
+                Ok(()) => Ok(()),
+                Err(glutin::ContextError::IoError(e)) => panic!(),
+                Err(glutin::ContextError::ContextLost) => Err(glium::SwapBuffersError::ContextLost),
+            }
         }
 
         // this function is called only after the OpenGL context has been made current
@@ -60,7 +64,7 @@ fn main() {
         }
 
         unsafe fn make_current(&self) {
-            self.window.make_current();
+            self.window.make_current().unwrap();
         }
     }
 
@@ -81,7 +85,7 @@ fn main() {
     // in the future
     let mut target = glium::Frame::new(context.clone(), context.get_framebuffer_dimensions());
     target.clear_color(0.0, 1.0, 0.0, 1.0);
-    target.finish();
+    target.finish().unwrap();
 
     // the window is still available
     for event in window.wait_events() {

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -121,7 +121,7 @@ fn main() {
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
     target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &Default::default()).unwrap();
-    target.finish();
+    target.finish().unwrap();
 
     // reading the front buffer into an image
     let image: image::DynamicImage = display.read_front_buffer();

--- a/examples/sprites-batching.rs
+++ b/examples/sprites-batching.rs
@@ -239,7 +239,7 @@ fn main() {
         target.clear_color(0.0, 0.0, 0.0, 0.0);
         target.draw(&vertex_buffer, &ib_slice,
                     &program, &uniform! { tex: &texture }, &Default::default()).unwrap();
-        target.finish();
+        target.finish().unwrap();
 
 
         for event in display.poll_events() {

--- a/examples/teapot.rs
+++ b/examples/teapot.rs
@@ -150,7 +150,7 @@ fn main() {
         target.draw(&vertex_buffer,
                     &glium::index::NoIndices(glium::index::PrimitiveType::TrianglesList),
                     &program, &uniforms, &params).unwrap();
-        target.finish();
+        target.finish().unwrap();
 
         // polling and handling the events received by the window
         for event in display.poll_events() {

--- a/examples/tessellation.rs
+++ b/examples/tessellation.rs
@@ -146,7 +146,7 @@ fn main() {
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 0.0, 0.0);
         target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &Default::default()).unwrap();
-        target.finish();
+        target.finish().unwrap();
 
         // polling and handling the events received by the window
         for event in display.poll_events() {

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -139,7 +139,7 @@ fn main() {
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 0.0, 0.0);
         target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &Default::default()).unwrap();
-        target.finish();
+        target.finish().unwrap();
 
         // polling and handling the events received by the window
         for event in display.poll_events() {

--- a/examples/tutorial-01.rs
+++ b/examples/tutorial-01.rs
@@ -47,7 +47,7 @@ fn main() {
         target.clear_color(0.0, 0.0, 1.0, 1.0);
         target.draw(&vertex_buffer, &indices, &program, &glium::uniforms::EmptyUniforms,
                     &Default::default()).unwrap();
-        target.finish();
+        target.finish().unwrap();
 
         for ev in display.poll_events() {
             match ev {

--- a/examples/tutorial-02.rs
+++ b/examples/tutorial-02.rs
@@ -67,7 +67,7 @@ fn main() {
 
         target.draw(&vertex_buffer, &indices, &program, &uniforms,
                     &Default::default()).unwrap();
-        target.finish();
+        target.finish().unwrap();
 
         for ev in display.poll_events() {
             match ev {

--- a/examples/tutorial-03a.rs
+++ b/examples/tutorial-03a.rs
@@ -70,7 +70,7 @@ fn main() {
 
         target.draw(&vertex_buffer, &indices, &program, &uniforms,
                     &Default::default()).unwrap();
-        target.finish();
+        target.finish().unwrap();
 
         for ev in display.poll_events() {
             match ev {

--- a/examples/tutorial-03b.rs
+++ b/examples/tutorial-03b.rs
@@ -87,7 +87,7 @@ fn main() {
 
         target.draw(&vertex_buffer, &indices, &program, &uniforms,
                     &Default::default()).unwrap();
-        target.finish();
+        target.finish().unwrap();
 
         for ev in display.poll_events() {
             match ev {

--- a/src/backend/glutin_backend.rs
+++ b/src/backend/glutin_backend.rs
@@ -15,6 +15,7 @@ use libc;
 use DisplayBuild;
 use Frame;
 use GliumCreationError;
+use SwapBuffersError;
 
 use context;
 use backend;
@@ -214,8 +215,12 @@ pub struct GlutinWindowBackend {
 }
 
 unsafe impl Backend for GlutinWindowBackend {
-    fn swap_buffers(&self) {
-        self.window.swap_buffers();
+    fn swap_buffers(&self) -> Result<(), SwapBuffersError> {
+        match self.window.swap_buffers() {
+            Ok(()) => Ok(()),
+            Err(glutin::ContextError::IoError(e)) => panic!("Error while swapping buffers: {:?}", e),
+            Err(glutin::ContextError::ContextLost) => Err(SwapBuffersError::ContextLost),
+        }
     }
 
     unsafe fn get_proc_address(&self, symbol: &str) -> *const libc::c_void {
@@ -233,7 +238,7 @@ unsafe impl Backend for GlutinWindowBackend {
     }
 
     unsafe fn make_current(&self) {
-        self.window.make_current();
+        self.window.make_current().unwrap();
     }
 }
 
@@ -279,7 +284,8 @@ pub struct GlutinHeadlessBackend {
 }
 
 unsafe impl Backend for GlutinHeadlessBackend {
-    fn swap_buffers(&self) {
+    fn swap_buffers(&self) -> Result<(), SwapBuffersError> {
+        Ok(())
     }
 
     unsafe fn get_proc_address(&self, symbol: &str) -> *const libc::c_void {
@@ -295,7 +301,7 @@ unsafe impl Backend for GlutinHeadlessBackend {
     }
 
     unsafe fn make_current(&self) {
-        self.context.make_current();
+        self.context.make_current().unwrap();
     }
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -16,6 +16,7 @@ use std::rc::Rc;
 use std::ops::Deref;
 
 use libc;
+use SwapBuffersError;
 
 pub use context::Context;
 
@@ -28,7 +29,7 @@ pub mod glutin_backend;
 /// the methods correctly.
 pub unsafe trait Backend {
     /// Swaps buffers at the end of a frame.
-    fn swap_buffers(&self);
+    fn swap_buffers(&self) -> Result<(), SwapBuffersError>;
 
     /// Returns the address of an OpenGL function.
     ///
@@ -52,8 +53,8 @@ pub trait Facade {
 }
 
 unsafe impl<T> Backend for Rc<T> where T: Backend {
-    fn swap_buffers(&self) {
-        self.deref().swap_buffers();
+    fn swap_buffers(&self) -> Result<(), SwapBuffersError> {
+        self.deref().swap_buffers()
     }
 
     unsafe fn get_proc_address(&self, symbol: &str) -> *const libc::c_void {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -14,6 +14,7 @@ use std::ffi::CStr;
 use std::rc::Rc;
 
 use GliumCreationError;
+use SwapBuffersError;
 use ContextExt;
 use backend::Backend;
 use version;
@@ -227,7 +228,7 @@ impl Context {
     }
 
     /// Swaps the buffers in the backend.
-    pub fn swap_buffers(&self) {
+    pub fn swap_buffers(&self) -> Result<(), SwapBuffersError> {
         let backend = self.backend.borrow();
 
         if self.check_current_context {
@@ -237,7 +238,7 @@ impl Context {
         }
 
         // swapping
-        backend.swap_buffers();
+        backend.swap_buffers()
     }
 
     /// Returns the OpenGL version detected by this context.

--- a/tests/attrs.rs
+++ b/tests/attrs.rs
@@ -48,7 +48,7 @@ fn attribute_types_mismatch() {
     let mut target = display.draw();
     target.draw(&vertex_buffer, &index_buffer, &program, &glium::uniforms::EmptyUniforms,
                 &Default::default()).unwrap();
-    target.finish();
+    target.finish().unwrap();
 
     display.assert_no_error(None);
 }
@@ -95,7 +95,7 @@ fn missing_attribute() {
     let mut target = display.draw();
     target.draw(&vertex_buffer, &index_buffer, &program, &glium::uniforms::EmptyUniforms,
                 &Default::default()).unwrap();
-    target.finish();
+    target.finish().unwrap();
 
     display.assert_no_error(None);
 }
@@ -178,7 +178,7 @@ macro_rules! attribute_test(
             let mut target = display.draw();
             target.draw(&vertex_buffer, &index_buffer, &program, &glium::uniforms::EmptyUniforms,
                         &Default::default()).unwrap();
-            target.finish();
+            target.finish().unwrap();
 
             display.assert_no_error(None);
         }

--- a/tests/blit.rs
+++ b/tests/blit.rs
@@ -37,7 +37,7 @@ fn blit_texture_to_window() {
     texture.as_surface().blit_color(&src_rect, &target, &dest_rect,
                                     glium::uniforms::MagnifySamplerFilter::Nearest);
 
-    target.finish();
+    target.finish().unwrap();
 
     let data: Vec<Vec<(u8, u8, u8, u8)>> = display.read_front_buffer();
 

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -78,10 +78,12 @@ fn viewport_too_large() {
 
     let (vb, ib, program) = support::build_fullscreen_red_pipeline(&display);
 
-    match display.draw().draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params) {
+    let mut frame = display.draw();
+    match frame.draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params) {
         Err(glium::DrawError::ViewportTooLarge) => (),
         a => panic!("{:?}", a)
     };
+    frame.finish().unwrap();
 
     display.assert_no_error(None);
 }
@@ -115,10 +117,12 @@ fn wrong_depth_range() {
 
     let (vb, ib, program) = support::build_fullscreen_red_pipeline(&display);
 
-    match display.draw().draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params) {
+    let mut frame = display.draw();
+    match frame.draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params) {
         Err(glium::DrawError::InvalidDepthRange) => (),
         a => panic!("{:?}", a)
     };
+    frame.finish().unwrap();
 
     display.assert_no_error(None);
 }

--- a/tests/indices.rs
+++ b/tests/indices.rs
@@ -70,7 +70,7 @@ fn triangles_list() {
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
     target.draw(&vb, &indices, &program, &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
-    target.finish();
+    target.finish().unwrap();
 
     let data: Vec<Vec<(u8, u8, u8, u8)>> = display.read_front_buffer();
 
@@ -96,7 +96,7 @@ fn triangle_strip() {
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
     target.draw(&vb, &indices, &program, &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
-    target.finish();
+    target.finish().unwrap();
 
     let data: Vec<Vec<(u8, u8, u8, u8)>> = display.read_front_buffer();
 
@@ -123,7 +123,7 @@ fn triangle_fan() {
     let mut target = display.draw();
     target.clear_color(0.0, 0.0, 0.0, 0.0);
     target.draw(&vb, &indices, &program, &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
-    target.finish();
+    target.finish().unwrap();
 
     let data: Vec<Vec<(u8, u8, u8, u8)>> = display.read_front_buffer();
 
@@ -199,7 +199,7 @@ fn triangles_list_noindices() {
     target.clear_color(0.0, 0.0, 0.0, 0.0);
     target.draw(&vb, &index::NoIndices(index::PrimitiveType::TrianglesList),
                 &program, &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
-    target.finish();
+    target.finish().unwrap();
 
     let data: Vec<Vec<(u8, u8, u8, u8)>> = display.read_front_buffer();
 
@@ -225,7 +225,7 @@ fn triangle_strip_noindices() {
     target.clear_color(0.0, 0.0, 0.0, 0.0);
     target.draw(&vb, &index::NoIndices(index::PrimitiveType::TriangleStrip),
                 &program, &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
-    target.finish();
+    target.finish().unwrap();
 
     let data: Vec<Vec<(u8, u8, u8, u8)>> = display.read_front_buffer();
 
@@ -253,7 +253,7 @@ fn triangle_fan_noindices() {
     target.clear_color(0.0, 0.0, 0.0, 0.0);
     target.draw(&vb, &index::NoIndices(index::PrimitiveType::TriangleFan),
                 &program, &glium::uniforms::EmptyUniforms, &Default::default()).unwrap();
-    target.finish();
+    target.finish().unwrap();
 
     let data: Vec<Vec<(u8, u8, u8, u8)>> = display.read_front_buffer();
 

--- a/tests/uniforms.rs
+++ b/tests/uniforms.rs
@@ -167,7 +167,7 @@ fn uniform_wrong_type() {
         Err(glium::DrawError::UniformTypeMismatch { .. }) => (),
         a => panic!("{:?}", a)
     };
-    target.finish();
+    target.finish().unwrap();
 
     display.assert_no_error(None);
 }


### PR DESCRIPTION
Fix #940 
Fix #368 

An OpenGL context can be lost at any time. Instead of making all functions return a `Result` to detect this situation (which would be far too annoying), only `Frame::finish` returns one.