### PR TITLE
Fix compiler warnings on nightly.

### DIFF
--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -110,7 +110,7 @@ include!(concat!(env!("OUT_DIR"), "/textures.rs"));
 
 /// Represents a layer of a cubemap.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[allow(missing_docs)]      // TODO: 
+#[allow(missing_docs)]      // TODO:
 pub enum CubeLayer {
     PositiveX,
     NegativeX,
@@ -258,7 +258,7 @@ pub trait Texture1dDataSource<'a> {
 /// as this is the only format that is guaranteed to be supported by OpenGL when reading pixels.
 pub trait Texture1dDataSink<T> {
     /// Builds a new object from raw data.
-    fn from_raw(data: Cow<[T]>, width: u32) -> Self;
+    fn from_raw(data: Cow<[T]>, width: u32) -> Self where [T]: ToOwned;
 }
 
 /// Represents raw data for a two-dimensional image.
@@ -340,7 +340,7 @@ pub trait Texture2dDataSource<'a> {
 /// as this is the only format that is guaranteed to be supported by OpenGL when reading pixels.
 pub trait Texture2dDataSink<T> {
     /// Builds a new object from raw data.
-    fn from_raw(data: Cow<[T]>, width: u32, height: u32) -> Self;
+    fn from_raw(data: Cow<[T]>, width: u32, height: u32) -> Self where [T]: ToOwned;
 }
 
 /// Represents raw data for a two-dimensional image.
@@ -507,7 +507,7 @@ pub trait Texture3dDataSource<'a> {
 /// as this is the only format that is guaranteed to be supported by OpenGL when reading pixels.
 pub trait Texture3dDataSink<T> {
     /// Builds a new object from raw data.
-    fn from_raw(data: Cow<[T]>, width: u32, height: u32, depth: u32) -> Self;
+    fn from_raw(data: Cow<[T]>, width: u32, height: u32, depth: u32) -> Self where [T]: ToOwned;
 }
 
 /// Represents raw data for a two-dimensional image.

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -380,7 +380,7 @@ impl VertexBufferAny {
 
     /// Turns the vertex buffer into a `VertexBuffer` without checking the type.
     #[inline]
-    pub unsafe fn into_vertex_buffer<T>(self) -> VertexBuffer<T> {
+    pub unsafe fn into_vertex_buffer<T: Copy>(self) -> VertexBuffer<T> {
         unimplemented!();
     }
 


### PR DESCRIPTION
This commit fixes some of the compiler warnings, which have been
introduced with recent changes on the nightly channel.
I made sure this did not influence building on stable (thus we're still
using str::connect()).

Not really sure if this is a breaking change, so I decided to create a seperate PR for this.