### PR TITLE
Rename BufferView to Buffer and Buffer to Alloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+ - Renamed `BufferView` to `Buffer`. `BufferView` still exists for backward compatibility.
+
 ## Version 0.8.5 (2015-08-12)
 
  - Added support for cubemaps and cubemap arrays. Not all operations are available yet.

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -8,16 +8,27 @@
 //! There are three levels of abstraction in glium:
 //!
 //!  - A `Buffer` corresponds to an OpenGL buffer object. This type is not public.
-//!  - A `BufferView` corresponds to a part of a `Buffer`. One buffer can contain one or multiple
+//!  - A `Buffer` corresponds to a part of a `Buffer`. One buffer can contain one or multiple
 //!    subbuffers.
 //!  - The `VertexBuffer`, `IndexBuffer`, `UniformBuffer`, `PixelBuffer`, ... types are
 //!    abstractions over a subbuffer indicating their specific purpose. They implement `Deref`
 //!    for the subbuffer. These types are in the `vertex`, `index`, ... modules.
 //!
-pub use self::view::{BufferView, BufferViewAny, BufferViewMutSlice};
-pub use self::view::{BufferViewSlice, BufferViewAnySlice};
+pub use self::view::{Buffer, BufferAny, BufferMutSlice};
+pub use self::view::{BufferSlice, BufferAnySlice};
 pub use self::alloc::{Mapping, WriteMapping, ReadMapping, ReadError, is_buffer_read_supported};
 pub use self::fences::Inserter;
+
+/// DEPRECATED. Only here for backward compatibility.
+pub use self::view::Buffer as BufferView;
+/// DEPRECATED. Only here for backward compatibility.
+pub use self::view::BufferSlice as BufferViewSlice;
+/// DEPRECATED. Only here for backward compatibility.
+pub use self::view::BufferMutSlice as BufferViewMutSlice;
+/// DEPRECATED. Only here for backward compatibility.
+pub use self::view::BufferAny as BufferViewAny;
+/// DEPRECATED. Only here for backward compatibility.
+pub use self::view::BufferAnySlice as BufferViewAnySlice;
 
 use gl;
 use std::mem;

--- a/src/draw_parameters/query.rs
+++ b/src/draw_parameters/query.rs
@@ -12,10 +12,10 @@ use std::fmt;
 use std::mem;
 use std::rc::Rc;
 
-use buffer::BufferView;
-use buffer::BufferViewSlice;
-use BufferViewExt;
-use BufferViewSliceExt;
+use buffer::Buffer;
+use buffer::BufferSlice;
+use BufferExt;
+use BufferSliceExt;
 
 use gl;
 use version::Api;
@@ -177,7 +177,7 @@ impl RawQuery {
             return false;
         }
 
