### PR TITLE
Update khronos_api to 0.0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ smallvec = "0.1.5"
 
 [build-dependencies]
 gl_generator = "0.0.25"
-khronos_api = "0.0.6"
+khronos_api = "0.0.7"
 
 [dev-dependencies]
 clock_ticks = "0.0.5"


### PR DESCRIPTION
Bypasses a bug with the MSVC target of rustc.