### PR TITLE
Bindless textures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - FEATURES='' TEST=0
     - FEATURES='headless glutin' TEST=1
     - FEATURES='headless glutin image cgmath nalgebra gl_read_buffer gl_depth_textures' TEST=1
-    - FEATURES='headless glutin image cgmath nalgebra gl_read_buffer gl_depth_textures gl_read_buffer gl_uniform_blocks gl_sync gl_program_binary gl_tessellation gl_instancing gl_integral_textures gl_depth_textures gl_stencil_textures' TEST=0
+    - FEATURES='headless glutin image cgmath nalgebra gl_read_buffer gl_depth_textures gl_read_buffer gl_uniform_blocks gl_sync gl_program_binary gl_tessellation gl_instancing gl_integral_textures gl_depth_textures gl_stencil_textures gl_bindless_textures' TEST=0
 
 addons:
   apt:
@@ -36,8 +36,7 @@ after_success:
         [ $TRAVIS_BRANCH = master ] &&
         [ $TRAVIS_PULL_REQUEST = false ] &&
         [ $TRAVIS_RUST_VERSION = nightly ] &&
-        cargo doc -j 1 --features "headless gl_read_buffer gl_uniform_blocks gl_sync gl_program_binary gl_tessellation gl_instancing gl_integral_textures gl_depth_textures gl_stencil_textures gl_texture_1d gl_texture_3d gl_texture_multisample gl_texture_multisample_array" &&
-        cp -R doc/* target/doc &&
+        cargo doc -j 1 --features "headless gl_read_buffer gl_uniform_blocks gl_sync gl_program_binary gl_tessellation gl_instancing gl_integral_textures gl_depth_textures gl_stencil_textures gl_texture_1d gl_texture_3d gl_texture_multisample gl_texture_multisample_array gl_bindless_textures" &&        cp -R doc/* target/doc &&
         sudo pip install ghp-import &&
         ghp-import target/doc &&
         git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+ - Added `ResidentTexture`, `TextureHandle` and `Texture::resident_if_supported()` for bindless textures.
+ - Buffers no longer require their content to be `Send` or `'static` (except for types with the `Any` suffix).
+
 ## Version 0.6.6 (2015-07-03)
 
  - Buffers with persistent mapping now synchronize individual segments of the buffer instead of the buffer as a whole.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ gl_texture_1d = []
 gl_texture_3d = []
 gl_texture_multisample = []
 gl_texture_multisample_array = []
+gl_bindless_textures = []
 headless = []
 
 [dependencies.glutin]

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ In addition to this, it has the following OpenGL-related features:
  - `gl_texture_3d` (three dimensional textures and two-dimensional texture arrays)
  - `gl_texture_multisample` (multisample textures)
  - `gl_texture_multisample_array` (arrays of multisample textures)
+ - `gl_bindless_textures` (faster textures access)
 
 Enabling each of these features adds more restrictions towards the backend and increases the
 likehood that `build_glium` will return an `Err`. However, it also gives you access to more

--- a/build/main.rs
+++ b/build/main.rs
@@ -31,6 +31,7 @@ fn generate_gl_bindings<W>(dest: &mut W) where W: Write {
             api: gl_generator::registry::Ns::Gl.to_string(),
             extensions: vec![
                 "GL_APPLE_vertex_array_object".to_string(),
+                "GL_ARB_bindless_texture".to_string(),
                 "GL_ARB_buffer_storage".to_string(),
                 "GL_ARB_compute_shader".to_string(),
                 "GL_ARB_copy_buffer".to_string(),

--- a/build/textures.rs
+++ b/build/textures.rs
@@ -1107,6 +1107,22 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
             /// a "reference to it" in a buffer (actually not a reference but a raw pointer).
             ///
             /// See the documentation of `ResidentTexture` for more infos.
+            ///
+            /// # Features
+            ///
+            /// Only available if the 'gl_bindless_textures' feature is enabled.
+            ///
+            #[cfg(gl_bindless_textures)]
+            pub fn resident_if_supported(self) -> ResidentTexture {{
+                ResidentTexture::new(self.0)
+            }}
+
+            /// Turns the texture into a `ResidentTexture`.
+            ///
+            /// This allows you to use the texture in a much more efficient way by storing
+            /// a "reference to it" in a buffer (actually not a reference but a raw pointer).
+            ///
+            /// See the documentation of `ResidentTexture` for more infos.
             pub fn resident_if_supported(self) -> Option<ResidentTexture> {{
                 ResidentTexture::new_if_supported(self.0)
             }}

--- a/build/textures.rs
+++ b/build/textures.rs
@@ -1099,6 +1099,19 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
             "#, format = relevant_format)).unwrap();
     }
 
+    // `resident_if_supported`
+    (write!(dest, r#"
+            /// Turns the texture into a `ResidentTexture`.
+            ///
+            /// This allows you to use the texture in a much more efficient way by storing
+            /// a "reference to it" in a buffer (actually not a reference but a raw pointer).
+            ///
+            /// See the documentation of `ResidentTexture` for more infos.
+            pub fn resident_if_supported(self) -> Option<ResidentTexture> {{
+                ResidentTexture::new_if_supported(self.0)
+            }}
+        "#)).unwrap();
+
     // writing the `layer()` function
     if dimensions.is_array() {
         (write!(dest, r#"

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ test:
     - cargo build --verbose -j 2
     - cargo test --features "headless glutin" --verbose -j 2
     - cargo test --no-default-features --features "headless glutin" --verbose -j 2
-    - cargo build --features "headless glutin gl_read_buffer gl_uniform_blocks gl_sync gl_program_binary gl_tessellation gl_instancing gl_integral_textures gl_depth_textures gl_stencil_textures" --verbose -j 2
+    - cargo build --features "headless glutin gl_read_buffer gl_uniform_blocks gl_sync gl_program_binary gl_tessellation gl_instancing gl_integral_textures gl_depth_textures gl_stencil_textures gl_bindless_textures" --verbose -j 2
     #- cargo test --manifest-path macros/Cargo.toml -j 2
 
 general:

--- a/src/buffer/view.rs
+++ b/src/buffer/view.rs
@@ -27,7 +27,7 @@ use buffer::alloc::ReadMapping;
 use buffer::alloc::WriteMapping;
 
 /// Represents a view of a buffer.
-pub struct BufferView<T> where T: Copy + Send + 'static {
+pub struct BufferView<T> where T: Copy {
     // TODO: this `Option` is here because we have a destructor and need to be able to move out
     alloc: Option<Buffer>,
     num_elements: usize,
@@ -36,13 +36,13 @@ pub struct BufferView<T> where T: Copy + Send + 'static {
     marker: PhantomData<T>,
 }
 
-impl<T> fmt::Debug for BufferView<T> where T: Copy + Send + 'static {
+impl<T> fmt::Debug for BufferView<T> where T: Copy {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(fmt, "{:?}", self.alloc.as_ref().unwrap())
     }
 }
 
-impl<T> Drop for BufferView<T> where T: Copy + Send + 'static {
+impl<T> Drop for BufferView<T> where T: Copy {
     fn drop(&mut self) {
         if let (Some(alloc), Some(mut fence)) = (self.alloc.take(), self.fence.take()) {
             fence.clean(&mut alloc.get_context().make_current());
@@ -52,7 +52,7 @@ impl<T> Drop for BufferView<T> where T: Copy + Send + 'static {
 
 /// Represents a sub-part of a buffer.
 #[derive(Copy, Clone)]
-pub struct BufferViewSlice<'a, T> where T: Copy + Send + 'static {
+pub struct BufferViewSlice<'a, T> where T: Copy {
     alloc: &'a Buffer,
     offset_bytes: usize,
     num_elements: usize,
@@ -60,14 +60,14 @@ pub struct BufferViewSlice<'a, T> where T: Copy + Send + 'static {
     marker: PhantomData<T>,
 }
 
-impl<'a, T> fmt::Debug for BufferViewSlice<'a, T> where T: Copy + Send + 'static {
+impl<'a, T> fmt::Debug for BufferViewSlice<'a, T> where T: Copy {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(fmt, "{:?}", self.alloc)
     }
 }
 
 /// Represents a sub-part of a buffer.
-pub struct BufferViewMutSlice<'a, T> where T: Copy + Send + 'static {
+pub struct BufferViewMutSlice<'a, T> where T: Copy {
     alloc: &'a mut Buffer,
     offset_bytes: usize,
     num_elements: usize,
@@ -75,7 +75,7 @@ pub struct BufferViewMutSlice<'a, T> where T: Copy + Send + 'static {
     marker: PhantomData<T>,
 }
 
-impl<'a, T> fmt::Debug for BufferViewMutSlice<'a, T> where T: Copy + Send + 'static {
+impl<'a, T> fmt::Debug for BufferViewMutSlice<'a, T> where T: Copy {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(fmt, "{:?}", self.alloc)
     }
@@ -130,7 +130,7 @@ impl<T> From<BufferView<T>> for BufferViewAny where T: Copy + Send + 'static {
     }
 }
 
-impl<T> BufferView<T> where T: Copy + Send + 'static {
+impl<T> BufferView<T> where T: Copy {
     /// Builds a new buffer containing the given data. The size of the buffer is equal to the size
     /// of the data.
     ///
@@ -307,7 +307,7 @@ impl<T> BufferView<T> where T: PixelValue {
     }
 }
 
-impl<'a, T> BufferViewSlice<'a, T> where T: Copy + Send + 'static {
+impl<'a, T> BufferViewSlice<'a, T> where T: Copy {
     /// Returns the number of elements in this slice.
     pub fn len(&self) -> usize {
         self.num_elements
@@ -404,7 +404,7 @@ impl<'a, T> BufferViewSlice<'a, T> where T: PixelValue {
     }
 }
 
-impl<'a, T> BufferViewMutSlice<'a, T> where T: Copy + Send + 'static {
+impl<'a, T> BufferViewMutSlice<'a, T> where T: Copy {
     /// Returns the number of elements in this slice.
     pub fn len(&self) -> usize {
         self.num_elements
@@ -573,7 +573,7 @@ impl BufferViewAny {
     /// Panicks if the size of the buffer is not a multiple of the size of the data.
     /// For example, trying to read some `(u8, u8, u8, u8)`s from a buffer of 7 bytes will panic.
     ///
-    pub unsafe fn read_if_supported<T>(&self) -> Option<Vec<T>> where T: Copy + Send + 'static {
+    pub unsafe fn read_if_supported<T>(&self) -> Option<Vec<T>> where T: Copy {
         assert!(self.get_size() % mem::size_of::<T>() == 0);
 
         self.fence.wait(&mut self.alloc.get_context().make_current(), 0 .. self.get_size());
@@ -621,7 +621,7 @@ impl<'a> BufferViewAnySlice<'a> {
     }
 }
 
-impl<T> BufferViewExt for BufferView<T> where T: Copy + Send + 'static {
+impl<T> BufferViewExt for BufferView<T> where T: Copy {
     fn get_offset_bytes(&self) -> usize {
         0
     }
@@ -685,7 +685,7 @@ impl<T> BufferViewExt for BufferView<T> where T: Copy + Send + 'static {
     }
 }
 
-impl<'a, T> BufferViewSliceExt<'a> for BufferViewSlice<'a, T> where T: Copy + Send + 'static {
+impl<'a, T> BufferViewSliceExt<'a> for BufferViewSlice<'a, T> where T: Copy {
     fn add_fence(&self) -> Option<Inserter<'a>> {
         if !self.alloc.uses_persistent_mapping() {
             return None;
@@ -696,7 +696,7 @@ impl<'a, T> BufferViewSliceExt<'a> for BufferViewSlice<'a, T> where T: Copy + Se
     }
 }
 
-impl<'a, T> BufferViewExt for BufferViewSlice<'a, T> where T: Copy + Send + 'static {
+impl<'a, T> BufferViewExt for BufferViewSlice<'a, T> where T: Copy {
     fn get_offset_bytes(&self) -> usize {
         self.offset_bytes
     }

--- a/src/context/extensions.rs
+++ b/src/context/extensions.rs
@@ -10,6 +10,8 @@ pub struct ExtensionsList {
     pub gl_apple_sync: bool,
     /// GL_APPLE_vertex_array_object
     pub gl_apple_vertex_array_object: bool,
+    /// GL_ARB_bindless_texture
+    pub gl_arb_bindless_texture: bool,
     /// GL_ARB_buffer_storage
     pub gl_arb_buffer_storage: bool,
     /// GL_ARB_compute_shader
@@ -181,6 +183,7 @@ pub unsafe fn get_extensions(gl: &gl::Gl, version: &Version) -> ExtensionsList {
     let mut extensions = ExtensionsList {
         gl_apple_sync: false,
         gl_apple_vertex_array_object: false,
+        gl_arb_bindless_texture: false,
         gl_arb_buffer_storage: false,
         gl_arb_copy_buffer: false,
         gl_arb_compute_shader: false,
@@ -263,6 +266,7 @@ pub unsafe fn get_extensions(gl: &gl::Gl, version: &Version) -> ExtensionsList {
         match &extension[..] {
             "GL_APPLE_sync" => extensions.gl_apple_sync = true,
             "GL_APPLE_vertex_array_object" => extensions.gl_apple_vertex_array_object = true,
+            "GL_ARB_bindless_texture" => extensions.gl_arb_bindless_texture = true,
             "GL_ARB_buffer_storage" => extensions.gl_arb_buffer_storage = true,
             "GL_ARB_compute_shader" => extensions.gl_arb_compute_shader = true,
             "GL_ARB_copy_buffer" => extensions.gl_arb_copy_buffer = true,

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -658,6 +658,12 @@ fn check_gl_compatibility<T>(ctxt: &mut CommandContext) -> Result<(), GliumCreat
         result.push("OpenGL implementation doesn't support arrays of multisample textures");
     }
 
+    if cfg!(feature = "gl_bindless_textures") &&
+        !(ctxt.extensions.gl_arb_bindless_texture)
+    {
+        result.push("OpenGL implementation doesn't support bindless textures");
+    }
+
     if result.len() == 0 {
         Ok(())
     } else {

--- a/src/texture/bindless.rs
+++ b/src/texture/bindless.rs
@@ -14,6 +14,7 @@ use ContextExt;
 use gl;
 
 use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
 
 /// A texture that is resident in video memory. This allows you to use bindless textures in your
 /// shaders.
@@ -73,6 +74,20 @@ impl ResidentTexture {
         }
 
         texture
+    }
+}
+
+impl Deref for ResidentTexture {
+    type Target = TextureAny;
+
+    fn deref(&self) -> &TextureAny {
+        self.texture.as_ref().unwrap()
+    }
+}
+
+impl DerefMut for ResidentTexture {
+    fn deref_mut(&mut self) -> &mut TextureAny {
+        self.texture.as_mut().unwrap()
     }
 }
 

--- a/src/texture/bindless.rs
+++ b/src/texture/bindless.rs
@@ -19,6 +19,7 @@ use std::ops::{Deref, DerefMut};
 use uniforms::AsUniformValue;
 use uniforms::UniformValue;
 use uniforms::UniformType;
+use uniforms::SamplerBehavior;
 
 /// A texture that is resident in video memory. This allows you to use bindless textures in your
 /// shaders.
@@ -110,7 +111,8 @@ pub struct TextureHandle<'a> {
 
 impl<'a> TextureHandle<'a> {
     /// Builds a new handle.
-    pub fn new(texture: &'a ResidentTexture) -> TextureHandle<'a> {
+    pub fn new(texture: &'a ResidentTexture, _: &SamplerBehavior) -> TextureHandle<'a> {
+        // FIXME: take sampler into account
         TextureHandle {
             value: texture.handle,
             marker: PhantomData,
@@ -118,7 +120,8 @@ impl<'a> TextureHandle<'a> {
     }
 
     /// Sets the value to the given texture.
-    pub fn set(&mut self, texture: &'a ResidentTexture) {
+    pub fn set(&mut self, texture: &'a ResidentTexture, _: &SamplerBehavior) {
+        // FIXME: take sampler into account
         self.value = texture.handle;
     }
 }

--- a/src/texture/bindless.rs
+++ b/src/texture/bindless.rs
@@ -29,7 +29,7 @@ impl ResidentTexture {
         let handle = {
             let mut ctxt = texture.get_context().make_current();
 
-            if ctxt.extensions.gl_arb_bindless_texture {
+            if !ctxt.extensions.gl_arb_bindless_texture {
                 return None;
             }
 
@@ -72,6 +72,7 @@ impl Drop for ResidentTexture {
 }
 
 /// Handle to a texture.
+#[derive(Copy, Clone)]
 pub struct TextureHandle<'a> {
     value: gl::types::GLuint64,
     marker: PhantomData<&'a ResidentTexture>,
@@ -92,7 +93,18 @@ impl<'a> TextureHandle<'a> {
     }
 }
 
-// TODO: implement `uniform::AsUniformValue` on `TextureHandle`
+impl<'a> ::uniforms::AsUniformValue for TextureHandle<'a> {
+    fn as_uniform_value(&self) -> ::uniforms::UniformValue {
+        // TODO: u64
+        unimplemented!();
+    }
+
+    fn matches(_: &::uniforms::UniformType) -> bool {
+        // FIXME: hack to make bindless textures work
+        true
+    }
+}
+
 // TODO: implement `vertex::Attribute` on `TextureHandle`
 
 #[cfg(test)]

--- a/src/texture/bindless.rs
+++ b/src/texture/bindless.rs
@@ -16,6 +16,10 @@ use gl;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 
+use uniforms::AsUniformValue;
+use uniforms::UniformValue;
+use uniforms::UniformType;
+
 /// A texture that is resident in video memory. This allows you to use bindless textures in your
 /// shaders.
 pub struct ResidentTexture {
@@ -119,15 +123,61 @@ impl<'a> TextureHandle<'a> {
     }
 }
 
-impl<'a> ::uniforms::AsUniformValue for TextureHandle<'a> {
-    fn as_uniform_value(&self) -> ::uniforms::UniformValue {
+impl<'a> AsUniformValue for TextureHandle<'a> {
+    fn as_uniform_value(&self) -> UniformValue {
         // TODO: u64
         unimplemented!();
     }
 
-    fn matches(_: &::uniforms::UniformType) -> bool {
-        // FIXME: hack to make bindless textures work
-        true
+    fn matches(ty: &UniformType) -> bool {
+        // TODO: unfortunately we have no idea what the exact type of this handle is
+        //       strong typing should be considered
+        //
+        //       however there is no safety problem here ; the worse that can happen in case of
+        //       wrong type is zeroes or undefined data being returned when sampling
+        match *ty {
+            UniformType::Sampler1d => true,
+            UniformType::ISampler1d => true,
+            UniformType::USampler1d => true,
+            UniformType::Sampler2d => true,
+            UniformType::ISampler2d => true,
+            UniformType::USampler2d => true,
+            UniformType::Sampler3d => true,
+            UniformType::ISampler3d => true,
+            UniformType::USampler3d => true,
+            UniformType::Sampler1dArray => true,
+            UniformType::ISampler1dArray => true,
+            UniformType::USampler1dArray => true,
+            UniformType::Sampler2dArray => true,
+            UniformType::ISampler2dArray => true,
+            UniformType::USampler2dArray => true,
+            UniformType::SamplerCube => true,
+            UniformType::ISamplerCube => true,
+            UniformType::USamplerCube => true,
+            UniformType::Sampler2dRect => true,
+            UniformType::ISampler2dRect => true,
+            UniformType::USampler2dRect => true,
+            UniformType::Sampler2dRectShadow => true,
+            UniformType::SamplerCubeArray => true,
+            UniformType::ISamplerCubeArray => true,
+            UniformType::USamplerCubeArray => true,
+            UniformType::SamplerBuffer => true,
+            UniformType::ISamplerBuffer => true,
+            UniformType::USamplerBuffer => true,
+            UniformType::Sampler2dMultisample => true,
+            UniformType::ISampler2dMultisample => true,
+            UniformType::USampler2dMultisample => true,
+            UniformType::Sampler2dMultisampleArray => true,
+            UniformType::ISampler2dMultisampleArray => true,
+            UniformType::USampler2dMultisampleArray => true,
+            UniformType::Sampler1dShadow => true,
+            UniformType::Sampler2dShadow => true,
+            UniformType::SamplerCubeShadow => true,
+            UniformType::Sampler1dArrayShadow => true,
+            UniformType::Sampler2dArrayShadow => true,
+            UniformType::SamplerCubeArrayShadow => true,
+            _ => false
+        }
     }
 }
 

--- a/src/texture/bindless.rs
+++ b/src/texture/bindless.rs
@@ -24,6 +24,17 @@ pub struct ResidentTexture {
 
 impl ResidentTexture {
     /// Takes ownership of the given texture and makes it resident.
+    ///
+    /// # Features
+    ///
+    /// Only available if the 'gl_bindless_textures' feature is enabled.
+    ///
+    #[cfg(gl_bindless_textures)]
+    pub fn new(texture: TextureAny) -> ResidentTexture {
+        ResidentTexture::new_if_supported(texture).unwrap()
+    }
+
+    /// Takes ownership of the given texture and makes it resident.
     // TODO: sampler
     pub fn new_if_supported(texture: TextureAny) -> Option<ResidentTexture> {
         let handle = {

--- a/src/texture/bindless.rs
+++ b/src/texture/bindless.rs
@@ -1,0 +1,107 @@
+/*!
+
+Handles bindless textures.
+
+
+
+
+*/
+use texture::any::TextureAny;
+use TextureExt;
+use GlObject;
+
+use ContextExt;
+use gl;
+
+use std::marker::PhantomData;
+
+/// A texture that is resident in video memory. This allows you to use bindless textures in your
+/// shaders.
+pub struct ResidentTexture {
+    texture: Option<TextureAny>,
+    handle: gl::types::GLuint64,
+}
+
+impl ResidentTexture {
+    /// Takes ownership of the given texture and makes it resident.
+    // TODO: sampler
+    pub fn new_if_supported(texture: TextureAny) -> Option<ResidentTexture> {
+        let handle = {
+            let mut ctxt = texture.get_context().make_current();
+
+            if ctxt.extensions.gl_arb_bindless_texture {
+                return None;
+            }
+
+            let handle = unsafe { ctxt.gl.GetTextureHandleARB(texture.get_id()) };
+            unsafe { ctxt.gl.MakeTextureHandleResidentARB(handle) };
+            ctxt.resident_texture_handles.push(handle);
+            handle
+        };
+
+        // store the handle in the context
+        Some(ResidentTexture {
+            texture: Some(texture),
+            handle: handle,
+        })
+    }
+
+    /// Unwraps the texture and restores it.
+    pub fn into_inner(mut self) -> TextureAny {
+        self.into_inner_impl()
+    }
+
+    /// Implementation of `into_inner`. Also called by the destructor.
+    fn into_inner_impl(&mut self) -> TextureAny {
+        let texture = self.texture.take().unwrap();
+
+        {
+            let mut ctxt = texture.get_context().make_current();
+            unsafe { ctxt.gl.MakeTextureHandleNonResidentARB(self.handle) };
+            ctxt.resident_texture_handles.retain(|&t| t != self.handle);
+        }
+
+        texture
+    }
+}
+
+impl Drop for ResidentTexture {
+    fn drop(&mut self) {
+        self.into_inner_impl();
+    }
+}
+
+/// Handle to a texture.
+pub struct TextureHandle<'a> {
+    value: gl::types::GLuint64,
+    marker: PhantomData<&'a ResidentTexture>,
+}
+
+impl<'a> TextureHandle<'a> {
+    /// Builds a new handle.
+    pub fn new(texture: &'a ResidentTexture) -> TextureHandle<'a> {
+        TextureHandle {
+            value: texture.handle,
+            marker: PhantomData,
+        }
+    }
+
+    /// Sets the value to the given texture.
+    pub fn set(&mut self, texture: &'a ResidentTexture) {
+        self.value = texture.handle;
+    }
+}
+
+// TODO: implement `uniform::AsUniformValue` on `TextureHandle`
+// TODO: implement `vertex::Attribute` on `TextureHandle`
+
+#[cfg(test)]
+mod test {
+    use std::mem;
+    use super::TextureHandle;
+
+    #[test]
+    fn texture_handle_size() {
+        assert_eq!(mem::size_of::<TextureHandle>(), 8);
+    }
+}

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -67,10 +67,12 @@ pub use image_format::{UncompressedFloatFormat, UncompressedIntFormat, Uncompres
 pub use image_format::{CompressedFormat, DepthFormat, DepthStencilFormat, StencilFormat};
 pub use image_format::{CompressedSrgbFormat, SrgbFormat};
 pub use self::any::{TextureAny, TextureAnyMipmap, TextureType};
+pub use self::bindless::{ResidentTexture, TextureHandle};
 pub use self::get_format::{InternalFormat, InternalFormatType};
 pub use self::pixel::PixelValue;
 
 mod any;
+mod bindless;
 mod get_format;
 mod pixel;
 

--- a/src/uniforms/buffer.rs
+++ b/src/uniforms/buffer.rs
@@ -8,7 +8,7 @@ use backend::Facade;
 
 /// Buffer that contains a uniform block.
 #[derive(Debug)]
-pub struct UniformBuffer<T> where T: Copy + Send + 'static {
+pub struct UniformBuffer<T> where T: Copy {
     buffer: BufferView<T>,
 }
 
@@ -23,7 +23,7 @@ pub struct TypelessUniformBuffer {
     buffer: BufferViewAny,
 }
 
-impl<T> UniformBuffer<T> where T: Copy + Send + 'static {
+impl<T> UniformBuffer<T> where T: Copy {
     /// Uploads data in the uniforms buffer.
     ///
     /// # Features
@@ -96,7 +96,7 @@ impl<T> UniformBuffer<T> where T: Copy + Send + 'static {
     }
 }
 
-impl<T> Deref for UniformBuffer<T> where T: Send + Copy + 'static {
+impl<T> Deref for UniformBuffer<T> where T: Copy {
     type Target = BufferView<T>;
 
     fn deref(&self) -> &BufferView<T> {
@@ -118,13 +118,13 @@ impl<'a, D> DerefMut for Mapping<'a, D> {
     }
 }
 
-impl<T> DerefMut for UniformBuffer<T> where T: Send + Copy + 'static {
+impl<T> DerefMut for UniformBuffer<T> where T: Copy {
     fn deref_mut(&mut self) -> &mut BufferView<T> {
         &mut self.buffer
     }
 }
 
-impl<'a, T> AsUniformValue for &'a UniformBuffer<T> where T: UniformBlock + Send + Copy + 'static {
+impl<'a, T> AsUniformValue for &'a UniformBuffer<T> where T: UniformBlock + Copy {
     fn as_uniform_value(&self) -> UniformValue {
         UniformValue::Block(self.buffer.as_slice_any(), <T as UniformBlock>::matches)
     }

--- a/src/uniforms/value.rs
+++ b/src/uniforms/value.rs
@@ -264,11 +264,9 @@ impl<'a> UniformValue<'a> {
     }
 }
 
-impl<T> UniformBlock for T where T: AsUniformValue + Copy + Send + 'static {
+impl<T> UniformBlock for T where T: AsUniformValue + Copy {
     fn matches(block: &program::UniformBlock) -> bool {
-        fn inner_match<T>(layout: &BlockLayout) -> bool where T: AsUniformValue + Copy +
-                                                                 Send + 'static
-        {
+        fn inner_match<T>(layout: &BlockLayout) -> bool where T: AsUniformValue + Copy {
             if let &BlockLayout::BasicType { ty, offset_in_buffer } = layout {
                 offset_in_buffer == 0 && <T as AsUniformValue>::matches(&ty)
 
@@ -284,7 +282,7 @@ impl<T> UniformBlock for T where T: AsUniformValue + Copy + Send + 'static {
             }
         }
 
-        block.size == mem::size_of::<T>() && inner_match::<T>(&block.layout)
+        block.size >= mem::size_of::<T>() && inner_match::<T>(&block.layout)
     }
 }
 

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -11,18 +11,18 @@ use ContextExt;
 
 /// A list of vertices loaded in the graphics card's memory.
 #[derive(Debug)]
-pub struct VertexBuffer<T> where T: Copy + Send + 'static {
+pub struct VertexBuffer<T> where T: Copy {
     buffer: BufferView<T>,
     bindings: VertexFormat,
 }
 
 /// Represents a slice of a `VertexBuffer`.
-pub struct VertexBufferSlice<'b, T: 'b> where T: Copy + Send + 'static {
+pub struct VertexBufferSlice<'b, T: 'b> where T: Copy {
     buffer: BufferViewSlice<'b, T>,
     bindings: &'b VertexFormat,
 }
 
-impl<T: Vertex + 'static + Send> VertexBuffer<T> {
+impl<T> VertexBuffer<T> where T: Vertex {
     /// Builds a new vertex buffer.
     ///
     /// Note that operations such as `write` will be very slow. If you want to modify the buffer
@@ -83,7 +83,7 @@ impl<T: Vertex + 'static + Send> VertexBuffer<T> {
     }
 }
 
-impl<T> VertexBuffer<T> where T: Send + Copy + 'static {
+impl<T> VertexBuffer<T> where T: Copy {
     /// Builds a new vertex buffer from an indeterminate data type and bindings.
     ///
     /// # Example
@@ -158,15 +158,6 @@ impl<T> VertexBuffer<T> where T: Send + Copy + 'static {
         &self.bindings
     }
 
-    /// DEPRECATED: use `.into()` instead.
-    /// Discard the type information and turn the vertex buffer into a `VertexBufferAny`.
-    pub fn into_vertex_buffer_any(self) -> VertexBufferAny {
-        VertexBufferAny {
-            buffer: self.buffer.into(),
-            bindings: self.bindings,
-        }
-    }
-
     /// Creates a marker that instructs glium to use multiple instances.
     ///
     /// Instead of calling `surface.draw(&vertex_buffer, ...)` you can call
@@ -202,7 +193,18 @@ impl<T> VertexBuffer<T> where T: Send + Copy + 'static {
     }
 }
 
