### PR TITLE
Implement i64 and u64 uniform types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ libc = "0.1"
 smallvec = "0.1.5"
 
 [build-dependencies]
-gl_generator = "0.0.27"
+gl_generator = "0.0.28"
 khronos_api = "0.0.8"
 
 [dev-dependencies]

--- a/build/main.rs
+++ b/build/main.rs
@@ -47,6 +47,7 @@ fn generate_gl_bindings<W>(dest: &mut W) where W: Write {
                 "GL_ARB_framebuffer_sRGB".to_string(),
                 "GL_ARB_geometry_shader4".to_string(),
                 "GL_ARB_gpu_shader_fp64".to_string(),
+                "GL_ARB_gpu_shader_int64".to_string(),
                 "GL_ARB_invalidate_subdata".to_string(),
                 "GL_ARB_multi_draw_indirect".to_string(),
                 "GL_ARB_occlusion_query".to_string(),

--- a/src/context/extensions.rs
+++ b/src/context/extensions.rs
@@ -76,6 +76,7 @@ extensions! {
     "GL_ARB_geometry_shader4" => gl_arb_geometry_shader4,
     "GL_ARB_get_program_binary" => gl_arb_get_programy_binary,
     "GL_ARB_gpu_shader_fp64" => gl_arb_gpu_shader_fp64,
+    "GL_ARB_gpu_shader_int64" => gl_arb_gpu_shader_int64,
     "GL_ARB_instanced_arrays" => gl_arb_instanced_arrays,
     "GL_ARB_invalidate_subdata" => gl_arb_invalidate_subdata,
     "GL_ARB_occlusion_query" => gl_arb_occlusion_query,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,6 +406,14 @@ enum RawUniformValue {
     DoubleVec2([gl::types::GLdouble; 2]),
     DoubleVec3([gl::types::GLdouble; 3]),
     DoubleVec4([gl::types::GLdouble; 4]),
+    Int64(gl::types::GLint64),
+    Int64Vec2([gl::types::GLint64; 2]),
+    Int64Vec3([gl::types::GLint64; 3]),
+    Int64Vec4([gl::types::GLint64; 4]),
+    UnsignedInt64(gl::types::GLuint64),
+    UnsignedInt64Vec2([gl::types::GLuint64; 2]),
+    UnsignedInt64Vec3([gl::types::GLuint64; 3]),
+    UnsignedInt64Vec4([gl::types::GLuint64; 4]),
 }
 
 /// Area of a surface in pixels.

--- a/src/program/uniforms_storage.rs
+++ b/src/program/uniforms_storage.rs
@@ -75,7 +75,7 @@ impl UniformsStorage {
                     if $ctxt.extensions.gl_arb_gpu_shader_int64 {
                         $ctxt.gl.$uniform($($params),+)
                     } else {
-                        panic!("Double precision integers are not supported on this system.")
+                        panic!("64 bit integers are not supported on this system.")
                     }
                 }
             )

--- a/src/program/uniforms_storage.rs
+++ b/src/program/uniforms_storage.rs
@@ -57,13 +57,25 @@ impl UniformsStorage {
             )
         );
 
