### PR TITLE
Add support for double precision uniforms.

### DIFF
--- a/build/main.rs
+++ b/build/main.rs
@@ -46,6 +46,7 @@ fn generate_gl_bindings<W>(dest: &mut W) where W: Write {
                 "GL_ARB_ES3_2_compatibility".to_string(),
                 "GL_ARB_framebuffer_sRGB".to_string(),
                 "GL_ARB_geometry_shader4".to_string(),
+                "GL_ARB_gpu_shader_fp64".to_string(),
                 "GL_ARB_invalidate_subdata".to_string(),
                 "GL_ARB_multi_draw_indirect".to_string(),
                 "GL_ARB_occlusion_query".to_string(),

--- a/src/context/extensions.rs
+++ b/src/context/extensions.rs
@@ -74,6 +74,7 @@ extensions! {
     "GL_ARB_framebuffer_sRGB" => gl_arb_framebuffer_srgb,
     "GL_ARB_geometry_shader4" => gl_arb_geometry_shader4,
     "GL_ARB_get_program_binary" => gl_arb_get_programy_binary,
+    "GL_ARB_gpu_shader_fp64" => gl_arb_gpu_shader_fp64,
     "GL_ARB_instanced_arrays" => gl_arb_instanced_arrays,
     "GL_ARB_invalidate_subdata" => gl_arb_invalidate_subdata,
     "GL_ARB_occlusion_query" => gl_arb_occlusion_query,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,6 +396,15 @@ enum RawUniformValue {
     UnsignedIntVec2([gl::types::GLuint; 2]),
     UnsignedIntVec3([gl::types::GLuint; 3]),
     UnsignedIntVec4([gl::types::GLuint; 4]),
+    
+    // Double precision primitives
+    Double(gl::types::GLdouble),
+    DoubleMat2([[gl::types::GLdouble; 2]; 2]),
+    DoubleMat3([[gl::types::GLdouble; 3]; 3]),
+    DoubleMat4([[gl::types::GLdouble; 4]; 4]),
+    DoubleVec2([gl::types::GLdouble;2]),
+    DoubleVec3([gl::types::GLdouble; 3]),
+    DoubleVec4([gl::types::GLdouble; 4]),
 }
 
 /// Area of a surface in pixels.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,13 +396,13 @@ enum RawUniformValue {
     UnsignedIntVec2([gl::types::GLuint; 2]),
     UnsignedIntVec3([gl::types::GLuint; 3]),
     UnsignedIntVec4([gl::types::GLuint; 4]),
-    
+
     // Double precision primitives
     Double(gl::types::GLdouble),
     DoubleMat2([[gl::types::GLdouble; 2]; 2]),
     DoubleMat3([[gl::types::GLdouble; 3]; 3]),
     DoubleMat4([[gl::types::GLdouble; 4]; 4]),
-    DoubleVec2([gl::types::GLdouble;2]),
+    DoubleVec2([gl::types::GLdouble; 2]),
     DoubleVec3([gl::types::GLdouble; 3]),
     DoubleVec4([gl::types::GLdouble; 4]),
 }

--- a/src/program/uniforms_storage.rs
+++ b/src/program/uniforms_storage.rs
@@ -57,6 +57,19 @@ impl UniformsStorage {
             )
         );
 
