### PR TITLE
Implement separate blending functions for color and alpha

### DIFF
--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -43,7 +43,7 @@ fn main() {
         }
 
         implement_vertex!(Vertex, position, normal, texcoord);
-        
+
         glium::VertexBuffer::new(&display,
             &[
                 Vertex { position: [-1.0, 0.0, -1.0, 1.0], normal: [0.0, 1.0, 0.0, 1.0], texcoord: [1.0, 0.0] },
@@ -65,7 +65,7 @@ fn main() {
         }
 
         implement_vertex!(Vertex, position, texcoord);
-        
+
         glium::VertexBuffer::new(&display,
             &[
                 Vertex { position: [0.0, 0.0, 0.0, 1.0], texcoord: [0.0, 0.0] },
@@ -108,7 +108,7 @@ fn main() {
         // fragment shader
         "
             #version 140
-            
+
             uniform sampler2D tex;
 
             smooth in vec4 frag_position;
@@ -153,7 +153,7 @@ fn main() {
         // fragment shader
         "
             #version 140
-            
+
             uniform sampler2D position_texture;
             uniform sampler2D normal_texture;
             uniform vec4 light_position;
@@ -180,7 +180,7 @@ fn main() {
                     );
                     attenuation_factor *= (1.0 - pow((light_distance / light_radius), 2.0));
                     diffuse *= attenuation_factor;
-                    
+
                 }
                 frag_output = vec4(light_color * diffuse, 1.0);
             }
@@ -333,10 +333,17 @@ fn main() {
         // lighting
         let draw_params = glium::DrawParameters {
             //depth_function: glium::DepthFunction::IfLessOrEqual,
-            blending_function: Some(glium::BlendingFunction::Addition{
-                source: glium::LinearBlendingFactor::One,
-                destination: glium::LinearBlendingFactor::One
-            }),
+            blend: glium::Blend {
+                color: glium::BlendingFunction::Addition {
+                    source: glium::LinearBlendingFactor::One,
+                    destination: glium::LinearBlendingFactor::One
+                },
+                alpha: glium::BlendingFunction::Addition {
+                    source: glium::LinearBlendingFactor::One,
+                    destination: glium::LinearBlendingFactor::One
+                },
+                constant_value: (1.0, 1.0, 1.0, 1.0)
+            },
             .. Default::default()
         };
         light_buffer.clear_color(0.0, 0.0, 0.0, 0.0);

--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -157,6 +157,10 @@ pub struct GlState {
     pub blend_func: (gl::types::GLenum, gl::types::GLenum,
         gl::types::GLenum, gl::types::GLenum),
 
+    /// The latest value passed to `glBlendColor`.
+    pub blend_color: (gl::types::GLclampf, gl::types::GLclampf,
+                      gl::types::GLclampf, gl::types::GLclampf),
+
     /// The latest value passed to `glDepthFunc`.
     pub depth_func: gl::types::GLenum,
 
@@ -412,6 +416,7 @@ impl Default for GlState {
             stencil_op_back: (gl::KEEP, gl::KEEP, gl::KEEP),
             blend_equation: (gl::FUNC_ADD, gl::FUNC_ADD),
             blend_func: (gl::ONE, gl::ZERO, gl::ONE, gl::ZERO),
+            blend_color: (0.0, 0.0, 0.0, 0.0),
             viewport: None,
             scissor: None,
             line_width: 1.0,

--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -151,10 +151,11 @@ pub struct GlState {
     pub renderbuffer: gl::types::GLuint,
 
     /// The latest values passed to `glBlendEquation`.
-    pub blend_equation: gl::types::GLenum,
+    pub blend_equation: (gl::types::GLenum, gl::types::GLenum),
 
     /// The latest values passed to `glBlendFunc`.
-    pub blend_func: (gl::types::GLenum, gl::types::GLenum),
+    pub blend_func: (gl::types::GLenum, gl::types::GLenum,
+        gl::types::GLenum, gl::types::GLenum),
 
     /// The latest value passed to `glDepthFunc`.
     pub depth_func: gl::types::GLenum,
@@ -409,8 +410,8 @@ impl Default for GlState {
             stencil_mask_back: 0xffffffff,
             stencil_op_front: (gl::KEEP, gl::KEEP, gl::KEEP),
             stencil_op_back: (gl::KEEP, gl::KEEP, gl::KEEP),
-            blend_equation: gl::FUNC_ADD,
-            blend_func: (gl::ONE, gl::ZERO),
+            blend_equation: (gl::FUNC_ADD, gl::FUNC_ADD),
+            blend_func: (gl::ONE, gl::ZERO, gl::ONE, gl::ZERO),
             viewport: None,
             scissor: None,
             line_width: 1.0,

--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -155,7 +155,7 @@ pub struct GlState {
 
     /// The latest values passed to `glBlendFunc`.
     pub blend_func: (gl::types::GLenum, gl::types::GLenum,
-        gl::types::GLenum, gl::types::GLenum),
+                     gl::types::GLenum, gl::types::GLenum),
 
     /// The latest value passed to `glBlendColor`.
     pub blend_color: (gl::types::GLclampf, gl::types::GLclampf,

--- a/src/draw_parameters/mod.rs
+++ b/src/draw_parameters/mod.rs
@@ -106,8 +106,8 @@ impl Blend {
                 destination: LinearBlendingFactor::OneMinusSourceAlpha,
             },
             alpha: BlendingFunction::Addition {
-                source: LinearBlendingFactor::One,
-                destination: LinearBlendingFactor::One
+                source: LinearBlendingFactor::SourceAlpha,
+                destination: LinearBlendingFactor::OneMinusSourceAlpha
             },
             constant_value: (1.0, 1.0, 1.0, 1.0)
         }

--- a/src/draw_parameters/mod.rs
+++ b/src/draw_parameters/mod.rs
@@ -763,11 +763,9 @@ pub struct DrawParameters<'a> {
     /// The default value is `Keep`.
     pub stencil_depth_pass_operation_counter_clockwise: StencilOperation,
 
-    /// The function that the GPU will use to merge the existing pixel with the pixel that is
+    /// The effect that the GPU will use to merge the existing pixel with the pixel that is
     /// being written.
-    ///
-    /// `None` means "don't care" (usually when you know that the alpha is always 1).
-    pub blending_function: Option<BlendingFunction>,
+    pub blend: Blend,
 
     /// Allows you to disable some color components.
     ///
@@ -952,7 +950,11 @@ impl<'a> Default for DrawParameters<'a> {
             stencil_fail_operation_counter_clockwise: StencilOperation::Keep,
             stencil_pass_depth_fail_operation_counter_clockwise: StencilOperation::Keep,
             stencil_depth_pass_operation_counter_clockwise: StencilOperation::Keep,
-            blending_function: Some(BlendingFunction::AlwaysReplace),
+            blend: Blend {
+                color: BlendingFunction::AlwaysReplace,
+                alpha: BlendingFunction::AlwaysReplace,
+                constant_value: (1.0, 1.0, 1.0, 1.0)
+            },
             color_mask: (true, true, true, true),
             line_width: None,
             point_size: None,
@@ -1012,13 +1014,13 @@ impl<'a> DrawParametersBuilder<'a> {
         self
     }
 
-    /// Sets the function that the GPU will use to merge the existing pixel with the pixel that is
+    /// Sets the effect that the GPU will use to merge the existing pixel with the pixel that is
     /// being written.
     #[inline]
-    pub fn with_blending_function(mut self, blending: BlendingFunction)
+    pub fn with_blend(mut self, blend: Blend)
                                  -> DrawParametersBuilder<'a>
     {
-        self.params.blending_function = Some(blending);
+        self.params.blend = blend;
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ extern crate smallvec;
 
 #[cfg(feature = "glutin")]
 pub use backend::glutin_backend::glutin;
-pub use draw_parameters::{BlendingFunction, LinearBlendingFactor, BackfaceCullingMode};
+pub use draw_parameters::{Blend, BlendingFunction, LinearBlendingFactor, BackfaceCullingMode};
 pub use draw_parameters::{DepthTest, PolygonMode, DrawParameters, StencilTest, StencilOperation};
 pub use draw_parameters::{Smooth};
 pub use index::IndexBuffer;

--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -21,7 +21,8 @@ use vertex::{MultiVerticesSource, VerticesSource, TransformFeedbackSession};
 use vertex_array_object::VertexAttributesSystem;
 
 use draw_parameters::DrawParameters;
-use draw_parameters::{Blend, BackfaceCullingMode};
+use draw_parameters::{Blend, BlendingFunction, BackfaceCullingMode,
+    LinearBlendingFactor};
 use draw_parameters::{DepthTest, DepthClamp, PolygonMode, StencilTest};
 use draw_parameters::{SamplesQueryParam, TransformFeedbackPrimitivesWrittenQuery};
 use draw_parameters::{PrimitivesGeneratedQuery, TimeElapsedQuery, ConditionalRendering};
@@ -567,7 +568,71 @@ fn sync_stencil(ctxt: &mut context::CommandContext, params: &DrawParameters) {
 }
 
 fn sync_blending(ctxt: &mut context::CommandContext, blend: Blend) {
+    #[inline(always)]
+    fn blend_eq(blending_function: BlendingFunction) -> gl::types::GLenum {
+        match blending_function {
+            BlendingFunction::AlwaysReplace |
+            BlendingFunction::Addition { .. } => gl::FUNC_ADD,
+            BlendingFunction::Min => gl::MIN,
+            BlendingFunction::Max => gl::MAX,
+            BlendingFunction::Subtraction { .. } => gl::FUNC_SUBTRACT,
+            BlendingFunction::ReverseSubtraction { .. } =>
+                gl::FUNC_REVERSE_SUBTRACT,
+        }
+    }
 
+    #[inline(always)]
+    fn blending_factors(blending_function: BlendingFunction) ->
+        Option<(LinearBlendingFactor, LinearBlendingFactor)> {
+        match blending_function {
+            BlendingFunction::AlwaysReplace |
+            BlendingFunction::Min |
+            BlendingFunction::Max => None,
+            BlendingFunction::Addition { source, destination } =>
+                Some((source, destination)),
+            BlendingFunction::Subtraction { source, destination } =>
+                Some((source, destination)),
+            BlendingFunction::ReverseSubtraction { source, destination } =>
+                Some((source, destination)),
+        }
+    }
+
+    if let (BlendingFunction::AlwaysReplace, BlendingFunction::AlwaysReplace) =
+        (blend.color, blend.alpha) {
+        // Both color and alpha always replace. This equals no blending.
+        if ctxt.state.enabled_blend {
+            unsafe { ctxt.gl.Disable(gl::BLEND); }
+            ctxt.state.enabled_blend = false;
+        }
+    } else {
+        if !ctxt.state.enabled_blend {
+            unsafe { ctxt.gl.Enable(gl::BLEND); }
+            ctxt.state.enabled_blend = true;
+        }
+        let (color_eq, alpha_eq) = (blend_eq(blend.color), blend_eq(blend.alpha));
+        if ctxt.state.blend_equation != (color_eq, alpha_eq) {
+            unsafe { ctxt.gl.BlendEquationSeparate(color_eq, alpha_eq); }
+            ctxt.state.blend_equation = (color_eq, alpha_eq);
+        }
+        // Map to dummy factors if the blending equation does not use the factors.
+        let (color_factor_src, color_factor_dst) = blending_factors(blend.color)
+            .unwrap_or((LinearBlendingFactor::One, LinearBlendingFactor::Zero));
+        let (alpha_factor_src, alpha_factor_dst) = blending_factors(blend.alpha)
+            .unwrap_or((LinearBlendingFactor::One, LinearBlendingFactor::Zero));
+        let color_factor_src = color_factor_src.to_glenum();
+        let color_factor_dst = color_factor_dst.to_glenum();
+        let alpha_factor_src = alpha_factor_src.to_glenum();
+        let alpha_factor_dst = alpha_factor_dst.to_glenum();
+        if ctxt.state.blend_func != (color_factor_src, color_factor_dst,
+            alpha_factor_src, alpha_factor_dst) {
+            unsafe {
+                ctxt.gl.BlendFuncSeparate(color_factor_src, color_factor_dst,
+                    alpha_factor_src, alpha_factor_dst);
+            }
+            ctxt.state.blend_func = (color_factor_src, color_factor_dst,
+                alpha_factor_src, alpha_factor_dst);
+        }
+    }
 }
 
 fn sync_color_mask(ctxt: &mut context::CommandContext, mask: (bool, bool, bool, bool)) {

--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -632,6 +632,13 @@ fn sync_blending(ctxt: &mut context::CommandContext, blend: Blend) {
             ctxt.state.blend_func = (color_factor_src, color_factor_dst,
                 alpha_factor_src, alpha_factor_dst);
         }
+
+        // Update blend color.
+        if ctxt.state.blend_color != blend.constant_value {
+            let (r, g, b, a) = blend.constant_value;
+            unsafe { ctxt.gl.BlendColor(r, g, b, a); }
+            ctxt.state.blend_color = blend.constant_value;
+        }
     }
 }
 

--- a/tests/draw_parameters.rs
+++ b/tests/draw_parameters.rs
@@ -670,10 +670,7 @@ macro_rules! blending_test {
             let params = glium::DrawParameters {
                 blend: glium::Blend {
                     color: $func,
-                    alpha: glium::BlendingFunction::Addition {
-                        source: glium::LinearBlendingFactor::One,
-                        destination: glium::LinearBlendingFactor::Zero
-                    },
+                    alpha: $func,
                     constant_value: (1.0, 1.0, 1.0, 1.0)
                 },
                 .. Default::default()

--- a/tests/draw_parameters.rs
+++ b/tests/draw_parameters.rs
@@ -668,7 +668,14 @@ macro_rules! blending_test {
             let display = support::build_display();
 
             let params = glium::DrawParameters {
-                blending_function: Some($func),
+                blend: glium::Blend {
+                    color: $func,
+                    alpha: glium::BlendingFunction::Addition {
+                        source: glium::LinearBlendingFactor::One,
+                        destination: glium::LinearBlendingFactor::Zero
+                    },
+                    constant_value: (1.0, 1.0, 1.0, 1.0)
+                },
                 .. Default::default()
             };
 


### PR DESCRIPTION
Closes https://github.com/tomaka/glium/issues/161

This is a breaking change.

- `DrawParameters::blending_function` is now replaced by `DrawParameters::blend`
- To disable blending, use `AlwaysReplace` for both `Blend::color` and `Blend::alpha`
- `Blend::constant_color` is a blend color that can be used in the blending equation