### PR TITLE
Support signed and unsigned int uniform vector types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  - Renamed `BufferView` to `Buffer`. `BufferView` still exists for backward compatibility.
  - Add support for the `GL_OES_element_index_uint` extension.
  - Fixed OpenGL ES 3.2 not working.
+ - Add support for `IntVec{2|3|4}` and `UnsignedIntVec{2|3|4}` uniform types.
 
 ## Version 0.8.5 (2015-08-12)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,6 +390,12 @@ enum RawUniformValue {
     Vec2([gl::types::GLfloat; 2]),
     Vec3([gl::types::GLfloat; 3]),
     Vec4([gl::types::GLfloat; 4]),
+    IntVec2([gl::types::GLint; 2]),
+    IntVec3([gl::types::GLint; 3]),
+    IntVec4([gl::types::GLint; 4]),
+    UnsignedIntVec2([gl::types::GLuint; 2]),
+    UnsignedIntVec3([gl::types::GLuint; 3]),
+    UnsignedIntVec4([gl::types::GLuint; 4]),
 }
 
 /// Area of a surface in pixels.

--- a/src/program/uniforms_storage.rs
+++ b/src/program/uniforms_storage.rs
@@ -67,6 +67,12 @@ impl UniformsStorage {
             (&RawUniformValue::Vec2(a), &mut Some(RawUniformValue::Vec2(b))) if a == b => (),
             (&RawUniformValue::Vec3(a), &mut Some(RawUniformValue::Vec3(b))) if a == b => (),
             (&RawUniformValue::Vec4(a), &mut Some(RawUniformValue::Vec4(b))) if a == b => (),
+            (&RawUniformValue::IntVec2(a), &mut Some(RawUniformValue::IntVec2(b))) if a == b => (),
+            (&RawUniformValue::IntVec3(a), &mut Some(RawUniformValue::IntVec3(b))) if a == b => (),
+            (&RawUniformValue::IntVec4(a), &mut Some(RawUniformValue::IntVec4(b))) if a == b => (),
+            (&RawUniformValue::UnsignedIntVec2(a), &mut Some(RawUniformValue::UnsignedIntVec2(b))) if a == b => (),
+            (&RawUniformValue::UnsignedIntVec3(a), &mut Some(RawUniformValue::UnsignedIntVec3(b))) if a == b => (),
+            (&RawUniformValue::UnsignedIntVec4(a), &mut Some(RawUniformValue::UnsignedIntVec4(b))) if a == b => (),
 
             (&RawUniformValue::SignedInt(v), target) => {
                 *target = Some(RawUniformValue::SignedInt(v));
@@ -126,6 +132,70 @@ impl UniformsStorage {
                 *target = Some(RawUniformValue::Vec4(v));
                 uniform!(ctxt, Uniform4fv, Uniform4fvARB, location, 1, v.as_ptr() as *const f32);
             },
+
+            (&RawUniformValue::IntVec2(v), target) => {
+                *target = Some(RawUniformValue::IntVec2(v));
+                uniform!(ctxt, Uniform2iv, Uniform2ivARB, location, 1, v.as_ptr() as *const gl::types::GLint);
+            },
+
+            (&RawUniformValue::IntVec3(v), target) => {
+                *target = Some(RawUniformValue::IntVec3(v));
+                uniform!(ctxt, Uniform3iv, Uniform3ivARB, location, 1, v.as_ptr() as *const gl::types::GLint);
+            },
+
+            (&RawUniformValue::IntVec4(v), target) => {
+                *target = Some(RawUniformValue::IntVec4(v));
+                uniform!(ctxt, Uniform4iv, Uniform4ivARB, location, 1, v.as_ptr() as *const gl::types::GLint);
+            },
+
+            (&RawUniformValue::UnsignedIntVec2(v), target) => {
+                *target = Some(RawUniformValue::UnsignedIntVec2(v));
+
+                // Uniform2uivARB doesn't exist
+                unsafe {
+                    if ctxt.version >= &Version(Api::Gl, 1, 5) ||
+                       ctxt.version >= &Version(Api::GlEs, 2, 0)
+                    {
+                        ctxt.gl.Uniform2uiv(location, 1, v.as_ptr() as *const gl::types::GLuint)
+                    } else {
+                        assert!(ctxt.extensions.gl_arb_shader_objects);
+                        ctxt.gl.Uniform2ivARB(location, 1, v.as_ptr() as *const gl::types::GLint)
+                    }
+                }
+            },
+
+            (&RawUniformValue::UnsignedIntVec3(v), target) => {
+                *target = Some(RawUniformValue::UnsignedIntVec3(v));
+
+                // Uniform3uivARB doesn't exist
+                unsafe {
+                    if ctxt.version >= &Version(Api::Gl, 1, 5) ||
+                       ctxt.version >= &Version(Api::GlEs, 2, 0)
+                    {
+                        ctxt.gl.Uniform3uiv(location, 1, v.as_ptr() as *const gl::types::GLuint)
+                    } else {
+                        assert!(ctxt.extensions.gl_arb_shader_objects);
+                        ctxt.gl.Uniform3ivARB(location, 1, v.as_ptr() as *const gl::types::GLint)
+                    }
+                }
+            },
+
+            (&RawUniformValue::UnsignedIntVec4(v), target) => {
+                *target = Some(RawUniformValue::UnsignedIntVec4(v));
+
+                // Uniform4uivARB doesn't exist
+                unsafe {
+                    if ctxt.version >= &Version(Api::Gl, 1, 5) ||
+                       ctxt.version >= &Version(Api::GlEs, 2, 0)
+                    {
+                        ctxt.gl.Uniform4uiv(location, 1, v.as_ptr() as *const gl::types::GLuint)
+                    } else {
+                        assert!(ctxt.extensions.gl_arb_shader_objects);
+                        ctxt.gl.Uniform4ivARB(location, 1, v.as_ptr() as *const gl::types::GLint)
+                    }
+                }
+            },
+
         }
     }
 