-        macro_rules! uniform64(
+        macro_rules! uniform_f64(
             ($ctxt:expr, $uniform:ident, $($params:expr),+) => (
                 unsafe {
                     if $ctxt.extensions.gl_arb_gpu_shader_fp64 {
                         $ctxt.gl.$uniform($($params),+)
                     } else {
-                        panic!("Double precision is not supported on this system.")
+                        panic!("Double precision floats are not supported on this system.")
+                    }
+                }
+            )
+        );
+
+        macro_rules! uniform_i64(
+            ($ctxt:expr, $uniform:ident, $($params:expr),+) => (
+                unsafe {
+                    if $ctxt.extensions.gl_arb_gpu_shader_int64 {
+                        $ctxt.gl.$uniform($($params),+)
+                    } else {
+                        panic!("Double precision integers are not supported on this system.")
                     }
                 }
             )
@@ -92,6 +104,14 @@ impl UniformsStorage {
             (&RawUniformValue::DoubleVec2(a), &mut Some(RawUniformValue::DoubleVec2(b))) if a == b => (),
             (&RawUniformValue::DoubleVec3(a), &mut Some(RawUniformValue::DoubleVec3(b))) if a == b => (),
             (&RawUniformValue::DoubleVec4(a), &mut Some(RawUniformValue::DoubleVec4(b))) if a == b => (),
+            (&RawUniformValue::Int64(a), &mut Some(RawUniformValue::Int64(b))) if a == b => (),
+            (&RawUniformValue::Int64Vec2(a), &mut Some(RawUniformValue::Int64Vec2(b))) if a == b => (),
+            (&RawUniformValue::Int64Vec3(a), &mut Some(RawUniformValue::Int64Vec3(b))) if a == b => (),
+            (&RawUniformValue::Int64Vec4(a), &mut Some(RawUniformValue::Int64Vec4(b))) if a == b => (),
+            (&RawUniformValue::UnsignedInt64(a), &mut Some(RawUniformValue::UnsignedInt64(b))) if a == b => (),
+            (&RawUniformValue::UnsignedInt64Vec2(a), &mut Some(RawUniformValue::UnsignedInt64Vec2(b))) if a == b => (),
+            (&RawUniformValue::UnsignedInt64Vec3(a), &mut Some(RawUniformValue::UnsignedInt64Vec3(b))) if a == b => (),
+            (&RawUniformValue::UnsignedInt64Vec4(a), &mut Some(RawUniformValue::UnsignedInt64Vec4(b))) if a == b => (),
 
             (&RawUniformValue::SignedInt(v), target) => {
                 *target = Some(RawUniformValue::SignedInt(v));
@@ -216,40 +236,76 @@ impl UniformsStorage {
             },
             (&RawUniformValue::Double(v), target) => {
                 *target = Some(RawUniformValue::Double(v));
-                uniform64!(ctxt, Uniform1d, location, v);
+                uniform_f64!(ctxt, Uniform1d, location, v);
             },
 
             (&RawUniformValue::DoubleMat2(v), target) => {
                 *target = Some(RawUniformValue::DoubleMat2(v));
-                uniform64!(ctxt, UniformMatrix2dv,
+                uniform_f64!(ctxt, UniformMatrix2dv,
                          location, 1, gl::FALSE, v.as_ptr() as *const gl::types::GLdouble);
             },
 
             (&RawUniformValue::DoubleMat3(v), target) => {
                 *target = Some(RawUniformValue::DoubleMat3(v));
-                uniform64!(ctxt, UniformMatrix3dv,
+                uniform_f64!(ctxt, UniformMatrix3dv,
                          location, 1, gl::FALSE, v.as_ptr() as *const gl::types::GLdouble);
             },
 
             (&RawUniformValue::DoubleMat4(v), target) => {
                 *target = Some(RawUniformValue::DoubleMat4(v));
-                uniform64!(ctxt, UniformMatrix4dv,
+                uniform_f64!(ctxt, UniformMatrix4dv,
                          location, 1, gl::FALSE, v.as_ptr() as *const gl::types::GLdouble);
             },
 
             (&RawUniformValue::DoubleVec2(v), target) => {
                 *target = Some(RawUniformValue::DoubleVec2(v));
-                uniform64!(ctxt, Uniform2dv, location, 1, v.as_ptr() as *const gl::types::GLdouble);
+                uniform_f64!(ctxt, Uniform2dv, location, 1, v.as_ptr() as *const gl::types::GLdouble);
             },
 
             (&RawUniformValue::DoubleVec3(v), target) => {
                 *target = Some(RawUniformValue::DoubleVec3(v));
-                uniform64!(ctxt, Uniform3dv, location, 1, v.as_ptr() as *const gl::types::GLdouble);
+                uniform_f64!(ctxt, Uniform3dv, location, 1, v.as_ptr() as *const gl::types::GLdouble);
             },
 
             (&RawUniformValue::DoubleVec4(v), target) => {
                 *target = Some(RawUniformValue::DoubleVec4(v));
-                uniform64!(ctxt, Uniform4dv, location, 1, v.as_ptr() as *const gl::types::GLdouble);
+                uniform_f64!(ctxt, Uniform4dv, location, 1, v.as_ptr() as *const gl::types::GLdouble);
+            },
+            (&RawUniformValue::Int64(v), target) => {
+                *target = Some(RawUniformValue::Int64(v));
+                uniform_i64!(ctxt, Uniform1i64ARB, location, v);
+            },
+            (&RawUniformValue::Int64Vec2(v), target) => {
+                *target = Some(RawUniformValue::Int64Vec2(v));
+                uniform_i64!(ctxt, Uniform2i64vARB, location, 1, v.as_ptr() as *const gl::types::GLint64);
+            },
+
+            (&RawUniformValue::Int64Vec3(v), target) => {
+                *target = Some(RawUniformValue::Int64Vec3(v));
+                uniform_i64!(ctxt, Uniform3i64vARB, location, 1, v.as_ptr() as *const gl::types::GLint64);
+            },
+
+            (&RawUniformValue::Int64Vec4(v), target) => {
+                *target = Some(RawUniformValue::Int64Vec4(v));
+                uniform_i64!(ctxt, Uniform4i64vARB, location, 1, v.as_ptr() as *const gl::types::GLint64);
+            },
+            (&RawUniformValue::UnsignedInt64(v), target) => {
+                *target = Some(RawUniformValue::UnsignedInt64(v));
+                uniform_i64!(ctxt, Uniform1ui64ARB, location, v);
+            },
+            (&RawUniformValue::UnsignedInt64Vec2(v), target) => {
+                *target = Some(RawUniformValue::UnsignedInt64Vec2(v));
+                uniform_i64!(ctxt, Uniform2ui64vARB, location, 1, v.as_ptr() as *const gl::types::GLuint64);
+            },
+
+            (&RawUniformValue::UnsignedInt64Vec3(v), target) => {
+                *target = Some(RawUniformValue::UnsignedInt64Vec3(v));
+                uniform_i64!(ctxt, Uniform3ui64vARB, location, 1, v.as_ptr() as *const gl::types::GLuint64);
+            },
+
+            (&RawUniformValue::UnsignedInt64Vec4(v), target) => {
+                *target = Some(RawUniformValue::UnsignedInt64Vec4(v));
+                uniform_i64!(ctxt, Uniform4ui64vARB, location, 1, v.as_ptr() as *const gl::types::GLuint64);
             },
         }
     }

--- a/src/uniforms/bind.rs
+++ b/src/uniforms/bind.rs
@@ -295,6 +295,38 @@ fn bind_uniform<P>(ctxt: &mut context::CommandContext,
             program.set_uniform(ctxt, location, &RawUniformValue::DoubleVec4(val));
             Ok(())
         },
+        UniformValue::Int64(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Int64(val));
+            Ok(())
+        },
+        UniformValue::Int64Vec2(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Int64Vec2(val));
+            Ok(())
+        },
+        UniformValue::Int64Vec3(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Int64Vec3(val));
+            Ok(())
+        },
+        UniformValue::Int64Vec4(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Int64Vec4(val));
+            Ok(())
+        },
+        UniformValue::UnsignedInt64(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedInt64(val));
+            Ok(())
+        },
+        UniformValue::UnsignedInt64Vec2(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedInt64Vec2(val));
+            Ok(())
+        },
+        UniformValue::UnsignedInt64Vec3(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedInt64Vec3(val));
+            Ok(())
+        },
+        UniformValue::UnsignedInt64Vec4(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedInt64Vec4(val));
+            Ok(())
+        },
         UniformValue::Texture1d(texture, sampler) => {
             bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
         },

