### PR TITLE
Check that the context is really current after making it current

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -560,6 +560,7 @@ impl ContextExt for Context {
             let backend = self.backend.borrow();
             if !backend.is_current() {
                 unsafe { backend.make_current() };
+                debug_assert!(backend.is_current());
             }
         }
 


### PR DESCRIPTION
Some implementations are buggy and don't report errors when calling `MakeCurrent`.
Therefore we detect this and fail early.