### PR TITLE
Fence discrete parts of a buffer instead of the buffer as a whole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+ - Buffers with persistent mapping now synchronize individual segments of the buffer instead of the buffer as a whole.
+
 ## Version 0.6.5 (2015-06-29)
 
  - Renamed and changed `UniformBlockMember` to `BlockLayout`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ optional = true
 lazy_static = "0.1"
 gl_common = "0.0.4"
 libc = "0.1"
-smallvec = "0.1.4"
+smallvec = "0.1.5"
 
 [build-dependencies]
 gl_generator = "0.0.25"

--- a/src/buffer/fences.rs
+++ b/src/buffer/fences.rs
@@ -1,0 +1,130 @@
+/*!
+
+This module handles the fences of a buffer.
+
+*/
+use smallvec::SmallVec;
+use std::cell::RefCell;
+use std::ops::Range;
+
+use context::CommandContext;
+use sync::{self, LinearSyncFence};
+
+/// Contains a list of fences.
+pub struct Fences {
+    fences: RefCell<SmallVec<[(Range<usize>, LinearSyncFence); 16]>>,
+}
+
+impl Fences {
+    /// Initialization.
+    pub fn new() -> Fences {
+        Fences {
+            fences: RefCell::new(SmallVec::new()),
+        }
+    }
+
+    /// Creates an `Inserter` that allows inserting a fence in the list for the given range.
+    pub fn inserter(&self, range: Range<usize>) -> Inserter {
+        Inserter {
+            fences: self,
+            range: range,
+        }
+    }
+
+    /// Waits until the given range is accessible.
+    pub fn wait(&self, ctxt: &mut CommandContext, range: Range<usize>) {
+        let mut existing_fences = self.fences.borrow_mut();
+        let mut new_fences = SmallVec::new();
+
+        for existing in existing_fences.into_iter() {
+            if (existing.0.start >= range.start && existing.0.start < range.end) ||
+               (existing.0.end > range.start && existing.0.end < range.end)
+            {
+                unsafe { sync::wait_linear_sync_fence_and_drop(existing.1, ctxt) };
+            } else {
+                new_fences.push(existing);
+            }
+        }
+
+        *existing_fences = new_fences;
+    }
+
+    /// Cleans up all fences in the container. Must be called or you'll get a panic.
+    pub fn clean(&mut self, ctxt: &mut CommandContext) {
+        let mut fences = self.fences.borrow_mut();
+        for (_, sync) in fences.into_iter() {
+            unsafe { sync::destroy_linear_sync_fence(ctxt, sync) };
+        }
+    }
+}
+
+/// Allows inserting a fence in the list.
+pub struct Inserter<'a> {
+    fences: &'a Fences,
+    range: Range<usize>,
+}
+
+impl<'a> Inserter<'a> {
+    /// Inserts a new fence.
+    pub fn insert(self, ctxt: &mut CommandContext) {
+        let mut new_fences = SmallVec::new();
+
+        let mut written = false;
+
+        let mut existing_fences = self.fences.fences.borrow_mut();
+        for existing in existing_fences.into_iter() {
+            if existing.0.start < self.range.start && existing.0.end <= self.range.start {
+                new_fences.push(existing);
+
+            } else if existing.0.start < self.range.start && existing.0.end >= self.range.end {
+                // we are stuck here, because we can't duplicate a fence
+                // so instead we just extend the new fence to the existing one
+                let new_fence = unsafe { sync::new_linear_sync_fence_if_supported(ctxt).unwrap() };
+                new_fences.push((existing.0.start .. self.range.start, existing.1));
+                new_fences.push((self.range.start .. existing.0.end, new_fence));
+                written = true;
+
+            } else if existing.0.start < self.range.start && existing.0.end >= self.range.start {
+                new_fences.push((existing.0.start .. self.range.start, existing.1));
+                if !written {
+                    let new_fence = unsafe { sync::new_linear_sync_fence_if_supported(ctxt).unwrap() };
+                    new_fences.push((self.range.clone(), new_fence));
+                    written = true;
+                }
+
+            } else if existing.0.start >= self.range.start && existing.0.end <= self.range.end {
+                unsafe { sync::destroy_linear_sync_fence(ctxt, existing.1) };
+                if !written {
+                    let new_fence = unsafe { sync::new_linear_sync_fence_if_supported(ctxt).unwrap() };
+                    new_fences.push((self.range.clone(), new_fence));
+                    written = true;
+                }
+
+            } else if existing.0.start >= self.range.end {
+                if !written {
+                    let new_fence = unsafe { sync::new_linear_sync_fence_if_supported(ctxt).unwrap() };
+                    new_fences.push((self.range.clone(), new_fence));
+                    written = true;
+                }
+
+                new_fences.push(existing);
+
+            } else {
+                if !written {
+                    let new_fence = unsafe { sync::new_linear_sync_fence_if_supported(ctxt).unwrap() };
+                    new_fences.push((self.range.clone(), new_fence));
+                    written = true;
+                }
+
+                new_fences.push((self.range.end .. existing.0.end, existing.1));
+            }
+        }
+
+        if !written {
+            let new_fence = unsafe { sync::new_linear_sync_fence_if_supported(ctxt).unwrap() };
+            new_fences.push((self.range, new_fence));
+        }
+
+        *existing_fences = new_fences;
+    }
+}

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -17,10 +17,12 @@
 pub use self::view::{BufferView, BufferViewAny, BufferViewMutSlice};
 pub use self::view::{BufferViewSlice, BufferViewAnySlice};
 pub use self::alloc::{Mapping, WriteMapping, ReadMapping};
+pub use self::fences::Inserter;
 
 use gl;
 
 mod alloc;
