### PR TITLE
Now using BaseVertex variants of draw functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+ - Glium now automatically calls `glDraw*BaseVertex` if it is supported.
  - Added the `CapabilitiesSource` trait implemented automatically on all types that implement `Facade`.
  - Added `is_supported` to `IndexType`, `Index`, `PrimitiveType`, `Attribute` and `AttributeType`.
  - The `implement_buffer_content!` and `implement_block_layout!` macros can now take a struct with a lifetime parameter by passing `Foo<'a>` instead of `Foo`.


### PR DESCRIPTION
cc #878 

For example if you draw vertices 0 to 10000, then 10000 to 20000, then 20000 to 30000, glium creates three vertex array objects and binds the correct one before each draw.

With this PR it will keep the same VAO and call `glDraw*BaseVertex` instead, which should greatly reduce the CPU overhead.