+        macro_rules! uniform64(
+            ($ctxt:expr, $uniform:ident, $($params:expr),+) => (
+                unsafe {
+                    if $ctxt.extensions.gl_arb_gpu_shader_fp64
+                    {
+                        $ctxt.gl.$uniform($($params),+)
+                    } else {
+                        panic!("Double precision is not supported on this system.")
+                    }
+                }
+            )
+        );
+
         match (value, &mut values[location as usize]) {
             (&RawUniformValue::SignedInt(a), &mut Some(RawUniformValue::SignedInt(b))) if a == b => (),
             (&RawUniformValue::UnsignedInt(a), &mut Some(RawUniformValue::UnsignedInt(b))) if a == b => (),
@@ -73,6 +86,13 @@ impl UniformsStorage {
             (&RawUniformValue::UnsignedIntVec2(a), &mut Some(RawUniformValue::UnsignedIntVec2(b))) if a == b => (),
             (&RawUniformValue::UnsignedIntVec3(a), &mut Some(RawUniformValue::UnsignedIntVec3(b))) if a == b => (),
             (&RawUniformValue::UnsignedIntVec4(a), &mut Some(RawUniformValue::UnsignedIntVec4(b))) if a == b => (),
+            (&RawUniformValue::Double(a), &mut Some(RawUniformValue::Double(b))) if a == b => (),
+            (&RawUniformValue::DoubleMat2(a), &mut Some(RawUniformValue::DoubleMat2(b))) if a == b => (),
+            (&RawUniformValue::DoubleMat3(a), &mut Some(RawUniformValue::DoubleMat3(b))) if a == b => (),
+            (&RawUniformValue::DoubleMat4(a), &mut Some(RawUniformValue::DoubleMat4(b))) if a == b => (),
+            (&RawUniformValue::DoubleVec2(a), &mut Some(RawUniformValue::DoubleVec2(b))) if a == b => (),
+            (&RawUniformValue::DoubleVec3(a), &mut Some(RawUniformValue::DoubleVec3(b))) if a == b => (),
+            (&RawUniformValue::DoubleVec4(a), &mut Some(RawUniformValue::DoubleVec4(b))) if a == b => (),
 
             (&RawUniformValue::SignedInt(v), target) => {
                 *target = Some(RawUniformValue::SignedInt(v));
@@ -94,40 +114,40 @@ impl UniformsStorage {
                     }
                 }
             },
-            
+
             (&RawUniformValue::Float(v), target) => {
                 *target = Some(RawUniformValue::Float(v));
                 uniform!(ctxt, Uniform1f, Uniform1fARB, location, v);
             },
-            
+
             (&RawUniformValue::Mat2(v), target) => {
                 *target = Some(RawUniformValue::Mat2(v));
                 uniform!(ctxt, UniformMatrix2fv, UniformMatrix2fvARB,
                          location, 1, gl::FALSE, v.as_ptr() as *const f32);
             },
-            
+
             (&RawUniformValue::Mat3(v), target) => {
                 *target = Some(RawUniformValue::Mat3(v));
                 uniform!(ctxt, UniformMatrix3fv, UniformMatrix3fvARB,
                          location, 1, gl::FALSE, v.as_ptr() as *const f32);
             },
-            
+
             (&RawUniformValue::Mat4(v), target) => {
                 *target = Some(RawUniformValue::Mat4(v));
                 uniform!(ctxt, UniformMatrix4fv, UniformMatrix4fvARB,
                          location, 1, gl::FALSE, v.as_ptr() as *const f32);
             },
-            
+
             (&RawUniformValue::Vec2(v), target) => {
                 *target = Some(RawUniformValue::Vec2(v));
                 uniform!(ctxt, Uniform2fv, Uniform2fvARB, location, 1, v.as_ptr() as *const f32);
             },
-            
+
             (&RawUniformValue::Vec3(v), target) => {
                 *target = Some(RawUniformValue::Vec3(v));
                 uniform!(ctxt, Uniform3fv, Uniform3fvARB, location, 1, v.as_ptr() as *const f32);
             },
-            
+
             (&RawUniformValue::Vec4(v), target) => {
                 *target = Some(RawUniformValue::Vec4(v));
                 uniform!(ctxt, Uniform4fv, Uniform4fvARB, location, 1, v.as_ptr() as *const f32);
@@ -195,7 +215,43 @@ impl UniformsStorage {
                     }
                 }
             },
+            (&RawUniformValue::Double(v), target) => {
+                *target = Some(RawUniformValue::Double(v));
+                uniform64!(ctxt, Uniform1d, location, v);
+            },
 