--- a/src/uniforms/bind.rs
+++ b/src/uniforms/bind.rs
@@ -223,6 +223,30 @@ fn bind_uniform<P>(ctxt: &mut context::CommandContext,
             program.set_uniform(ctxt, location, &RawUniformValue::Vec4(val));
             Ok(())
         },
+        UniformValue::IntVec2(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::IntVec2(val));
+            Ok(())
+        },
+        UniformValue::IntVec3(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::IntVec3(val));
+            Ok(())
+        },
+        UniformValue::IntVec4(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::IntVec4(val));
+            Ok(())
+        },
+        UniformValue::UnsignedIntVec2(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedIntVec2(val));
+            Ok(())
+        },
+        UniformValue::UnsignedIntVec3(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedIntVec3(val));
+            Ok(())
+        },
+        UniformValue::UnsignedIntVec4(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedIntVec4(val));
+            Ok(())
+        },
         UniformValue::Texture1d(texture, sampler) => {
             bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
         },

--- a/src/uniforms/value.rs
+++ b/src/uniforms/value.rs
@@ -150,6 +150,12 @@ pub enum UniformValue<'a> {
     Vec2([f32; 2]),
     Vec3([f32; 3]),
     Vec4([f32; 4]),
+    IntVec2([i32; 2]),
+    IntVec3([i32; 3]),
+    IntVec4([i32; 4]),
+    UnsignedIntVec2([u32; 2]),
+    UnsignedIntVec3([u32; 3]),
+    UnsignedIntVec4([u32; 4]),
     Texture1d(&'a texture::Texture1d, Option<SamplerBehavior>),
     CompressedTexture1d(&'a texture::CompressedTexture1d, Option<SamplerBehavior>),
     SrgbTexture1d(&'a texture::SrgbTexture1d, Option<SamplerBehavior>),
@@ -232,6 +238,12 @@ impl<'a> UniformValue<'a> {
             (&UniformValue::Vec2(_), UniformType::FloatVec2) => true,
             (&UniformValue::Vec3(_), UniformType::FloatVec3) => true,
             (&UniformValue::Vec4(_), UniformType::FloatVec4) => true,
+            (&UniformValue::IntVec2(_), UniformType::IntVec2) => true,
+            (&UniformValue::IntVec3(_), UniformType::IntVec3) => true,
+            (&UniformValue::IntVec4(_), UniformType::IntVec4) => true,
+            (&UniformValue::UnsignedIntVec2(_), UniformType::UnsignedIntVec2) => true,
+            (&UniformValue::UnsignedIntVec3(_), UniformType::UnsignedIntVec3) => true,
+            (&UniformValue::UnsignedIntVec4(_), UniformType::UnsignedIntVec4) => true,
             (&UniformValue::Texture1d(_, _), UniformType::Sampler1d) => true,
             (&UniformValue::CompressedTexture1d(_, _), UniformType::Sampler1d) => true,
             (&UniformValue::SrgbTexture1d(_, _), UniformType::Sampler1d) => true,
@@ -376,11 +388,59 @@ impl AsUniformValue for i32 {
 }
 
 impl_uniform_block_basic!(i32, UniformType::Int);
+
+impl AsUniformValue for [i32; 2] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::IntVec2(*self)
+    }
+}
+
 impl_uniform_block_basic!([i32; 2], UniformType::IntVec2);
+
+impl AsUniformValue for (i32, i32) {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::IntVec2([self.0, self.1])
+    }
+}
+
 impl_uniform_block_basic!((i32, i32), UniformType::IntVec2);
+
+impl AsUniformValue for [i32; 3] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::IntVec3(*self)
+    }
+}
+
 impl_uniform_block_basic!([i32; 3], UniformType::IntVec3);
