### PR TITLE
Fix test and remove println!

### DIFF
--- a/src/program/reflection.rs
+++ b/src/program/reflection.rs
@@ -850,7 +850,6 @@ fn introspection_output_to_layout<I>(elements: I) -> BlockLayout
     // ↓ actual body of `introspection_output_to_layout` starts here ↓
     let mut layout = BlockLayout::Struct { members: Vec::new() };
     for (name, offset, ty, array_size, top_level_array_size) in elements {
-        println!("{:?} {:?} {:?}", offset, array_size, top_level_array_size);
         process(&mut layout, &name, offset, ty, array_size, top_level_array_size);
     }
     layout

--- a/tests/shaders.rs
+++ b/tests/shaders.rs
@@ -793,20 +793,20 @@ fn array_layout_offsets() {
     let program = glium::Program::from_source(&display,
         "
             #version 330
-            uniform layout(std140);
 
             struct Foo {
-                vec3 pos;
-                vec3 dir;
+                vec2 pos;
+                vec2 dir;
                 float speed;
             };
 
+            layout(std140)
             uniform MyBlock {
                 Foo data[256];
             };
 
             void main() {
-                gl_Position = vec4(data[0].pos, 1.0);
+                gl_Position = vec4(data[0].pos, 0.0, 1.0);
             }
         ",
         "
@@ -837,18 +837,18 @@ fn array_layout_offsets() {
                 content: Box::new(glium::program::BlockLayout::Struct {
                     members: vec![
                         ("pos".to_string(), glium::program::BlockLayout::BasicType {
-                            ty: glium::uniforms::UniformType::FloatVec3,
+                            ty: glium::uniforms::UniformType::FloatVec2,
                             offset_in_buffer: 0,
                         }),
 
                         ("dir".to_string(), glium::program::BlockLayout::BasicType {
-                            ty: glium::uniforms::UniformType::FloatVec3,
-                            offset_in_buffer: 16,
+                            ty: glium::uniforms::UniformType::FloatVec2,
+                            offset_in_buffer: 8,
                         }),
 
                         ("speed".to_string(), glium::program::BlockLayout::BasicType {
                             ty: glium::uniforms::UniformType::Float,
-                            offset_in_buffer: 28,
+                            offset_in_buffer: 16,
                         }),
                     ],
                 }),


### PR DESCRIPTION
Fix #1123 

The offset mismatch is probably because:

> Warning: Implementations sometimes get the std140​ layout wrong for vec3​ components. You are advised to manually pad your structures/arrays out and avoid using vec3​ at all.