+            (&RawUniformValue::DoubleMat2(v), target) => {
+                *target = Some(RawUniformValue::DoubleMat2(v));
+                uniform64!(ctxt, UniformMatrix2dv,
+                         location, 1, gl::FALSE, v.as_ptr() as *const gl::types::GLdouble);
+            },
+
+            (&RawUniformValue::DoubleMat3(v), target) => {
+                *target = Some(RawUniformValue::DoubleMat3(v));
+                uniform64!(ctxt, UniformMatrix3dv,
+                         location, 1, gl::FALSE, v.as_ptr() as *const gl::types::GLdouble);
+            },
+
+            (&RawUniformValue::DoubleMat4(v), target) => {
+                *target = Some(RawUniformValue::DoubleMat4(v));
+                uniform64!(ctxt, UniformMatrix4dv,
+                         location, 1, gl::FALSE, v.as_ptr() as *const gl::types::GLdouble);
+            },
+
+            (&RawUniformValue::DoubleVec2(v), target) => {
+                *target = Some(RawUniformValue::DoubleVec2(v));
+                uniform64!(ctxt, Uniform2dv, location, 1, v.as_ptr() as *const gl::types::GLdouble);
+            },
+
+            (&RawUniformValue::DoubleVec3(v), target) => {
+                *target = Some(RawUniformValue::DoubleVec3(v));
+                uniform64!(ctxt, Uniform3dv, location, 1, v.as_ptr() as *const gl::types::GLdouble);
+            },
+
+            (&RawUniformValue::DoubleVec4(v), target) => {
+                *target = Some(RawUniformValue::DoubleVec4(v));
+                uniform64!(ctxt, Uniform4dv, location, 1, v.as_ptr() as *const gl::types::GLdouble);
+            },
         }
     }
 

--- a/src/program/uniforms_storage.rs
+++ b/src/program/uniforms_storage.rs
@@ -60,8 +60,7 @@ impl UniformsStorage {
         macro_rules! uniform64(
             ($ctxt:expr, $uniform:ident, $($params:expr),+) => (
                 unsafe {
-                    if $ctxt.extensions.gl_arb_gpu_shader_fp64
-                    {
+                    if $ctxt.extensions.gl_arb_gpu_shader_fp64 {
                         $ctxt.gl.$uniform($($params),+)
                     } else {
                         panic!("Double precision is not supported on this system.")

--- a/src/uniforms/bind.rs
+++ b/src/uniforms/bind.rs
@@ -267,6 +267,34 @@ fn bind_uniform<P>(ctxt: &mut context::CommandContext,
             program.set_uniform(ctxt, location, &RawUniformValue::IntVec4(val_casted));
             Ok(())
         },
+        UniformValue::Double(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Double(val));
+            Ok(())
+        },
+        UniformValue::DoubleMat2(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::DoubleMat2(val));
+            Ok(())
+        },
+        UniformValue::DoubleMat3(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::DoubleMat3(val));
+            Ok(())
+        },
+        UniformValue::DoubleMat4(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::DoubleMat4(val));
+            Ok(())
+        },
+        UniformValue::DoubleVec2(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::DoubleVec2(val));
+            Ok(())
+        },
+        UniformValue::DoubleVec3(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::DoubleVec3(val));
+            Ok(())
+        },
+        UniformValue::DoubleVec4(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::DoubleVec4(val));
+            Ok(())
+        },
         UniformValue::Texture1d(texture, sampler) => {
             bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
         },

--- a/src/uniforms/value.rs
+++ b/src/uniforms/value.rs
@@ -160,6 +160,13 @@ pub enum UniformValue<'a> {
     BoolVec2([bool; 2]),
     BoolVec3([bool; 3]),
     BoolVec4([bool; 4]),