-impl<T> From<BufferView<T>> for VertexBuffer<T> where T: Vertex + Send + Copy + 'static {
+impl<T> VertexBuffer<T> where T: Copy + Send + 'static {
+    /// DEPRECATED: use `.into()` instead.
+    /// Discard the type information and turn the vertex buffer into a `VertexBufferAny`.
+    pub fn into_vertex_buffer_any(self) -> VertexBufferAny {
+        VertexBufferAny {
+            buffer: self.buffer.into(),
+            bindings: self.bindings,
+        }
+    }
+}
+
+impl<T> From<BufferView<T>> for VertexBuffer<T> where T: Vertex + Copy {
     fn from(buffer: BufferView<T>) -> VertexBuffer<T> {
         let bindings = <T as Vertex>::build_bindings();
 
@@ -213,7 +215,7 @@ impl<T> From<BufferView<T>> for VertexBuffer<T> where T: Vertex + Send + Copy + 
     }
 }
 
-impl<T> Deref for VertexBuffer<T> where T: Send + Copy + 'static {
+impl<T> Deref for VertexBuffer<T> where T: Copy {
     type Target = BufferView<T>;
 
     fn deref(&self) -> &BufferView<T> {
@@ -221,19 +223,19 @@ impl<T> Deref for VertexBuffer<T> where T: Send + Copy + 'static {
     }
 }
 