-        BufferView::<u8>::unbind_query(&mut ctxt);
+        Buffer::<u8>::unbind_query(&mut ctxt);
 
         unsafe {
             let mut value = mem::uninitialized();
@@ -214,7 +214,7 @@ impl RawQuery {
             return 0;
         }
 
-        BufferView::<u8>::unbind_query(&mut ctxt);
+        Buffer::<u8>::unbind_query(&mut ctxt);
 
         unsafe {
             let mut value = mem::uninitialized();
@@ -224,7 +224,7 @@ impl RawQuery {
     }
 
     /// Writes the value of the query to a buffer.
-    pub fn write_u32_to_buffer(&self, target: BufferViewSlice<u32>) -> Result<(), ToBufferError> {
+    pub fn write_u32_to_buffer(&self, target: BufferSlice<u32>) -> Result<(), ToBufferError> {
         let mut ctxt = self.context.make_current();
 
         if !(ctxt.version >= &Version(Api::Gl, 4, 4) || ctxt.extensions.gl_arb_query_buffer_object ||
@@ -279,7 +279,7 @@ impl RawQuery {
             return 0;
         }
 
-        BufferView::<u8>::unbind_query(&mut ctxt);
+        Buffer::<u8>::unbind_query(&mut ctxt);
 
         unsafe {
             let mut value = mem::uninitialized();
@@ -720,7 +720,7 @@ macro_rules! impl_helper {
             ///
             /// This operation is not necessarly supported everywhere.
             #[inline]
-            pub fn to_buffer_u32(&self, target: BufferViewSlice<u32>)
+            pub fn to_buffer_u32(&self, target: BufferSlice<u32>)
                                  -> Result<(), ToBufferError>
             {
                 self.query.write_u32_to_buffer(target)

--- a/src/index/buffer.rs
+++ b/src/index/buffer.rs
@@ -1,7 +1,7 @@
-use buffer::{BufferView, BufferViewSlice, BufferViewAny, BufferType};
+use buffer::{Buffer, BufferSlice, BufferAny, BufferType};
 use buffer::{BufferMode, BufferCreationError};
 use gl;
-use BufferViewExt;
+use BufferExt;
 use GlObject;
 
 use backend::Facade;
@@ -36,7 +36,7 @@ impl From<BufferCreationError> for CreationError {
 /// A list of indices loaded in the graphics card's memory.
 #[derive(Debug)]
 pub struct IndexBuffer<T> where T: Index {
-    buffer: BufferView<[T]>,
+    buffer: Buffer<[T]>,
     primitives: PrimitiveType,
 }
 
@@ -91,7 +91,7 @@ impl<T> IndexBuffer<T> where T: Index {
         }
 
         Ok(IndexBuffer {
-            buffer: try!(BufferView::new(facade, data, BufferType::ElementArrayBuffer, mode)).into(),
+            buffer: try!(Buffer::new(facade, data, BufferType::ElementArrayBuffer, mode)).into(),
             primitives: prim,
         })
     }
@@ -146,7 +146,7 @@ impl<T> IndexBuffer<T> where T: Index {
         }
 
         Ok(IndexBuffer {
-            buffer: try!(BufferView::empty_array(facade, BufferType::ElementArrayBuffer, len,
+            buffer: try!(Buffer::empty_array(facade, BufferType::ElementArrayBuffer, len,
                                                  mode)).into(),
             primitives: prim,
         })
@@ -177,17 +177,17 @@ impl<T> IndexBuffer<T> where T: Index {
 }
 
 impl<T> Deref for IndexBuffer<T> where T: Index {
-    type Target = BufferView<[T]>;
+    type Target = Buffer<[T]>;
 
     #[inline]
-    fn deref(&self) -> &BufferView<[T]> {
+    fn deref(&self) -> &Buffer<[T]> {
         &self.buffer
     }
 }
 
 impl<T> DerefMut for IndexBuffer<T> where T: Index {
     #[inline]
-    fn deref_mut(&mut self) -> &mut BufferView<[T]> {
+    fn deref_mut(&mut self) -> &mut Buffer<[T]> {
         &mut self.buffer
     }
 }
@@ -216,7 +216,7 @@ impl<'a, T> From<&'a IndexBuffer<T>> for IndicesSource<'a> where T: Index {
 /// Slice of an `IndexBuffer`.
 #[derive(Debug)]
 pub struct IndexBufferSlice<'a, T: 'a> where T: Index {
-    buffer: BufferViewSlice<'a, [T]>,
+    buffer: BufferSlice<'a, [T]>,
     primitives: PrimitiveType,
 }
 
@@ -246,17 +246,17 @@ impl<'a, T: 'a> IndexBufferSlice<'a, T> where T: Index {
 }
 
 impl<'a, T> Deref for IndexBufferSlice<'a, T> where T: Index {
-    type Target = BufferViewSlice<'a, [T]>;
+    type Target = BufferSlice<'a, [T]>;
 
     #[inline]
-    fn deref(&self) -> &BufferViewSlice<'a, [T]> {
+    fn deref(&self) -> &BufferSlice<'a, [T]> {
         &self.buffer
     }
 }
 
 impl<'a, T> DerefMut for IndexBufferSlice<'a, T> where T: Index {
     #[inline]
-    fn deref_mut(&mut self) -> &mut BufferViewSlice<'a, [T]> {
+    fn deref_mut(&mut self) -> &mut BufferSlice<'a, [T]> {
         &mut self.buffer
     }
 }
@@ -288,7 +288,7 @@ impl<'a, 'r, T> From<&'r IndexBufferSlice<'a, T>> for IndicesSource<'a> where T:
 /// Makes it easier to store in a `Vec` or return from a function, for example.
 #[derive(Debug)]
 pub struct IndexBufferAny {
-    buffer: BufferViewAny,
+    buffer: BufferAny,
     primitives: PrimitiveType,
     data_type: IndexType,
 }
@@ -308,17 +308,17 @@ impl IndexBufferAny {
 }
 
 impl Deref for IndexBufferAny {
-    type Target = BufferViewAny;
+    type Target = BufferAny;
 
     #[inline]
-    fn deref(&self) -> &BufferViewAny {
+    fn deref(&self) -> &BufferAny {
         &self.buffer
     }
 }
 
 impl DerefMut for IndexBufferAny {
     #[inline]
-    fn deref_mut(&mut self) -> &mut BufferViewAny {
+    fn deref_mut(&mut self) -> &mut BufferAny {
         &mut self.buffer
     }
 }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -37,7 +37,7 @@ use version::Version;
 
 use std::mem;
 
-use buffer::BufferViewAnySlice;
+use buffer::BufferAnySlice;
 
 pub use self::buffer::{IndexBuffer, IndexBufferSlice, IndexBufferAny};
 pub use self::buffer::CreationError as BufferCreationError;
@@ -53,7 +53,7 @@ pub enum IndicesSource<'a> {
     /// A buffer uploaded in video memory.
     IndexBuffer {
         /// The buffer.
-        buffer: BufferViewAnySlice<'a>,
+        buffer: BufferAnySlice<'a>,
         /// Type of indices in the buffer.
         data_type: IndexType,
         /// Type of primitives contained in the vertex source.
@@ -63,7 +63,7 @@ pub enum IndicesSource<'a> {
     /// Use a multidraw indirect buffer without indices.
     MultidrawArray {
         /// The buffer.
-        buffer: BufferViewAnySlice<'a>,
+        buffer: BufferAnySlice<'a>,
         /// Type of primitives contained in the vertex source.
         primitives: PrimitiveType,
     },
@@ -71,9 +71,9 @@ pub enum IndicesSource<'a> {
     /// Use a multidraw indirect buffer with indices.
     MultidrawElement {
         /// The buffer of the commands.
-        commands: BufferViewAnySlice<'a>,
+        commands: BufferAnySlice<'a>,
         /// The buffer of the indices.
-        indices: BufferViewAnySlice<'a>,
+        indices: BufferAnySlice<'a>,
         /// Type of indices in the buffer.
         data_type: IndexType,
         /// Type of primitives contained in the vertex source.

--- a/src/index/multidraw.rs
+++ b/src/index/multidraw.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 use std::ops::DerefMut;
 
 use backend::Facade;
-use buffer::{BufferCreationError, BufferType, BufferMode, BufferView};
+use buffer::{BufferCreationError, BufferType, BufferMode, Buffer};
 use index::{IndicesSource, PrimitiveType, IndexBuffer, Index};
 
 /// Represents an element in a list of draw commands.
@@ -47,7 +47,7 @@ implement_uniform_block!(DrawCommandIndices, count, instance_count, first_index,
 
 /// A buffer containing a list of draw commands.
 pub struct DrawCommandsNoIndicesBuffer {
-    buffer: BufferView<[DrawCommandNoIndices]>,
+    buffer: Buffer<[DrawCommandNoIndices]>,
 }
 
 impl DrawCommandsNoIndicesBuffer {
@@ -59,7 +59,7 @@ impl DrawCommandsNoIndicesBuffer {
                     -> Result<DrawCommandsNoIndicesBuffer, BufferCreationError>
                     where F: Facade
     {
-        let buf = try!(BufferView::empty_array(facade, BufferType::DrawIndirectBuffer,
+        let buf = try!(Buffer::empty_array(facade, BufferType::DrawIndirectBuffer,
                                                elements, BufferMode::Default));
         Ok(DrawCommandsNoIndicesBuffer { buffer: buf })
     }
@@ -72,7 +72,7 @@ impl DrawCommandsNoIndicesBuffer {
                             -> Result<DrawCommandsNoIndicesBuffer, BufferCreationError>
                             where F: Facade
     {
-        let buf = try!(BufferView::empty_array(facade, BufferType::DrawIndirectBuffer,
+        let buf = try!(Buffer::empty_array(facade, BufferType::DrawIndirectBuffer,
                                                elements, BufferMode::Dynamic));
         Ok(DrawCommandsNoIndicesBuffer { buffer: buf })
     }
@@ -85,7 +85,7 @@ impl DrawCommandsNoIndicesBuffer {
                                -> Result<DrawCommandsNoIndicesBuffer, BufferCreationError>
                                where F: Facade
     {
-        let buf = try!(BufferView::empty_array(facade, BufferType::DrawIndirectBuffer,
+        let buf = try!(Buffer::empty_array(facade, BufferType::DrawIndirectBuffer,
                                                elements, BufferMode::Persistent));
         Ok(DrawCommandsNoIndicesBuffer { buffer: buf })
     }
@@ -98,7 +98,7 @@ impl DrawCommandsNoIndicesBuffer {
                               -> Result<DrawCommandsNoIndicesBuffer, BufferCreationError>
                               where F: Facade
     {
-        let buf = try!(BufferView::empty_array(facade, BufferType::DrawIndirectBuffer,
+        let buf = try!(Buffer::empty_array(facade, BufferType::DrawIndirectBuffer,
                                                elements, BufferMode::Immutable));
         Ok(DrawCommandsNoIndicesBuffer { buffer: buf })
     }
@@ -115,24 +115,24 @@ impl DrawCommandsNoIndicesBuffer {
 }
 
 impl Deref for DrawCommandsNoIndicesBuffer {
-    type Target = BufferView<[DrawCommandNoIndices]>;
+    type Target = Buffer<[DrawCommandNoIndices]>;
 
     #[inline]
-    fn deref(&self) -> &BufferView<[DrawCommandNoIndices]> {
+    fn deref(&self) -> &Buffer<[DrawCommandNoIndices]> {
         &self.buffer
     }
 }
 
 impl DerefMut for DrawCommandsNoIndicesBuffer {
     #[inline]
-    fn deref_mut(&mut self) -> &mut BufferView<[DrawCommandNoIndices]> {
+    fn deref_mut(&mut self) -> &mut Buffer<[DrawCommandNoIndices]> {
         &mut self.buffer
     }
 }
 
 /// A buffer containing a list of draw commands.
 pub struct DrawCommandsIndicesBuffer {
-    buffer: BufferView<[DrawCommandIndices]>,
+    buffer: Buffer<[DrawCommandIndices]>,
 }
 
 impl DrawCommandsIndicesBuffer {
@@ -144,7 +144,7 @@ impl DrawCommandsIndicesBuffer {
                     -> Result<DrawCommandsIndicesBuffer, BufferCreationError>
                     where F: Facade
     {
-        let buf = try!(BufferView::empty_array(facade, BufferType::DrawIndirectBuffer,
+        let buf = try!(Buffer::empty_array(facade, BufferType::DrawIndirectBuffer,
                                                elements, BufferMode::Default));
         Ok(DrawCommandsIndicesBuffer { buffer: buf })
     }
@@ -157,7 +157,7 @@ impl DrawCommandsIndicesBuffer {
                             -> Result<DrawCommandsIndicesBuffer, BufferCreationError>
                             where F: Facade
     {
-        let buf = try!(BufferView::empty_array(facade, BufferType::DrawIndirectBuffer,
+        let buf = try!(Buffer::empty_array(facade, BufferType::DrawIndirectBuffer,
                                                elements, BufferMode::Dynamic));
         Ok(DrawCommandsIndicesBuffer { buffer: buf })
     }
@@ -170,7 +170,7 @@ impl DrawCommandsIndicesBuffer {
                                -> Result<DrawCommandsIndicesBuffer, BufferCreationError>
                                where F: Facade
     {
-        let buf = try!(BufferView::empty_array(facade, BufferType::DrawIndirectBuffer,
+        let buf = try!(Buffer::empty_array(facade, BufferType::DrawIndirectBuffer,
                                                elements, BufferMode::Persistent));
         Ok(DrawCommandsIndicesBuffer { buffer: buf })
     }
@@ -183,7 +183,7 @@ impl DrawCommandsIndicesBuffer {
                               -> Result<DrawCommandsIndicesBuffer, BufferCreationError>
                               where F: Facade
     {
-        let buf = try!(BufferView::empty_array(facade, BufferType::DrawIndirectBuffer,
+        let buf = try!(Buffer::empty_array(facade, BufferType::DrawIndirectBuffer,
                                                elements, BufferMode::Immutable));
         Ok(DrawCommandsIndicesBuffer { buffer: buf })
     }
@@ -204,17 +204,17 @@ impl DrawCommandsIndicesBuffer {
 }
 
 impl Deref for DrawCommandsIndicesBuffer {
-    type Target = BufferView<[DrawCommandIndices]>;
+    type Target = Buffer<[DrawCommandIndices]>;
 
     #[inline]
-    fn deref(&self) -> &BufferView<[DrawCommandIndices]> {
+    fn deref(&self) -> &Buffer<[DrawCommandIndices]> {
         &self.buffer
     }
 }
 
 impl DerefMut for DrawCommandsIndicesBuffer {
     #[inline]
-    fn deref_mut(&mut self) -> &mut BufferView<[DrawCommandIndices]> {
+    fn deref_mut(&mut self) -> &mut Buffer<[DrawCommandIndices]> {
         &mut self.buffer
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,7 @@ trait ToGlEnum {
 }
 
 /// Internal trait for subbuffers.
-trait BufferViewExt {
+trait BufferExt {
     /// Returns the number of bytes from the start of the buffer to this subbuffer.
     fn get_offset_bytes(&self) -> usize;
 
@@ -254,7 +254,7 @@ trait BufferViewExt {
 }
 
 /// Internal trait for subbuffer slices.
-trait BufferViewSliceExt<'a> {
+trait BufferSliceExt<'a> {
     /// Tries to get an object where to write a fence.
     ///
     /// If this function returns `None`, no fence will be created nor written.

--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -1,8 +1,8 @@
 use std::ptr;
 use std::ops::Range;
 
-use BufferViewExt;
-use BufferViewSliceExt;
+use BufferExt;
+use BufferSliceExt;
 use ProgramExt;
 use DrawError;
 use UniformsExt;

--- a/src/ops/read.rs
+++ b/src/ops/read.rs
@@ -7,8 +7,8 @@ use texture::PixelValue;
 use fbo;
 use fbo::FramebuffersContainer;
 
-use buffer::BufferViewAny;
-use BufferViewExt;
+use buffer::BufferAny;
+use BufferExt;
 use Rect;
 use context::CommandContext;
 use gl;
@@ -96,7 +96,7 @@ pub fn read_if_supported<'a, S, D, T>(mut ctxt: &mut CommandContext, source: S, 
             Destination::Memory(dest) => {
                 let mut buf = Vec::with_capacity(pixels_to_read as usize);
 
-                BufferViewAny::unbind_pixel_pack(ctxt);
+                BufferAny::unbind_pixel_pack(ctxt);
 
                 // adjusting data alignement
                 let ptr = buf.as_mut_ptr() as *mut D;

--- a/src/texture/any.rs
+++ b/src/texture/any.rs
@@ -19,10 +19,10 @@ use texture::{get_format, InternalFormat, GetFormatError};
 use texture::pixel::PixelValue;
 use texture::pixel_buffer::PixelBuffer;
 
-use buffer::BufferViewSlice;
-use buffer::BufferViewAny;
-use BufferViewExt;
-use BufferViewSliceExt;
+use buffer::BufferSlice;
+use buffer::BufferAny;
+use BufferExt;
+use BufferSliceExt;
 
 use libc;
 use std::cmp;
@@ -169,7 +169,7 @@ pub fn new_texture<'a, F, P>(facade: &F, format: TextureFormatRequest,
             ctxt.gl.PixelStorei(gl::UNPACK_ALIGNMENT, 1);
         }
 
-        BufferViewAny::unbind_pixel_unpack(&mut ctxt);
+        BufferAny::unbind_pixel_unpack(&mut ctxt);
 
         let id: gl::types::GLuint = mem::uninitialized();
         ctxt.gl.GenTextures(1, mem::transmute(&id));
@@ -803,7 +803,7 @@ impl<'a> TextureAnyMipmap<'a> {
     /// Panicks if the offsets and dimenions are outside the boundaries of the texture. Panicks
     /// if the buffer is not big enough to hold the data.
     #[inline]
-    pub fn raw_upload_from_pixel_buffer<P>(&self, source: BufferViewSlice<[P]>, x: Range<u32>,
+    pub fn raw_upload_from_pixel_buffer<P>(&self, source: BufferSlice<[P]>, x: Range<u32>,
                                            y: Range<u32>, z: Range<u32>)
                                            where P: PixelValue
     {
@@ -817,14 +817,14 @@ impl<'a> TextureAnyMipmap<'a> {
     /// Panicks if the offsets and dimenions are outside the boundaries of the texture. Panicks
     /// if the buffer is not big enough to hold the data.
     #[inline]
-    pub fn raw_upload_from_pixel_buffer_inverted<P>(&self, source: BufferViewSlice<[P]>,
+    pub fn raw_upload_from_pixel_buffer_inverted<P>(&self, source: BufferSlice<[P]>,
                                                     x: Range<u32>, y: Range<u32>, z: Range<u32>)
                                                     where P: PixelValue
     {
         self.raw_upload_from_pixel_buffer_impl(source, x, y, z, true);
     }
 
-    fn raw_upload_from_pixel_buffer_impl<P>(&self, source: BufferViewSlice<[P]>, x: Range<u32>,
+    fn raw_upload_from_pixel_buffer_impl<P>(&self, source: BufferSlice<[P]>, x: Range<u32>,
                                             y: Range<u32>, z: Range<u32>, inverted: bool)
                                             where P: PixelValue
     {
@@ -1074,7 +1074,7 @@ impl<'t> TextureMipmapExt for TextureAnyMipmap<'t> {
                 ctxt.gl.PixelStorei(gl::UNPACK_ALIGNMENT, 1);
             }
 
-            BufferViewAny::unbind_pixel_unpack(&mut ctxt);
+            BufferAny::unbind_pixel_unpack(&mut ctxt);
             let bind_point = self.texture.bind_to_current(&mut ctxt);
 
             if bind_point == gl::TEXTURE_3D || bind_point == gl::TEXTURE_2D_ARRAY {
@@ -1145,7 +1145,7 @@ impl<'t> TextureMipmapExt for TextureAnyMipmap<'t> {
                         let mut buf = Vec::with_capacity(buffer_size as usize);
                         buf.set_len(buffer_size as usize);
 
-                        BufferViewAny::unbind_pixel_pack(&mut ctxt);
+                        BufferAny::unbind_pixel_pack(&mut ctxt);
                         
                         // adjusting data alignement
                         let ptr = buf.as_ptr() as *const u8;

--- a/src/texture/buffer_texture.rs
+++ b/src/texture/buffer_texture.rs
@@ -7,7 +7,7 @@ A buffer texture is composed of two things:
  - A buffer.
  - A texture.
 
-The `BufferTexture` object derefs to a `BufferView`, which allows you to modify the content of the
+The `BufferTexture` object derefs to a `Buffer`, which allows you to modify the content of the
 buffer just like any other buffer type.
 
 The texture aspect of the buffer texture is very limited. The only thing you can do is use the
@@ -67,10 +67,10 @@ use ContextExt;
 
 use TextureExt;
 
-use BufferViewExt;
+use BufferExt;
 use buffer::BufferMode;
 use buffer::BufferType;
-use buffer::BufferView;
+use buffer::Buffer;
 use buffer::BufferCreationError;
 use buffer::Content as BufferContent;
 
@@ -136,7 +136,7 @@ pub enum BufferTextureType {
 
 /// A one-dimensional texture that gets its data from a buffer.
 pub struct BufferTexture<T> where [T]: BufferContent {
-    buffer: BufferView<[T]>,
+    buffer: Buffer<[T]>,
     texture: gl::types::GLuint,
     ty: BufferTextureType,
 }
@@ -183,7 +183,7 @@ impl<T> BufferTexture<T> where [T]: BufferContent, T: TextureBufferContent + Cop
                    -> Result<BufferTexture<T>, CreationError>
                    where F: Facade
     {
-        let buffer = try!(BufferView::new(facade, data, BufferType::TextureBuffer, mode));
+        let buffer = try!(Buffer::new(facade, data, BufferType::TextureBuffer, mode));
         BufferTexture::from_buffer(facade, buffer, ty).map_err(|(e, _)| e.into())
     }
 
@@ -228,13 +228,13 @@ impl<T> BufferTexture<T> where [T]: BufferContent, T: TextureBufferContent + Cop
                      -> Result<BufferTexture<T>, CreationError>
                      where F: Facade
     {
-        let buffer = try!(BufferView::empty_array(facade, BufferType::TextureBuffer, len, mode));
+        let buffer = try!(Buffer::empty_array(facade, BufferType::TextureBuffer, len, mode));
         BufferTexture::from_buffer(facade, buffer, ty).map_err(|(e, _)| e.into())
     }
 
     /// Builds a new buffer texture by taking ownership of a buffer.
-    pub fn from_buffer<F>(context: &F, buffer: BufferView<[T]>, ty: BufferTextureType)
-                          -> Result<BufferTexture<T>, (TextureCreationError, BufferView<[T]>)>
+    pub fn from_buffer<F>(context: &F, buffer: Buffer<[T]>, ty: BufferTextureType)
+                          -> Result<BufferTexture<T>, (TextureCreationError, Buffer<[T]>)>
                           where F: Facade
     {
         let context = context.get_context();
@@ -413,17 +413,17 @@ impl<T> BufferTexture<T> where [T]: BufferContent, T: TextureBufferContent + Cop
 }
 
 impl<T> Deref for BufferTexture<T> where [T]: BufferContent {
-    type Target = BufferView<[T]>;
+    type Target = Buffer<[T]>;
 
     #[inline]
-    fn deref(&self) -> &BufferView<[T]> {
+    fn deref(&self) -> &Buffer<[T]> {
         &self.buffer
     }
 }
 
 impl<T> DerefMut for BufferTexture<T> where [T]: BufferContent {
     #[inline]
-    fn deref_mut(&mut self) -> &mut BufferView<[T]> {
+    fn deref_mut(&mut self) -> &mut Buffer<[T]> {
         &mut self.buffer
     }
 }

--- a/src/texture/pixel_buffer.rs
+++ b/src/texture/pixel_buffer.rs
@@ -11,8 +11,8 @@ use std::ops::{Deref, DerefMut};
 use backend::Facade;
 
 use GlObject;
-use BufferViewExt;
-use buffer::{ReadError, BufferView, BufferType, BufferMode};
+use BufferExt;
+use buffer::{ReadError, Buffer, BufferType, BufferMode};
 use gl;
 
 use texture::PixelValue;
@@ -22,7 +22,7 @@ use texture::Texture2dDataSink;
 ///
 /// The generic type represents the type of pixels that the buffer contains.
 pub struct PixelBuffer<T> where T: PixelValue {
-    buffer: BufferView<[T]>,
+    buffer: Buffer<[T]>,
     dimensions: Cell<Option<(u32, u32)>>,
 }
 
@@ -31,7 +31,7 @@ impl<T> PixelBuffer<T> where T: PixelValue {
     #[inline]
     pub fn new_empty<F>(facade: &F, capacity: usize) -> PixelBuffer<T> where F: Facade {
         PixelBuffer {
-            buffer: BufferView::empty_array(facade, BufferType::PixelPackBuffer, capacity,
+            buffer: Buffer::empty_array(facade, BufferType::PixelPackBuffer, capacity,
                                             BufferMode::Default).unwrap(),
             dimensions: Cell::new(None),
         }
@@ -47,17 +47,17 @@ impl<T> PixelBuffer<T> where T: PixelValue {
 }
 
 impl<T> Deref for PixelBuffer<T> where T: PixelValue {
-    type Target = BufferView<[T]>;
+    type Target = Buffer<[T]>;
 
     #[inline]
-    fn deref(&self) -> &BufferView<[T]> {
+    fn deref(&self) -> &Buffer<[T]> {
         &self.buffer
     }
 }
 
 impl<T> DerefMut for PixelBuffer<T> where T: PixelValue {
     #[inline]
-    fn deref_mut(&mut self) -> &mut BufferView<[T]> {
+    fn deref_mut(&mut self) -> &mut Buffer<[T]> {
         &mut self.buffer
     }
 }

--- a/src/uniforms/bind.rs
+++ b/src/uniforms/bind.rs
@@ -5,8 +5,8 @@ Handles binding uniforms to the OpenGL state machine.
 */
 use gl;
 
-use BufferViewExt;
-use BufferViewSliceExt;
+use BufferExt;
+use BufferSliceExt;
 use DrawError;
 use ProgramExt;
 use UniformsExt;

--- a/src/uniforms/buffer.rs
+++ b/src/uniforms/buffer.rs
@@ -1,4 +1,4 @@
-use buffer::{Content, BufferView, BufferViewAny, BufferType, BufferMode, BufferCreationError};
+use buffer::{Content, Buffer, BufferAny, BufferType, BufferMode, BufferCreationError};
 use uniforms::{AsUniformValue, UniformBlock, UniformValue, LayoutMismatchError};
 use program;
 
@@ -9,13 +9,13 @@ use backend::Facade;
 /// Buffer that contains a uniform block.
 #[derive(Debug)]
 pub struct UniformBuffer<T: ?Sized> where T: Content {
-    buffer: BufferView<T>,
+    buffer: Buffer<T>,
 }
 
 /// Same as `UniformBuffer` but doesn't contain any information about the type.
 #[derive(Debug)]
 pub struct TypelessUniformBuffer {
-    buffer: BufferViewAny,
+    buffer: BufferAny,
 }
 
 impl<T> UniformBuffer<T> where T: Copy {
@@ -56,7 +56,7 @@ impl<T> UniformBuffer<T> where T: Copy {
                    -> Result<UniformBuffer<T>, BufferCreationError>
                    where F: Facade
     {
-        let buffer = try!(BufferView::new(facade, &data, BufferType::UniformBuffer, mode));
+        let buffer = try!(Buffer::new(facade, &data, BufferType::UniformBuffer, mode));
 
         Ok(UniformBuffer {
             buffer: buffer,
@@ -97,7 +97,7 @@ impl<T> UniformBuffer<T> where T: Copy {
     fn empty_impl<F>(facade: &F, mode: BufferMode) -> Result<UniformBuffer<T>, BufferCreationError>
                      where F: Facade
     {
-        let buffer = try!(BufferView::empty(facade, BufferType::UniformBuffer, mode));
+        let buffer = try!(Buffer::empty(facade, BufferType::UniformBuffer, mode));
 
         Ok(UniformBuffer {
             buffer: buffer,
@@ -167,7 +167,7 @@ impl<T: ?Sized> UniformBuffer<T> where T: Content {
                              -> Result<UniformBuffer<T>, BufferCreationError>
                              where F: Facade
     {
-        let buffer = try!(BufferView::empty_unsized(facade, BufferType::UniformBuffer, size, mode));
+        let buffer = try!(Buffer::empty_unsized(facade, BufferType::UniformBuffer, size, mode));
 
         Ok(UniformBuffer {
             buffer: buffer,
@@ -176,17 +176,17 @@ impl<T: ?Sized> UniformBuffer<T> where T: Content {
 }
 
 impl<T: ?Sized> Deref for UniformBuffer<T> where T: Content {
-    type Target = BufferView<T>;
+    type Target = Buffer<T>;
 
     #[inline]
-    fn deref(&self) -> &BufferView<T> {
+    fn deref(&self) -> &Buffer<T> {
         &self.buffer
     }
 }
 
 impl<T: ?Sized> DerefMut for UniformBuffer<T> where T: Content {
     #[inline]
-    fn deref_mut(&mut self) -> &mut BufferView<T> {
+    fn deref_mut(&mut self) -> &mut Buffer<T> {
         &mut self.buffer
     }
 }

--- a/src/uniforms/mod.rs
+++ b/src/uniforms/mod.rs
@@ -96,7 +96,7 @@ pub use self::uniforms::{EmptyUniforms, UniformsStorage};
 pub use self::value::{UniformValue, UniformType};
 
 use buffer::Content as BufferContent;
-use buffer::BufferView;
+use buffer::Buffer;
 use program;
 use program::BlockLayout;
 
@@ -167,7 +167,7 @@ pub trait AsUniformValue {
 }
 
 // TODO: no way to bind a slice
-impl<'a, T: ?Sized> AsUniformValue for &'a BufferView<T> where T: UniformBlock + BufferContent {
+impl<'a, T: ?Sized> AsUniformValue for &'a Buffer<T> where T: UniformBlock + BufferContent {
     #[inline]
     fn as_uniform_value(&self) -> UniformValue {
         #[inline]

--- a/src/uniforms/value.rs
+++ b/src/uniforms/value.rs
@@ -7,7 +7,7 @@ use uniforms::LayoutMismatchError;
 use uniforms::UniformBlock;
 use uniforms::SamplerBehavior;
 
-use buffer::BufferViewAnySlice;
+use buffer::BufferAnySlice;
 
 #[cfg(feature = "cgmath")]
 use cgmath;
@@ -137,7 +137,7 @@ pub enum UniformValue<'a> {
     /// can be binded on a block with the given layout.
     /// The last parameter is a sender which must be used to send a `SyncFence` that expires when
     /// the buffer has finished being used.
-    Block(BufferViewAnySlice<'a>, fn(&program::UniformBlock) -> Result<(), LayoutMismatchError>),
+    Block(BufferAnySlice<'a>, fn(&program::UniformBlock) -> Result<(), LayoutMismatchError>),
     SignedInt(i32),
     UnsignedInt(u32),
     Float(f32),

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -1,6 +1,6 @@
 use std::ops::{Range, Deref, DerefMut};
 
-use buffer::{BufferView, BufferViewSlice, BufferViewAny, BufferType, BufferMode, BufferCreationError};
+use buffer::{Buffer, BufferSlice, BufferAny, BufferType, BufferMode, BufferCreationError};
 use vertex::{Vertex, VerticesSource, IntoVerticesSource, PerInstance};
 use vertex::format::VertexFormat;
 
@@ -30,13 +30,13 @@ impl From<BufferCreationError> for CreationError {
 /// A list of vertices loaded in the graphics card's memory.
 #[derive(Debug)]
 pub struct VertexBuffer<T> where T: Copy {
-    buffer: BufferView<[T]>,
+    buffer: Buffer<[T]>,
     bindings: VertexFormat,
 }
 
 /// Represents a slice of a `VertexBuffer`.
 pub struct VertexBufferSlice<'b, T: 'b> where T: Copy {
-    buffer: BufferViewSlice<'b, [T]>,
+    buffer: BufferSlice<'b, [T]>,
     bindings: &'b VertexFormat,
 }
 
@@ -111,7 +111,7 @@ impl<T> VertexBuffer<T> where T: Vertex {
             return Err(CreationError::FormatNotSupported);
         }
 
-        let buffer = try!(BufferView::new(facade, data, BufferType::ArrayBuffer, mode));
+        let buffer = try!(Buffer::new(facade, data, BufferType::ArrayBuffer, mode));
         Ok(buffer.into())
     }
 
@@ -165,7 +165,7 @@ impl<T> VertexBuffer<T> where T: Vertex {
             return Err(CreationError::FormatNotSupported);
         }
 
-        let buffer = try!(BufferView::empty_array(facade, BufferType::ArrayBuffer, elements, mode));
+        let buffer = try!(Buffer::empty_array(facade, BufferType::ArrayBuffer, elements, mode));
         Ok(buffer.into())
     }
 }
@@ -211,7 +211,7 @@ impl<T> VertexBuffer<T> where T: Copy {
         // FIXME: check that the format is supported
 
         Ok(VertexBuffer {
-            buffer: try!(BufferView::new(facade, data, BufferType::ArrayBuffer,
+            buffer: try!(Buffer::new(facade, data, BufferType::ArrayBuffer,
                                          BufferMode::Default)),
             bindings: bindings,
         })
@@ -227,7 +227,7 @@ impl<T> VertexBuffer<T> where T: Copy {
         // FIXME: check that the format is supported
 
         Ok(VertexBuffer {
-            buffer: try!(BufferView::new(facade, data, BufferType::ArrayBuffer,
+            buffer: try!(Buffer::new(facade, data, BufferType::ArrayBuffer,
                                          BufferMode::Dynamic)),
             bindings: bindings,
         })
@@ -286,9 +286,9 @@ impl<T> VertexBuffer<T> where T: Copy + Send + 'static {
     }
 }
 
-impl<T> From<BufferView<[T]>> for VertexBuffer<T> where T: Vertex + Copy {
+impl<T> From<Buffer<[T]>> for VertexBuffer<T> where T: Vertex + Copy {
     #[inline]
-    fn from(buffer: BufferView<[T]>) -> VertexBuffer<T> {
+    fn from(buffer: Buffer<[T]>) -> VertexBuffer<T> {
         assert!(T::is_supported(buffer.get_context()));
 
         let bindings = <T as Vertex>::build_bindings();
@@ -301,17 +301,17 @@ impl<T> From<BufferView<[T]>> for VertexBuffer<T> where T: Vertex + Copy {
 }
 
 impl<T> Deref for VertexBuffer<T> where T: Copy {
-    type Target = BufferView<[T]>;
+    type Target = Buffer<[T]>;
 
     #[inline]
-    fn deref(&self) -> &BufferView<[T]> {
+    fn deref(&self) -> &Buffer<[T]> {
         &self.buffer
     }
 }
 
 impl<T> DerefMut for VertexBuffer<T> where T: Copy {
     #[inline]
-    fn deref_mut(&mut self) -> &mut BufferView<[T]> {
+    fn deref_mut(&mut self) -> &mut Buffer<[T]> {
         &mut self.buffer
     }
 }
@@ -324,17 +324,17 @@ impl<'a, T> IntoVerticesSource<'a> for &'a VertexBuffer<T> where T: Copy {
 }
 
 impl<'a, T> Deref for VertexBufferSlice<'a, T> where T: Copy {
-    type Target = BufferViewSlice<'a, [T]>;
+    type Target = BufferSlice<'a, [T]>;
 
     #[inline]
-    fn deref(&self) -> &BufferViewSlice<'a, [T]> {
+    fn deref(&self) -> &BufferSlice<'a, [T]> {
         &self.buffer
     }
 }
 
 impl<'a, T> DerefMut for VertexBufferSlice<'a, T> where T: Copy {
     #[inline]
-    fn deref_mut(&mut self) -> &mut BufferViewSlice<'a, [T]> {
+    fn deref_mut(&mut self) -> &mut BufferSlice<'a, [T]> {
         &mut self.buffer
     }
 }
@@ -355,7 +355,7 @@ impl<'a, T> IntoVerticesSource<'a> for VertexBufferSlice<'a, T> where T: Copy {
 /// or return a `VertexBufferAny` instead of a `VertexBuffer<MyPrivateVertexType>`.
 #[derive(Debug)]
 pub struct VertexBufferAny {
-    buffer: BufferViewAny,
+    buffer: BufferAny,
     bindings: VertexFormat,
 }
 
@@ -410,9 +410,9 @@ impl<T> From<VertexBuffer<T>> for VertexBufferAny where T: Copy + Send + 'static
     }
 }
 
-impl<T> From<BufferView<[T]>> for VertexBufferAny where T: Vertex + Copy + Send + 'static {
+impl<T> From<Buffer<[T]>> for VertexBufferAny where T: Vertex + Copy + Send + 'static {
     #[inline]
-    fn from(buf: BufferView<[T]>) -> VertexBufferAny {
+    fn from(buf: Buffer<[T]>) -> VertexBufferAny {
         let buf: VertexBuffer<T> = buf.into();
         buf.into_vertex_buffer_any()
     }

--- a/src/vertex/mod.rs
+++ b/src/vertex/mod.rs
@@ -141,7 +141,7 @@ pub use self::buffer::CreationError as BufferCreationError;
 pub use self::format::{AttributeType, VertexFormat};
 pub use self::transform_feedback::{is_transform_feedback_supported, TransformFeedbackSession};
 
-use buffer::BufferViewAnySlice;
+use buffer::BufferAnySlice;
 use CapabilitiesSource;
 
 mod buffer;
@@ -157,7 +157,7 @@ pub enum VerticesSource<'a> {
     ///
     /// The third parameter tells whether or not this buffer is "per instance" (true) or
     /// "per vertex" (false).
-    VertexBuffer(BufferViewAnySlice<'a>, &'a VertexFormat, bool),
+    VertexBuffer(BufferAnySlice<'a>, &'a VertexFormat, bool),
 
     /// A marker indicating a "phantom list of attributes".
     Marker {
@@ -209,7 +209,7 @@ impl<'a> IntoVerticesSource<'a> for EmptyInstanceAttributes {
 }
 
 /// Marker that instructs glium that the buffer is to be used per instance.
-pub struct PerInstance<'a>(BufferViewAnySlice<'a>, &'a VertexFormat);
+pub struct PerInstance<'a>(BufferAnySlice<'a>, &'a VertexFormat);
 
 impl<'a> IntoVerticesSource<'a> for PerInstance<'a> {
     #[inline]

--- a/src/vertex/transform_feedback.rs
+++ b/src/vertex/transform_feedback.rs
@@ -4,10 +4,10 @@ use version::Api;
 use version::Version;
 use context::CommandContext;
 use backend::Facade;
-use BufferViewExt;
+use BufferExt;
 use CapabilitiesSource;
 use TransformFeedbackSessionExt;
-use buffer::{BufferView, BufferViewAnySlice};
+use buffer::{Buffer, BufferAnySlice};
 use index::PrimitiveType;
 use program::OutputPrimitives;
 use program::Program;
@@ -89,7 +89,7 @@ use gl;
 /// ```
 #[derive(Debug)]
 pub struct TransformFeedbackSession<'a> {
-    buffer: BufferViewAnySlice<'a>,
+    buffer: BufferAnySlice<'a>,
     program: &'a Program,
 }
 
@@ -118,7 +118,7 @@ impl<'a> TransformFeedbackSession<'a> {
     ///
     /// TODO: this constructor should ultimately support passing multiple buffers of different
     ///       types
-    pub fn new<F, V>(facade: &F, program: &'a Program, buffer: &'a mut BufferView<[V]>)
+    pub fn new<F, V>(facade: &F, program: &'a Program, buffer: &'a mut Buffer<[V]>)
                      -> Result<TransformFeedbackSession<'a>, TransformFeedbackSessionCreationError>
                      where F: Facade, V: Vertex + Copy + Send + 'static
     {

--- a/src/vertex_array_object.rs
+++ b/src/vertex_array_object.rs
@@ -6,12 +6,12 @@ use std::mem;
 use smallvec::SmallVec;
 
 use Handle;
-use buffer::BufferViewAnySlice;
+use buffer::BufferAnySlice;
 use program::Program;
 use vertex::AttributeType;
 use vertex::VertexFormat;
 use GlObject;
-use BufferViewExt;
+use BufferExt;
 
 use {libc, gl};
 use context::CommandContext;
@@ -29,7 +29,7 @@ pub struct VertexAttributesSystem {
 pub struct Binder<'a, 'b, 'c: 'b> {
     context: &'b mut CommandContext<'c>,
     program: &'a Program,
-    element_array_buffer: Option<BufferViewAnySlice<'a>>,
+    element_array_buffer: Option<BufferAnySlice<'a>>,
     vertex_buffers: SmallVec<[(gl::types::GLuint, VertexFormat, usize, usize, Option<u32>); 2]>,
     base_vertex: bool,
 }
@@ -49,7 +49,7 @@ impl VertexAttributesSystem {
     /// functions. If `base_vertex` is true, then `bind` will return the base vertex to use.
     #[inline]
     pub fn start<'a, 'b, 'c: 'b>(ctxt: &'b mut CommandContext<'c>, program: &'a Program,
-                                 indices: Option<BufferViewAnySlice<'a>>, base_vertex: bool)
+                                 indices: Option<BufferAnySlice<'a>>, base_vertex: bool)
                                  -> Binder<'a, 'b, 'c>
     {
         if let Some(indices) = indices {
@@ -142,7 +142,7 @@ impl<'a, 'b, 'c> Binder<'a, 'b, 'c> {
     /// - `first`: Offset of the first element of the buffer in number of elements.
     /// - `divisor`: If `Some`, use this value for `glVertexAttribDivisor` (instancing-related).
     #[inline]
-    pub fn add(mut self, buffer: &BufferViewAnySlice, bindings: &VertexFormat, divisor: Option<u32>)
+    pub fn add(mut self, buffer: &BufferAnySlice, bindings: &VertexFormat, divisor: Option<u32>)
                -> Binder<'a, 'b, 'c>
     {
         let offset = buffer.get_offset_bytes();
@@ -255,7 +255,7 @@ impl VertexArrayObject {
     /// VAO, and the VB & program attributes must not change.
     unsafe fn new(mut ctxt: &mut CommandContext,
                   vertex_buffers: &[(gl::types::GLuint, VertexFormat, usize, usize, Option<u32>)],
-                  index_buffer: Option<BufferViewAnySlice>, program: &Program) -> VertexArrayObject
+                  index_buffer: Option<BufferAnySlice>, program: &Program) -> VertexArrayObject
     {
         // checking the attributes types
         for &(_, ref bindings, _, _, _) in vertex_buffers {


### PR DESCRIPTION
Not a breaking change. The old symbols are reexported.