### PR TITLE
Add a work-around for Radeon drivers crashing with 32+ texture units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - Add support for the `GL_OES_element_index_uint` extension.
  - Fixed OpenGL ES 3.2 not working.
  - Add support for `IntVec{2|3|4}` and `UnsignedIntVec{2|3|4}` uniform types.
+ - Add a work-around for Radeon drivers crashing with 32+ texture units.
 
 ## Version 0.8.5 (2015-08-12)
 

--- a/src/context/capabilities.rs
+++ b/src/context/capabilities.rs
@@ -101,7 +101,7 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
         let s = gl.GetString(gl::RENDERER);
         assert!(!s.is_null());
         String::from_utf8(CStr::from_ptr(s as *const i8).to_bytes().to_vec()).ok()
-                                    .expect("glGetString(GL_RENDERER) returned an non-UTF8 string")
+                                    .expect("glGetString(GL_RENDERER) returned a non-UTF8 string")
     };
 
     Capabilities {


### PR DESCRIPTION
Fix #1181 

cc @neivv
This should fix it I guess.