### PR TITLE
Use `constant_value: (0.0, 0.0, 0.0, 0.0)` in `Blend::alpha_blending`

### DIFF
--- a/src/draw_parameters/mod.rs
+++ b/src/draw_parameters/mod.rs
@@ -109,7 +109,7 @@ impl Blend {
                 source: LinearBlendingFactor::SourceAlpha,
                 destination: LinearBlendingFactor::OneMinusSourceAlpha
             },
-            constant_value: (1.0, 1.0, 1.0, 1.0)
+            constant_value: (0.0, 0.0, 0.0, 0.0)
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/tomaka/glium/issues/1211