### PR TITLE
Several changes related to textures

### DIFF
--- a/build/textures.rs
+++ b/build/textures.rs
@@ -1258,8 +1258,8 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
 
                         let client_format = ClientFormatAny::ClientFormat(client_format);
 
-                        any::upload_texture(&self.0, rect.left, rect.bottom, 0, (client_format, data), width,
-                                            Some(height), None, true).unwrap()
+                        self.0.upload_texture(rect.left, rect.bottom, 0, (client_format, data),
+                                              width, Some(height), None, true).unwrap()
                     }}
                 "#, data_source_trait = data_source_trait,
                     compressed_restrictions = compressed_restrictions)).unwrap();
@@ -1307,8 +1307,8 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
                         let data = Cow::Borrowed(data.as_ref());
                         let client_format = {client_format_any}(format);
 
-                        any::upload_texture(&self.0, rect.left, rect.bottom, 0, (client_format, data),
-                                            width, Some(height), None, false)
+                        self.0.upload_texture(rect.left, rect.bottom, 0, (client_format, data),
+                                              width, Some(height), None, false)
                     }}
                 "#, format = relevant_format, client_format_any = client_format_any_ty)).unwrap();
         }
@@ -1325,7 +1325,7 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
                     /// Returns the compressed format of the texture and the compressed data, gives
                     /// `None` when the internal compression format is generic or unknown.
                     pub fn read_compressed_data(&self) -> Option<({format}, Vec<u8>)> {{
-                        match any::download_compressed_data(&self.0) {{
+                        match self.0.download_compressed_data() {{
                             Some(({client_format_any}(format), buf)) => Some((format, buf)),
                             None => None,
                             _ => unreachable!(),

--- a/build/textures.rs
+++ b/build/textures.rs
@@ -990,7 +990,7 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
                 /// operations (for example, while you're drawing).
                 /// Use `read_to_pixel_buffer` instead.
                 pub fn read<T>(&self) -> T where T: Texture2dDataSink<(u8, u8, u8, u8)> {{
-                    self.0.read(0)
+                    self.0.mipmap(0, 0).unwrap().read()
                 }}
             "#)).unwrap();
 
@@ -1001,7 +1001,7 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
                 /// (a pixel buffer). Contrary to the `read` function, this operation is
                 /// done asynchronously and doesn't need a synchronization.
                 pub fn read_to_pixel_buffer(&self) -> PixelBuffer<(u8, u8, u8, u8)> {{
-                    self.0.read_to_pixel_buffer(0)
+                    self.0.mipmap(0, 0).unwrap().read_to_pixel_buffer()
                 }}
             "#)).unwrap();
     }

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -40,6 +40,7 @@ use std::rc::Rc;
 
 use texture::Texture2d;
 use texture::TextureAnyMipmap;
+use TextureExt;
 
 use backend::Facade;
 use context::Context;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,6 +297,10 @@ trait QueryExt {
 trait TextureExt {
     /// Returns the bind point of the texture.
     fn get_bind_point(&self) -> gl::types::GLenum;
+
+    /// Makes sure that the texture is binded to the current texture unit and returns the
+    /// bind point to use to access the texture (eg. `GL_TEXTURE_2D`, `GL_TEXTURE_3D`, etc.).
+    fn bind_to_current(&self, &mut CommandContext) -> gl::types::GLenum;
 }
 
 /// Internal trait for transform feedback sessions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,6 +303,19 @@ trait TextureExt {
     fn bind_to_current(&self, &mut CommandContext) -> gl::types::GLenum;
 }
 
+/// Internal trait for textures.
+trait TextureMipmapExt {
+    /// Changes some parts of the texture.
+    fn upload_texture<'a, P>(&self, x_offset: u32, y_offset: u32, z_offset: u32,
+                             (image_format::ClientFormatAny, std::borrow::Cow<'a, [P]>), width: u32,
+                             height: Option<u32>, depth: Option<u32>,
+                             regen_mipmaps: bool)
+                             -> Result<(), ()>   // TODO return a better Result!?
+                             where P: Send + Copy + Clone + 'a;
+
+    fn download_compressed_data(&self) -> Option<(image_format::ClientFormatAny, Vec<u8>)>;
+}
+
 /// Internal trait for transform feedback sessions.
 trait TransformFeedbackSessionExt {
     /// Updates the state of OpenGL to make the transform feedback session current.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,6 +295,9 @@ trait QueryExt {
 
 /// Internal trait for textures.
 trait TextureExt {
+    /// Returns the context associated to this texture.
+    fn get_context(&self) -> &Rc<Context>;
+
     /// Returns the bind point of the texture.
     fn get_bind_point(&self) -> gl::types::GLenum;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,6 +308,14 @@ trait TextureExt {
 
 /// Internal trait for textures.
 trait TextureMipmapExt {
+    /// Reads the content of the mipmap to RAM.
+    // TODO: take 2D/3D/etc. into account
+    fn read<T>(&self) -> T where T: texture::Texture2dDataSink<(u8, u8, u8, u8)>;
+
+    /// Reads the content of the mipmap to a pixel buffer.
+    // TODO: take 2D/3D/etc. into account
+    fn read_to_pixel_buffer(&self) -> pixel_buffer::PixelBuffer<(u8, u8, u8, u8)>;
+
     /// Changes some parts of the texture.
     fn upload_texture<'a, P>(&self, x_offset: u32, y_offset: u32, z_offset: u32,
                              (image_format::ClientFormatAny, std::borrow::Cow<'a, [P]>), width: u32,

--- a/src/texture/any.rs
+++ b/src/texture/any.rs
@@ -583,11 +583,6 @@ impl<'t> TextureMipmapExt for TextureAnyMipmap<'t> {
     }
 }
 
-/// Returns the `Context` associated with this texture.
-pub fn get_context(tex: &TextureAny) -> &Rc<Context> {
-    &tex.context
-}
-
 impl TextureAny {
     /// UNSTABLE. Reads the content of a mipmap level of the texture.
     // TODO: this function only works for level 0 right now

--- a/src/texture/any.rs
+++ b/src/texture/any.rs
@@ -641,11 +641,6 @@ impl TextureAny {
         pb
     }
 
-    /// UNSTABLE. Returns the `Context` associated with this texture.
-    pub fn get_context(&self) -> &Rc<Context> {
-        &self.context
-    }
-
     /// Returns the width of the texture.
     pub fn get_width(&self) -> u32 {
         self.width
@@ -716,6 +711,10 @@ impl TextureAny {
 }
 
 impl TextureExt for TextureAny {
+    fn get_context(&self) -> &Rc<Context> {
+        &self.context
+    }
+
     fn get_bind_point(&self) -> gl::types::GLenum {
         match self.ty {
             TextureType::Texture1d => gl::TEXTURE_1D,

--- a/src/texture/get_format.rs
+++ b/src/texture/get_format.rs
@@ -1,12 +1,12 @@
 use context::CommandContext;
 use version::Version;
 use version::Api;
-use GlObject;
 use gl;
 
 use std::mem;
 
-use texture::any::{self, TextureAny};
+use texture::any::TextureAny;
+use TextureExt;
 
 /// Internal format of a texture.
 ///
@@ -128,10 +128,7 @@ pub fn get_format_if_supported(ctxt: &mut CommandContext, texture: &TextureAny)
         {
             // TODO: use DSA if available
 
-            let bind_point = any::get_bind_point(texture);
-            ctxt.gl.BindTexture(bind_point, texture.get_id());
-            let active_texture = ctxt.state.active_texture as usize;
-            ctxt.state.texture_units[active_texture].texture = texture.get_id();
+            let bind_point = texture.bind_to_current(ctxt);
 
             let mut red_sz = mem::uninitialized();
             ctxt.gl.GetTexLevelParameteriv(bind_point, 0, gl::TEXTURE_RED_SIZE, &mut red_sz);

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -56,6 +56,7 @@ use FboAttachments;
 use fbo::ValidatedAttachments;
 use Rect;
 use BlitTarget;
+use TextureMipmapExt;
 use uniforms;
 
 use image_format::{TextureFormatRequest, ClientFormatAny, FormatNotSupportedError};

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -56,6 +56,7 @@ use FboAttachments;
 use fbo::ValidatedAttachments;
 use Rect;
 use BlitTarget;
+use TextureExt;
 use TextureMipmapExt;
 use uniforms;
 

--- a/src/uniforms/bind.rs
+++ b/src/uniforms/bind.rs
@@ -14,10 +14,13 @@ use DrawError;
 use ProgramExt;
 use UniformsExt;
 use RawUniformValue;
+use TextureExt;
 
 use uniforms::Uniforms;
 use uniforms::UniformValue;
 use uniforms::SamplerBehavior;
+
+use texture::TextureAny;
 
 use context::CommandContext;
 use ContextExt;
@@ -215,190 +218,145 @@ fn bind_uniform<P>(ctxt: &mut context::CommandContext,
             Ok(())
         },
         UniformValue::Texture1d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
         },
         UniformValue::CompressedTexture1d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
         },
         UniformValue::SrgbTexture1d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
         },
         UniformValue::CompressedSrgbTexture1d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
         },
         UniformValue::IntegralTexture1d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
         },
         UniformValue::UnsignedTexture1d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
         },
         UniformValue::DepthTexture1d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D)
         },
         UniformValue::Texture2d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
         },
         UniformValue::CompressedTexture2d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
         },
         UniformValue::SrgbTexture2d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
         },
         UniformValue::CompressedSrgbTexture2d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
         },
         UniformValue::IntegralTexture2d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
         },
         UniformValue::UnsignedTexture2d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
         },
         UniformValue::DepthTexture2d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D)
         },
         UniformValue::Texture2dMultisample(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE)
         },
         UniformValue::SrgbTexture2dMultisample(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE)
         },
         UniformValue::IntegralTexture2dMultisample(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE)
         },
         UniformValue::UnsignedTexture2dMultisample(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE)
         },
         UniformValue::DepthTexture2dMultisample(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE)
         },
         UniformValue::Texture3d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
         },
         UniformValue::CompressedTexture3d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
         },
         UniformValue::SrgbTexture3d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
         },
         UniformValue::CompressedSrgbTexture3d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
         },
         UniformValue::IntegralTexture3d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
         },
         UniformValue::UnsignedTexture3d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
         },
         UniformValue::DepthTexture3d(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_3D)
         },
         UniformValue::Texture1dArray(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
         },
         UniformValue::CompressedTexture1dArray(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
         },
         UniformValue::SrgbTexture1dArray(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
         },
         UniformValue::CompressedSrgbTexture1dArray(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
         },
         UniformValue::IntegralTexture1dArray(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
         },
         UniformValue::UnsignedTexture1dArray(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
         },
         UniformValue::DepthTexture1dArray(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_1D_ARRAY)
         },
         UniformValue::Texture2dArray(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
         },
         UniformValue::CompressedTexture2dArray(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
         },
         UniformValue::SrgbTexture2dArray(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
         },
         UniformValue::CompressedSrgbTexture2dArray(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
         },
         UniformValue::IntegralTexture2dArray(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
         },
         UniformValue::UnsignedTexture2dArray(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
         },
         UniformValue::DepthTexture2dArray(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_ARRAY)
         },
         UniformValue::Texture2dMultisampleArray(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE_ARRAY)
         },
         UniformValue::SrgbTexture2dMultisampleArray(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE_ARRAY)
         },
         UniformValue::IntegralTexture2dMultisampleArray(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE_ARRAY)
         },
         UniformValue::UnsignedTexture2dMultisampleArray(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE_ARRAY)
         },
         UniformValue::DepthTexture2dMultisampleArray(texture, sampler) => {
-            let texture = texture.get_id();
             bind_texture_uniform(ctxt, texture, sampler, location, program, texture_bind_points, gl::TEXTURE_2D_MULTISAMPLE_ARRAY)
         },
     }
 }
 
 fn bind_texture_uniform<P>(mut ctxt: &mut context::CommandContext,
-                           texture: gl::types::GLuint,
+                           texture: &TextureAny,
                            sampler: Option<SamplerBehavior>, location: gl::types::GLint,
                            program: &P,
                            texture_bind_points: &mut Bitsfield,
@@ -418,8 +376,8 @@ fn bind_texture_uniform<P>(mut ctxt: &mut context::CommandContext,
         ctxt.state.texture_units
             .iter().enumerate()
             .find(|&(unit, content)| {
-                content.texture == texture && (content.sampler == sampler ||
-                                               !texture_bind_points.is_used(unit as u16))
+                content.texture == texture.get_id() && (content.sampler == sampler ||
+                                                        !texture_bind_points.is_used(unit as u16))
             })
             .map(|(unit, _)| unit as u16)
             .or_else(|| {
@@ -449,7 +407,8 @@ fn bind_texture_uniform<P>(mut ctxt: &mut context::CommandContext,
         }
     }
 
-    if ctxt.state.texture_units[texture_unit as usize].texture != texture ||
+    // TODO: do better
+    if ctxt.state.texture_units[texture_unit as usize].texture != texture.get_id() ||
        ctxt.state.texture_units[texture_unit as usize].sampler != sampler
     {
         // TODO: what if it's not supported?
@@ -458,10 +417,7 @@ fn bind_texture_uniform<P>(mut ctxt: &mut context::CommandContext,
             ctxt.state.active_texture = texture_unit as gl::types::GLenum;
         }
 
-        if ctxt.state.texture_units[texture_unit as usize].texture != texture {
-            unsafe { ctxt.gl.BindTexture(bind_point, texture); }
-            ctxt.state.texture_units[texture_unit as usize].texture = texture;
-        }
+        texture.bind_to_current(ctxt);
 
         if ctxt.state.texture_units[texture_unit as usize].sampler != sampler {
             assert!(ctxt.version >= &Version(Api::Gl, 3, 3) ||


### PR DESCRIPTION
General cleanup.
Shouldn't have any effect, except that it removes the three functions of `TextureAny` that were marked `UNSTABLE DO NOT USE`.