-impl<T> DerefMut for VertexBuffer<T> where T: Send + Copy + 'static {
+impl<T> DerefMut for VertexBuffer<T> where T: Copy {
     fn deref_mut(&mut self) -> &mut BufferView<T> {
         &mut self.buffer
     }
 }
 
-impl<'a, T> IntoVerticesSource<'a> for &'a VertexBuffer<T> where T: Send + Copy + 'static {
+impl<'a, T> IntoVerticesSource<'a> for &'a VertexBuffer<T> where T: Copy {
     fn into_vertices_source(self) -> VerticesSource<'a> {
         VerticesSource::VertexBuffer(self.buffer.as_slice_any(), &self.bindings, false)
     }
 }
 
-impl<'a, T> Deref for VertexBufferSlice<'a, T> where T: Send + Copy + 'static {
+impl<'a, T> Deref for VertexBufferSlice<'a, T> where T: Copy {
     type Target = BufferViewSlice<'a, T>;
 
     fn deref(&self) -> &BufferViewSlice<'a, T> {
@@ -241,13 +243,13 @@ impl<'a, T> Deref for VertexBufferSlice<'a, T> where T: Send + Copy + 'static {
     }
 }
 
-impl<'a, T> DerefMut for VertexBufferSlice<'a, T> where T: Send + Copy + 'static {
+impl<'a, T> DerefMut for VertexBufferSlice<'a, T> where T: Copy {
     fn deref_mut(&mut self) -> &mut BufferViewSlice<'a, T> {
         &mut self.buffer
     }
 }
 