+    Double(f64),
+    DoubleVec2([f64; 2]),
+    DoubleVec3([f64; 3]),
+    DoubleVec4([f64; 4]),
+    DoubleMat2([[f64;2]; 2]),
+    DoubleMat3([[f64;3]; 3]),
+    DoubleMat4([[f64;4]; 4]),
     Texture1d(&'a texture::Texture1d, Option<SamplerBehavior>),
     CompressedTexture1d(&'a texture::CompressedTexture1d, Option<SamplerBehavior>),
     SrgbTexture1d(&'a texture::SrgbTexture1d, Option<SamplerBehavior>),
@@ -252,6 +259,13 @@ impl<'a> UniformValue<'a> {
             (&UniformValue::BoolVec2(_), UniformType::BoolVec2) => true,
             (&UniformValue::BoolVec3(_), UniformType::BoolVec3) => true,
             (&UniformValue::BoolVec4(_), UniformType::BoolVec4) => true,
+            (&UniformValue::Double(_), UniformType::Double) => true,
+            (&UniformValue::DoubleMat2(_), UniformType::DoubleMat2) => true,
+            (&UniformValue::DoubleMat3(_), UniformType::DoubleMat3) => true,
+            (&UniformValue::DoubleMat4(_), UniformType::DoubleMat4) => true,
+            (&UniformValue::DoubleVec2(_), UniformType::DoubleVec2) => true,
+            (&UniformValue::DoubleVec3(_), UniformType::DoubleVec3) => true,
+            (&UniformValue::DoubleVec4(_), UniformType::DoubleVec4) => true,
             (&UniformValue::Texture1d(_, _), UniformType::Sampler1d) => true,
             (&UniformValue::CompressedTexture1d(_, _), UniformType::Sampler1d) => true,
             (&UniformValue::SrgbTexture1d(_, _), UniformType::Sampler1d) => true,
@@ -986,3 +1000,95 @@ impl AsUniformValue for cgmath::Point3<f32> {
 
 #[cfg(feature = "cgmath")]
 impl_uniform_block_basic!(cgmath::Point3<f32>, UniformType::FloatVec3);
+
+//TODO bool, i32, u32 and f64 should also be implemented as cgmath and nalgebra variants (i.e. nalgebra::Vec3<f64>).
+// Start of double type variants
+impl AsUniformValue for f64 {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::Double(*self)
+    }
+}
+
+impl_uniform_block_basic!(f64, UniformType::Double);
+
+impl AsUniformValue for [f64; 2] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::DoubleVec2(*self)
+    }
+}
+
+impl_uniform_block_basic!([f64; 2], UniformType::DoubleVec2);
+
+impl AsUniformValue for (f64, f64) {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::DoubleVec2([self.0, self.1])
+    }
+}
+
+impl_uniform_block_basic!((f64, f64), UniformType::DoubleVec2);
+
+impl AsUniformValue for [f64; 3] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::DoubleVec3(*self)
+    }
+}
+
+impl_uniform_block_basic!([f64; 3], UniformType::DoubleVec3);
+
+impl AsUniformValue for (f64, f64, f64) {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::DoubleVec3([self.0, self.1, self.2])
+    }
+}
+
+impl_uniform_block_basic!((f64, f64, f64), UniformType::DoubleVec3);
+
+impl AsUniformValue for [f64; 4] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::DoubleVec4(*self)
+    }
+}
+
+impl_uniform_block_basic!([f64; 4], UniformType::DoubleVec4);
+
+impl AsUniformValue for (f64, f64, f64, f64) {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::DoubleVec4([self.0, self.1, self.2, self.3])
+    }
+}
+
+impl_uniform_block_basic!((f64, f64, f64, f64), UniformType::DoubleVec4);
+
+impl AsUniformValue for [[f64; 2]; 2] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::DoubleMat2(*self)
+    }
+}
+
+impl_uniform_block_basic!([[f64; 2]; 2], UniformType::DoubleMat2);
+
+impl AsUniformValue for [[f64; 3]; 3] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::DoubleMat3(*self)
+    }
+}
+
+impl_uniform_block_basic!([[f64; 3]; 3], UniformType::DoubleMat3);
+
+impl AsUniformValue for [[f64; 4]; 4] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::DoubleMat4(*self)
+    }
+}
+
+impl_uniform_block_basic!([[f64; 4]; 4], UniformType::DoubleMat4);


### PR DESCRIPTION
These were missing in glium until now. Require `GL_ARB_gpu_shader_fp64` .

I'm not really sure if I did the OpenGL extension handling right, so maybe someone should look over that. Only compile tested for now because the Mesa drivers for my card only support OpenGL 3.3.