### PR TITLE
Fix the doctest in bindless textures's doc

### DIFF
--- a/src/texture/bindless.rs
+++ b/src/texture/bindless.rs
@@ -29,7 +29,7 @@ In a real application, you will likely manage a `Vec<ResidentTexture>`.
 You can then use a `TextureHandle` as if it was a pointer to a texture. A `TextureHandle` can be
 built from a `&ResidentTexture` and can't outlive it.
 
-```ignore       // TODO: doctest ICEs on Rust 1.1 (but not on nightly, so this can be `no_run` eventually)
+```no_run
 #[macro_use]
 extern crate glium;
 


### PR DESCRIPTION
Was disabled because of an ICE.
Trying now with Rust 1.2.