-impl<'a, T> IntoVerticesSource<'a> for VertexBufferSlice<'a, T> where T: Copy + Send + 'static {
+impl<'a, T> IntoVerticesSource<'a> for VertexBufferSlice<'a, T> where T: Copy {
     fn into_vertices_source(self) -> VerticesSource<'a> {
         VerticesSource::VertexBuffer(self.buffer.as_slice_any(), &self.bindings, false)
     }
@@ -322,13 +324,13 @@ impl VertexBufferAny {
     }
 }
 
-impl<T> From<VertexBuffer<T>> for VertexBufferAny where T: Send + Copy + 'static {
+impl<T> From<VertexBuffer<T>> for VertexBufferAny where T: Copy + Send + 'static {
     fn from(buf: VertexBuffer<T>) -> VertexBufferAny {
         buf.into_vertex_buffer_any()
     }
 }
 
-impl<T> From<BufferView<T>> for VertexBufferAny where T: Vertex + Send + Copy + 'static {
+impl<T> From<BufferView<T>> for VertexBufferAny where T: Vertex + Copy + Send + 'static {
     fn from(buf: BufferView<T>) -> VertexBufferAny {
         let buf: VertexBuffer<T> = buf.into();
         buf.into_vertex_buffer_any()

--- a/tests/texture_creation.rs
+++ b/tests/texture_creation.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate glium;
 
+use glium::Surface;
 use glium::Texture;
 
 mod support;
@@ -294,6 +295,72 @@ fn zero_sized_texture_3d_creation() {
     assert_eq!(texture.get_height(), Some(0));
     assert_eq!(texture.get_depth(), Some(0));
     assert_eq!(texture.get_array_size(), None);
+
+    display.assert_no_error(None);
+}
+
+#[test]
+fn bindless_texture_residency_context_rebuild() {
+    let display = support::build_display();
+    let (vb, ib) = support::build_rectangle_vb_ib(&display);
+
+    let texture = glium::texture::Texture2d::new(&display, vec![
+        vec![(255, 0, 0, 255), (255, 0, 0, 255)],
+        vec![(255, 0, 0, 255), (255, 0, 0, 255u8)],
+    ]);
+
+    let texture = match texture.resident_if_supported() {
+        Some(t) => t,
+        None => return
+    };
+
+    // here is the trick: we rebuild the display, meaning that texture residency has to be updated
+    // by glium
+    support::rebuild_display(&display);
+
+    // if bindless textures are supported, we can call .unwrap() and expect that everything
+    // else is supported here as well
+
+    let program = glium::Program::from_source(&display,
+        "
+            #version 100
+
+            attribute lowp vec2 position;
+
+            void main() {
+                gl_Position = vec4(position, 0.0, 1.0);
+            }
+        ",
+        "
+            #version 400
+            #extension GL_ARB_bindless_texture : require
+
+            uniform Samplers {
+                sampler2D tex;
+            };
+
+            out vec4 f_color;
+
+            void main() {
+                f_color = texture(tex, vec2(0.0, 0.0));
+            }
+        ",
+        None).unwrap();
+
+    let buffer = glium::uniforms::UniformBuffer::new_if_supported(&display,
+                                            glium::texture::TextureHandle::new(&texture)).unwrap();
+
+    let output = support::build_renderable_texture(&display);
+    output.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
+    output.as_surface().draw(&vb, &ib, &program, &uniform!{ Samplers: &buffer },
+                             &Default::default()).unwrap();
+
+    let data: Vec<Vec<(u8, u8, u8, u8)>> = output.read();
+    for row in data.iter() {
+        for pixel in row.iter() {
+            assert_eq!(pixel, &(255, 0, 0, 255));
+        }
+    }
 
     display.assert_no_error(None);
 }

--- a/tests/texture_creation.rs
+++ b/tests/texture_creation.rs
@@ -348,7 +348,7 @@ fn bindless_texture_residency_context_rebuild() {
         None).unwrap();
 
     let buffer = glium::uniforms::UniformBuffer::new_if_supported(&display,
-                                            glium::texture::TextureHandle::new(&texture)).unwrap();
+                                            glium::texture::TextureHandle::new(&texture, &Default::default())).unwrap();
 
     let output = support::build_renderable_texture(&display);
     output.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);