+
+impl AsUniformValue for (i32, i32, i32) {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::IntVec3([self.0, self.1, self.2])
+    }
+}
+
 impl_uniform_block_basic!((i32, i32, i32), UniformType::IntVec3);
+
+impl AsUniformValue for [i32; 4] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::IntVec4(*self)
+    }
+}
+
 impl_uniform_block_basic!([i32; 4], UniformType::IntVec4);
+
+impl AsUniformValue for (i32, i32, i32, i32) {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::IntVec4([self.0, self.1, self.2, self.3])
+    }
+}
+
 impl_uniform_block_basic!((i32, i32, i32, i32), UniformType::IntVec4);
 
 impl AsUniformValue for u32 {
@@ -391,11 +451,59 @@ impl AsUniformValue for u32 {
 }
 
 impl_uniform_block_basic!(u32, UniformType::UnsignedInt);
+
+impl AsUniformValue for [u32; 2] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::UnsignedIntVec2(*self)
+    }
+}
+
 impl_uniform_block_basic!([u32; 2], UniformType::UnsignedIntVec2);
+
+impl AsUniformValue for (u32, u32) {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::UnsignedIntVec2([self.0, self.1])
+    }
+}
+
 impl_uniform_block_basic!((u32, u32), UniformType::UnsignedIntVec2);
+
+impl AsUniformValue for [u32; 3] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::UnsignedIntVec3(*self)
+    }
+}
+
 impl_uniform_block_basic!([u32; 3], UniformType::UnsignedIntVec3);
+
+impl AsUniformValue for (u32, u32, u32) {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::UnsignedIntVec3([self.0, self.1, self.2])
+    }
+}
+
 impl_uniform_block_basic!((u32, u32, u32), UniformType::UnsignedIntVec3);
+
+impl AsUniformValue for [u32; 4] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::UnsignedIntVec4(*self)
+    }
+}
+
 impl_uniform_block_basic!([u32; 4], UniformType::UnsignedIntVec4);
+
+impl AsUniformValue for (u32, u32, u32, u32) {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::UnsignedIntVec4([self.0, self.1, self.2, self.3])
+    }
+}
+
 impl_uniform_block_basic!((u32, u32, u32, u32), UniformType::UnsignedIntVec4);
 
 impl AsUniformValue for f32 {


### PR DESCRIPTION
Note: The context versions for the `gl.Uniform{1|2|3|4}ui{v}` should probably be changed. [OpenGL](https://www.opengl.org/sdk/docs/man/html/glUniform.xhtml) and [GL ES](https://www.khronos.org/opengles/sdk/docs/man3/html/glUniform.xhtml) support these since 3.0 according to the docs. But I couldn't test it at the moment and used [these] (https://github.com/tomaka/glium/blob/master/src/program/uniforms_storage.rs#L79-L89) versions insteads.