### PR TITLE
Implement Display and Error for [Buffer]CreationError

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -62,6 +62,8 @@ pub use self::view::BufferAny as BufferViewAny;
 pub use self::view::BufferAnySlice as BufferViewAnySlice;
 
 use gl;
+use std::error::Error;
+use std::fmt;
 use std::mem;
 use std::slice;
 
@@ -177,6 +179,21 @@ pub enum BufferCreationError {
 
     /// This type of buffer is not supported.
     BufferTypeNotSupported,
+}
+
+impl fmt::Display for BufferCreationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        self.description().fmt(formatter)
+    }
+}
+
+impl Error for BufferCreationError {
+    fn description(&self) -> &str {
+        match self {
+            &BufferCreationError::OutOfMemory => "Not enough memory to create the buffer",
+            &BufferCreationError::BufferTypeNotSupported => "This type of buffer is not supported",
+        }
+    }
 }
 
 /// How the buffer is created.

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+use std::fmt;
 use std::ops::{Range, Deref, DerefMut};
 
 use buffer::{Buffer, BufferSlice, BufferAny, BufferType, BufferMode, BufferCreationError};
@@ -24,6 +26,33 @@ impl From<BufferCreationError> for CreationError {
     #[inline]
     fn from(err: BufferCreationError) -> CreationError {
         CreationError::BufferCreationError(err)
+    }
+}
+
+impl fmt::Display for CreationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            &CreationError::FormatNotSupported => "The vertex format is not supported by the \
+                                                   backend".fmt(formatter),
+            &CreationError::BufferCreationError(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl Error for CreationError {
+    fn description(&self) -> &str {
+        match self {
+            &CreationError::FormatNotSupported => "The vertex format is not supported by the \
+                                                   backend",
+            &CreationError::BufferCreationError(..) => "Error while creating the vertex buffer",
+        }
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        match self {
+            &CreationError::FormatNotSupported => None,
+            &CreationError::BufferCreationError(ref error) => Some(error),
+        }
     }
 }
 


### PR DESCRIPTION
Hi,


I’m wondering if `CreationError` and `BufferCreationError` could implement `Error` for consistency with other error types. I should mention that, although there were no compilation errors, I wasn’t able to run the test suite on my machine. Thanks.


Regards,
Ivan