+mod fences;
 mod view;
 
 /// Error that can happen when creating a buffer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,6 @@ pub use sync::{LinearSyncFence, SyncFence};
 pub use texture::{Texture, Texture2d};
 pub use version::{Api, Version, get_supported_glsl_version};
 
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::thread;
@@ -235,10 +234,10 @@ trait BufferViewExt {
 
 /// Internal trait for subbuffer slices.
 trait BufferViewSliceExt<'a> {
-    /// Tries to get a reference to a `RefCell` where to write a fence.
+    /// Tries to get an object where to write a fence.
     ///
     /// If this function returns `None`, no fence will be created nor written.
-    fn add_fence(&self) -> Option<&'a RefCell<Option<sync::LinearSyncFence>>>;
+    fn add_fence(&self) -> Option<buffer::Inserter<'a>>;
 }
 
 /// Internal trait for contexts.
@@ -354,8 +353,7 @@ trait UniformsExt {
     /// Binds the uniforms to a given program.
     ///
     /// Will replace texture and buffer bind points.
-    fn bind_uniforms<'a, P>(&'a self, &mut CommandContext, &P,
-                            &mut Vec<&'a RefCell<Option<sync::LinearSyncFence>>>)
+    fn bind_uniforms<'a, P>(&'a self, &mut CommandContext, &P, &mut Vec<buffer::Inserter<'a>>)
                             -> Result<(), DrawError> where P: ProgramExt;
 }
 

--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -1,5 +1,4 @@
 use std::ptr;
-use std::mem;
 
 use BufferViewExt;
 use BufferViewSliceExt;
@@ -14,7 +13,6 @@ use TransformFeedbackSessionExt;
 
 use fbo::{self, ValidatedAttachments};
 
-use sync;
 use uniforms::Uniforms;
 use {Program, ToGlEnum};
 use index::{self, IndicesSource, PrimitiveType};
@@ -277,15 +275,7 @@ pub fn draw<'a, U, V>(context: &Context, framebuffer: Option<&ValidatedAttachmen
 
     // fulfilling the fences
     for fence in fences.into_iter() {
-        let mut new_fence = Some(unsafe {
-            sync::new_linear_sync_fence_if_supported(&mut ctxt)
-        }.unwrap());
-
-        mem::swap(&mut new_fence, &mut *fence.borrow_mut());
-
-        if let Some(new_fence) = new_fence {
-            unsafe { sync::destroy_linear_sync_fence(&mut ctxt, new_fence) };
-        }
+        fence.insert(&mut ctxt);
     }
 
     Ok(())

--- a/src/program/raw.rs
+++ b/src/program/raw.rs
@@ -22,8 +22,6 @@ use ProgramExt;
 use Handle;
 use RawUniformValue;
 
-use sync;
-
 use QueryExt;
 use draw_parameters::TimeElapsedQuery;
 
@@ -472,13 +470,7 @@ impl RawProgram {
         ctxt.gl.DispatchCompute(x, y, z);
 
         for fence in fences {
-            let mut new_fence = Some(sync::new_linear_sync_fence_if_supported(&mut ctxt).unwrap());
-
-            mem::swap(&mut new_fence, &mut *fence.borrow_mut());
-
-            if let Some(new_fence) = new_fence {
-                sync::destroy_linear_sync_fence(&mut ctxt, new_fence);
-            }
+            fence.insert(&mut ctxt);
         }
 
         Ok(())

--- a/src/uniforms/bind.rs
+++ b/src/uniforms/bind.rs
@@ -4,9 +4,6 @@ Handles binding uniforms to the OpenGL state machine.
 
 */
 use gl;
-use sync;
-
-use std::cell::RefCell;
 
 use BufferViewExt;
 use BufferViewSliceExt;
@@ -23,6 +20,7 @@ use uniforms::SamplerBehavior;
 use texture::TextureAny;
 
 use context::CommandContext;
+use buffer::Inserter;
 use ContextExt;
 
 use utils::bitsfield::Bitsfield;
@@ -37,7 +35,7 @@ use version::Api;
 
 impl<U> UniformsExt for U where U: Uniforms {
     fn bind_uniforms<'a, P>(&'a self, mut ctxt: &mut CommandContext, program: &P,
-                            fences: &mut Vec<&'a RefCell<Option<sync::LinearSyncFence>>>)
+                            fences: &mut Vec<Inserter<'a>>)
                             -> Result<(), DrawError>
                             where P: ProgramExt
     {
@@ -110,7 +108,7 @@ impl<U> UniformsExt for U where U: Uniforms {
 fn bind_uniform_block<'a, P>(ctxt: &mut context::CommandContext, value: &UniformValue<'a>,
                              block: &program::UniformBlock,
                              program: &P, buffer_bind_points: &mut Bitsfield, name: &str)
-                             -> Result<Option<&'a RefCell<Option<sync::LinearSyncFence>>>, DrawError>
+                             -> Result<Option<Inserter<'a>>, DrawError>
                              where P: ProgramExt
 {
     match value {
@@ -140,7 +138,7 @@ fn bind_uniform_block<'a, P>(ctxt: &mut context::CommandContext, value: &Uniform
 fn bind_shared_storage_block<'a, P>(ctxt: &mut context::CommandContext, value: &UniformValue<'a>,
                                     block: &program::UniformBlock,
                                     program: &P, buffer_bind_points: &mut Bitsfield, name: &str)
-                                    -> Result<Option<&'a RefCell<Option<sync::LinearSyncFence>>>, DrawError>
+                                    -> Result<Option<Inserter<'a>>, DrawError>
                                     where P: ProgramExt
 {
     match value {


### PR DESCRIPTION
Waiting for https://github.com/servo/rust-smallvec/pull/11 to be merged and publish

Fix #1030 
cc #878 