--- a/tests/texture_sample.rs
+++ b/tests/texture_sample.rs
@@ -84,7 +84,7 @@ fn bindless_texture() {
         None => return
     };
 
-    // if resident textures are supported, we can call .unwrap() and expect that everything
+    // if bindless textures are supported, we can call .unwrap() and expect that everything
     // else is supported here as well
 
     let program = glium::Program::from_source(&display,

--- a/tests/texture_sample.rs
+++ b/tests/texture_sample.rs
@@ -67,3 +67,66 @@ texture_sample_test!(compressed_texture_2d_draw, CompressedTexture2d, "sampler2D
         vec![(255, 0, 0, 255), (255, 0, 0, 255)],
         vec![(255, 0, 0, 255), (255, 0, 0, 255u8)],
     ]);
+
+
+#[test]
+fn bindless_texture() {
+    let display = support::build_display();
+    let (vb, ib) = support::build_rectangle_vb_ib(&display);
+
+    let texture = glium::texture::Texture2d::new(&display, vec![
+        vec![(255, 0, 0, 255), (255, 0, 0, 255)],
+        vec![(255, 0, 0, 255), (255, 0, 0, 255u8)],
+    ]);
+
+    let texture = match texture.resident_if_supported() {
+        Some(t) => t,
+        None => return
+    };
+
+    // if resident textures are supported, we can call .unwrap() and expect that everything
+    // else is supported here as well
+
+    let program = glium::Program::from_source(&display,
+        "
+            #version 100
+
+            attribute lowp vec2 position;
+
+            void main() {
+                gl_Position = vec4(position, 0.0, 1.0);
+            }
+        ",
+        "
+            #version 400
+            #extension GL_ARB_bindless_texture : require
+
+            uniform Samplers {
+                sampler2D tex;
+            };
+
+            out vec4 f_color;
+
+            void main() {
+                f_color = texture(tex, vec2(0.0, 0.0));
+            }
+        ",
+        None).unwrap();
+
+    let buffer = glium::uniforms::UniformBuffer::new_if_supported(&display,
+                                            glium::texture::TextureHandle::new(&texture)).unwrap();
+
+    let output = support::build_renderable_texture(&display);
+    output.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
+    output.as_surface().draw(&vb, &ib, &program, &uniform!{ Samplers: &buffer },
+                             &Default::default()).unwrap();
+
+    let data: Vec<Vec<(u8, u8, u8, u8)>> = output.read();
+    for row in data.iter() {
+        for pixel in row.iter() {
+            assert_eq!(pixel, &(255, 0, 0, 255));
+        }
+    }
+
+    display.assert_no_error(None);
+}