--- a/src/uniforms/value.rs
+++ b/src/uniforms/value.rs
@@ -34,6 +34,14 @@ pub enum UniformType {
     UnsignedIntVec2,
     UnsignedIntVec3,
     UnsignedIntVec4,
+    Int64,
+    Int64Vec2,
+    Int64Vec3,
+    Int64Vec4,
+    UnsignedInt64,
+    UnsignedInt64Vec2,
+    UnsignedInt64Vec3,
+    UnsignedInt64Vec4,
     Bool,
     BoolVec2,
     BoolVec3,
@@ -167,6 +175,14 @@ pub enum UniformValue<'a> {
     DoubleMat2([[f64;2]; 2]),
     DoubleMat3([[f64;3]; 3]),
     DoubleMat4([[f64;4]; 4]),
+    Int64(i64),
+    Int64Vec2([i64; 2]),
+    Int64Vec3([i64; 3]),
+    Int64Vec4([i64; 4]),
+    UnsignedInt64(u64),
+    UnsignedInt64Vec2([u64; 2]),
+    UnsignedInt64Vec3([u64; 3]),
+    UnsignedInt64Vec4([u64; 4]),
     Texture1d(&'a texture::Texture1d, Option<SamplerBehavior>),
     CompressedTexture1d(&'a texture::CompressedTexture1d, Option<SamplerBehavior>),
     SrgbTexture1d(&'a texture::SrgbTexture1d, Option<SamplerBehavior>),
@@ -1092,3 +1108,129 @@ impl AsUniformValue for [[f64; 4]; 4] {
 }
 
 impl_uniform_block_basic!([[f64; 4]; 4], UniformType::DoubleMat4);
+
+impl AsUniformValue for i64 {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::Int64(*self as i64)
+    }
+}
+
+impl_uniform_block_basic!(i64, UniformType::Int);
+
+impl AsUniformValue for [i64; 2] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::Int64Vec2(*self)
+    }
+}
+
+impl_uniform_block_basic!([i64; 2], UniformType::Int64Vec2);
+
+impl AsUniformValue for (i64, i64) {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::Int64Vec2([self.0, self.1])
+    }
+}
+
+impl_uniform_block_basic!((i64, i64), UniformType::Int64Vec2);
+
+impl AsUniformValue for [i64; 3] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::Int64Vec3(*self)
+    }
+}
+
+impl_uniform_block_basic!([i64; 3], UniformType::Int64Vec3);
+
+impl AsUniformValue for (i64, i64, i64) {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::Int64Vec3([self.0, self.1, self.2])
+    }
+}
+
+impl_uniform_block_basic!((i64, i64, i64), UniformType::Int64Vec3);
+
+impl AsUniformValue for [i64; 4] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::Int64Vec4(*self)
+    }
+}
+
+impl_uniform_block_basic!([i64; 4], UniformType::Int64Vec4);
+
+impl AsUniformValue for (i64, i64, i64, i64) {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::Int64Vec4([self.0, self.1, self.2, self.3])
+    }
+}
+
+impl_uniform_block_basic!((i64, i64, i64, i64), UniformType::Int64Vec4);
+
+impl AsUniformValue for u64 {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::UnsignedInt64(*self as u64)
+    }
+}
+
+impl_uniform_block_basic!(u64, UniformType::UnsignedInt64);
+
+impl AsUniformValue for [u64; 2] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::UnsignedInt64Vec2(*self)
+    }
+}
+
+impl_uniform_block_basic!([u64; 2], UniformType::UnsignedInt64Vec2);
+
+impl AsUniformValue for (u64, u64) {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::UnsignedInt64Vec2([self.0, self.1])
+    }
+}
+
+impl_uniform_block_basic!((u64, u64), UniformType::UnsignedInt64Vec2);
+
+impl AsUniformValue for [u64; 3] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::UnsignedInt64Vec3(*self)
+    }
+}
+
+impl_uniform_block_basic!([u64; 3], UniformType::UnsignedInt64Vec3);
+
+impl AsUniformValue for (u64, u64, u64) {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::UnsignedInt64Vec3([self.0, self.1, self.2])
+    }
+}
+
+impl_uniform_block_basic!((u64, u64, u64), UniformType::UnsignedInt64Vec3);
+
+impl AsUniformValue for [u64; 4] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::UnsignedInt64Vec4(*self)
+    }
+}
+
+impl_uniform_block_basic!([u64; 4], UniformType::UnsignedInt64Vec4);
+
+impl AsUniformValue for (u64, u64, u64, u64) {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::UnsignedInt64Vec4([self.0, self.1, self.2, self.3])
+    }
+}
+
+impl_uniform_block_basic!((u64, u64, u64, u64), UniformType::UnsignedInt64Vec4);

