### PR TITLE
Check if the sync object is signaled before flushing and waiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
  - Fixed an OpenGL error if GL_ARB_robustness was present with OpenGL < 3.0.
+ - Slightly improved performances when using a dynamic buffer.
 
 ## Version 0.6.3
 


### PR DESCRIPTION
It was already done in `wait_linear_sync_fence_and_drop` in a previous PR, but not in `wait` (which is the function that is used most of the time).