--- a/tests/texture_sample.rs
+++ b/tests/texture_sample.rs
@@ -114,7 +114,7 @@ fn bindless_texture() {
         None).unwrap();
 
     let buffer = glium::uniforms::UniformBuffer::new_if_supported(&display,
-                                            glium::texture::TextureHandle::new(&texture)).unwrap();
+                                            glium::texture::TextureHandle::new(&texture, &Default::default())).unwrap();
 
     let output = support::build_renderable_texture(&display);
     output.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);


### PR DESCRIPTION
Summary of the changes:

 - The buffer types no longer require their content to `Send` or `'static`, except for buffers types which don't have type information.
 - Add the `TextureHandle<'a>` type that can be put into uniform buffers/SSBOs. Vertex buffers and regular uniforms are not yet supported.
 - A texture can be turned into a `ResidentTexture` by calling `resident` or `resident_if_supported`.
 - A `TextureHandle<'a>` can be built from a `&'a ResidentTexture` and can't outlive the resident texture.

The implementation should be entirely safe.

Future work:
 - Add bindless textures support for vertex buffers and regular uniforms.
 - Support using a sampler.
 - Image load/store.
 - Consider strong typing, with `ResidentTexture2dArray` and `Texture2dArrayHandle` for example.

Close #243 
cc #878 