--- a/tests/uniforms.rs
+++ b/tests/uniforms.rs
@@ -332,6 +332,24 @@ uniform_test!(uniform_type_u32tup_uintvec3, "uvec3", (1u32, 24, 7));
 uniform_test!(uniform_type_u32arr_uintvec4, "uvec4", [1u32, 24, 7, 123456]);
 uniform_test!(uniform_type_u32tup_uintvec4, "uvec4", (1u32, 24, 7, 123456));
 
+// Integer 64 bit
+uniform_test!(uniform_type_i64_int64_t, "int64_t", 9_223_372_036_854_775_807i64);
+uniform_test!(uniform_type_i64arr_i64vec2, "i64vec2", [1i64, 24]);
+uniform_test!(uniform_type_i64tup_i64vec2, "i64vec2", (1i64, 24));
+uniform_test!(uniform_type_i64arr_i64vec3, "i64vec3", [1i64, 24, -7]);
+uniform_test!(uniform_type_i64tup_i64vec3, "i64vec3", (1i64, 24, -7));
+uniform_test!(uniform_type_i64arr_i64vec4, "i64vec4", [1i64, 24, -7, -123456]);
+uniform_test!(uniform_type_i64tup_i64vec4, "i64vec4", (1i64, 24, -7, -123456));
+
+// Unsigned integer 64 bit
+uniform_test!(uniform_type_u64_uint64_t, "uint64_t", 9_223_372_036_854_775_807u64);
+uniform_test!(uniform_type_u64arr_u64vec2, "u64vec2", [1u64, 24]);
+uniform_test!(uniform_type_u64tup_u64vec2, "u64vec2", (1u64, 24));
+uniform_test!(uniform_type_u64arr_u64vec3, "u64vec3", [1u64, 24, 7]);
+uniform_test!(uniform_type_u64tup_u64vec3, "u64vec3", (1u64, 24, 7));
+uniform_test!(uniform_type_u64arr_u64vec4, "u64vec4", [1u64, 24, 7, 123456]);
+uniform_test!(uniform_type_u64tup_u64vec4, "u64vec4", (1u64, 24, 7, 123456));
+
 // Booleans
 uniform_test!(uniform_type_bool_bool, "bool", true);
 uniform_test!(uniform_type_boolarr_boolvec2, "bvec2", [true, false]);


### PR DESCRIPTION
cc #1157 
I'm not really sure if additional work is required to support 64 Bit integer attributes.
Also you should probably run the tests locally once to make sure it really works, since my drivers do not support this feature yet and thus the tests return early.