### PR TITLE
Move the read functions to TextureAnyImage and make them public

### DIFF
--- a/build/textures.rs
+++ b/build/textures.rs
@@ -858,7 +858,9 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
                 /// Use `read_to_pixel_buffer` instead.
                 #[inline]
                 pub fn read<T>(&self) -> T where T: Texture2dDataSink<(u8, u8, u8, u8)> {{
-                    self.0.mipmap(0).unwrap().read()
+                    let rect = Rect {{ left: 0, bottom: 0, width: self.get_width(),
+                                       height: self.get_height().unwrap_or(1) }};
+                    self.0.main_level().first_layer().into_image(None).unwrap().raw_read(&rect)
                 }}
             "#)).unwrap();
 
@@ -870,7 +872,13 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
                 /// done asynchronously and doesn't need a synchronization.
                 #[inline]
                 pub fn read_to_pixel_buffer(&self) -> PixelBuffer<(u8, u8, u8, u8)> {{
-                    self.0.mipmap(0).unwrap().read_to_pixel_buffer()
+                    let rect = Rect {{ left: 0, bottom: 0, width: self.get_width(),
+                                       height: self.get_height().unwrap_or(1) }};
+                    let pb = PixelBuffer::new_empty(self.0.get_context(),
+                                                    rect.width as usize * rect.height as usize);
+                    self.0.main_level().first_layer().into_image(None).unwrap()
+                          .raw_read_to_pixel_buffer(&rect, &pb);
+                    pb
                 }}
             "#)).unwrap();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,14 +337,6 @@ trait TextureExt {
 
 /// Internal trait for textures.
 trait TextureMipmapExt {
-    /// Reads the content of the mipmap to RAM.
-    // TODO: take 2D/3D/etc. into account
-    fn read<T>(&self) -> T where T: texture::Texture2dDataSink<(u8, u8, u8, u8)>;
-
-    /// Reads the content of the mipmap to a pixel buffer.
-    // TODO: take 2D/3D/etc. into account
-    fn read_to_pixel_buffer(&self) -> pixel_buffer::PixelBuffer<(u8, u8, u8, u8)>;
-
     /// Changes some parts of the texture.
     fn upload_texture<'a, P>(&self, x_offset: u32, y_offset: u32, z_offset: u32,
                              (image_format::ClientFormatAny, std::borrow::Cow<'a, [P]>), width: u32,


### PR DESCRIPTION
Follow-up of the reorganization between layers, mipmaps and images.