### PR TITLE
Change Range to RangeArgument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
  - Fixed `glBufferData` being called to invalidate a buffer created with `glBufferStorage`.
- - Changed use of `Range` in buffer slice to `RangeArgument`.  You will need to import the trait `glium::buffer::RangeArgument` now.
+ - Changed use of `Range` in buffer slice to `RangeArgument`.
 
 ## Version 0.10.0 (2015-10-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
  - Fixed `glBufferData` being called to invalidate a buffer created with `glBufferStorage`.
+ - Changed use of `Range` in buffer slice to `RangeArgument`.  You will need to import the trait `glium::buffer::RangeArgument` now.
 
 ## Version 0.10.0 (2015-10-14)
 

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -67,9 +67,6 @@ use std::fmt;
 use std::mem;
 use std::slice;
 
-//For temp RangeArgument
-use std::ops::{Range, RangeTo, RangeFrom, RangeFull};
-
 mod alloc;
 mod fences;
 mod view;
@@ -318,45 +315,4 @@ impl BufferType {
             BufferType::ElementArrayBuffer => gl::ELEMENT_ARRAY_BUFFER,
         }
     }
-}
-
-/// Temporary re-implemenation of RangeArgument from stdlib while
-/// waiting for it to become stable
-pub trait RangeArgument<T> {
-	/// Get the (possible) requested first element of a range.
-	fn start(&self) -> Option<&T>;
-	/// Get the (possible) requested last element of a range.
-	fn end(&self) -> Option<&T>;
-}
-impl<T> RangeArgument<T> for RangeFull {
-	fn start(&self) -> Option<&T> {
-		None
-	}
-	fn end(&self) -> Option<&T> {
-		None
-	}
-}
-impl<T> RangeArgument<T> for RangeFrom<T> {
-	fn start(&self) -> Option<&T> {
-		Some(&self.start)
-	}
-	fn end(&self) -> Option<&T> {
-		None
-	}
-}
-impl<T> RangeArgument<T> for RangeTo<T> {
-	fn start(&self) -> Option<&T> {
-		None
-	}
-	fn end(&self) -> Option<&T> {
-		Some(&self.end)
-	}
-}
-impl<T> RangeArgument<T> for Range<T> {
-	fn start(&self) -> Option<&T> {
-		Some(&self.start)
-	}
-	fn end(&self) -> Option<&T> {
-		Some(&self.end)
-	}
 }

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -67,6 +67,9 @@ use std::fmt;
 use std::mem;
 use std::slice;
 
+//For temp RangeArgument
+use std::ops::{Range, RangeTo, RangeFrom, RangeFull};
+
 mod alloc;
 mod fences;
 mod view;
@@ -315,4 +318,45 @@ impl BufferType {
             BufferType::ElementArrayBuffer => gl::ELEMENT_ARRAY_BUFFER,
         }
     }
+}
+
+/// Temporary re-implemenation of RangeArgument from stdlib while
+/// waiting for it to become stable
+pub trait RangeArgument<T> {
+	/// Get the (possible) requested first element of a range.
+	fn start(&self) -> Option<&T>;
+	/// Get the (possible) requested last element of a range.
+	fn end(&self) -> Option<&T>;
+}
+impl<T> RangeArgument<T> for RangeFull {
+	fn start(&self) -> Option<&T> {
+		None
+	}
+	fn end(&self) -> Option<&T> {
+		None
+	}
+}
+impl<T> RangeArgument<T> for RangeFrom<T> {
+	fn start(&self) -> Option<&T> {
+		Some(&self.start)
+	}
+	fn end(&self) -> Option<&T> {
+		None
+	}
+}
+impl<T> RangeArgument<T> for RangeTo<T> {
+	fn start(&self) -> Option<&T> {
+		None
+	}
+	fn end(&self) -> Option<&T> {
+		Some(&self.end)
+	}
+}
+impl<T> RangeArgument<T> for Range<T> {
+	fn start(&self) -> Option<&T> {
+		Some(&self.start)
+	}
+	fn end(&self) -> Option<&T> {
+		Some(&self.end)
+	}
 }

--- a/src/buffer/view.rs
+++ b/src/buffer/view.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::mem;
 use std::borrow::Cow;
-use buffer::RangeArgument;
+use utils::range::RangeArgument;
 use std::marker::PhantomData;
 
 use texture::{PixelValue, Texture1dDataSink};
@@ -659,15 +659,14 @@ impl<'a, T> BufferSlice<'a, [T]> where [T]: Content + 'a {
     /// OpenGL is performed.
     #[inline]
     pub fn slice<R: RangeArgument<usize>>(&self, range: R) -> Option<BufferSlice<'a, [T]>> {
-		let clos = |val: &usize| { *val };
-        if range.start().map_or(0, &clos) > self.len() || range.end().map_or(0, &clos) > self.len() {
+        if range.start().map_or(0, |e| *e) > self.len() || range.end().map_or(0, |e| *e) > self.len() {
             return None;
         }
 
         Some(BufferSlice {
             alloc: self.alloc,
-            bytes_start: self.bytes_start + range.start().map_or(0, &clos) * mem::size_of::<T>(),
-            bytes_end: self.bytes_start + range.end().map_or(self.len(), &clos) * mem::size_of::<T>(),
+            bytes_start: self.bytes_start + range.start().map_or(0, |e| *e) * mem::size_of::<T>(),
+            bytes_end: self.bytes_start + range.end().map_or(self.len(), |e| *e) * mem::size_of::<T>(),
             fence: self.fence,
             marker: PhantomData,
         })
@@ -1022,16 +1021,15 @@ impl<'a, T> BufferMutSlice<'a, [T]> where [T]: Content, T: Copy + 'a {
     /// OpenGL is performed.
     #[inline]
     pub fn slice<R: RangeArgument<usize>>(self, range: R) -> Option<BufferMutSlice<'a, [T]>> {
-		let clos = |val: &usize| { *val };
-        if range.start().map_or(0, &clos) > self.len() || range.end().map_or(0, &clos) > self.len() {
+        if range.start().map_or(0, |e| *e) > self.len() || range.end().map_or(0, |e| *e) > self.len() {
             return None;
         }
 
 		let len = self.len();
         Some(BufferMutSlice {
             alloc: self.alloc,
-            bytes_start: self.bytes_start + range.start().map_or(0, &clos) * mem::size_of::<T>(),
-            bytes_end: self.bytes_start + range.end().map_or(len, &clos) * mem::size_of::<T>(),
+            bytes_start: self.bytes_start + range.start().map_or(0, |e| *e) * mem::size_of::<T>(),
+            bytes_end: self.bytes_start + range.end().map_or(len, |e| *e) * mem::size_of::<T>(),
             fence: self.fence,
             marker: PhantomData,
         })
@@ -1403,4 +1401,3 @@ impl<'a> BufferExt for BufferAnySlice<'a> {
         self.alloc.bind_to_transform_feedback(ctxt, index, 0 .. self.alloc.get_size());
     }
 }
-

--- a/src/buffer/view.rs
+++ b/src/buffer/view.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::mem;
 use std::borrow::Cow;
-use std::ops::Range;
+use buffer::RangeArgument;
 use std::marker::PhantomData;
 
 use texture::{PixelValue, Texture1dDataSink};
@@ -356,7 +356,7 @@ impl<T> Buffer<[T]> where [T]: Content, T: Copy {
     /// This method builds an object that represents a slice of the buffer. No actual operation
     /// OpenGL is performed.
     #[inline]
-    pub fn slice(&self, range: Range<usize>) -> Option<BufferSlice<[T]>> {
+    pub fn slice<R: RangeArgument<usize>>(&self, range: R) -> Option<BufferSlice<[T]>> {
         self.as_slice().slice(range)
     }
 
@@ -365,7 +365,7 @@ impl<T> Buffer<[T]> where [T]: Content, T: Copy {
     /// This method builds an object that represents a slice of the buffer. No actual operation
     /// OpenGL is performed.
     #[inline]
-    pub fn slice_mut(&mut self, range: Range<usize>) -> Option<BufferMutSlice<[T]>> {
+    pub fn slice_mut<R: RangeArgument<usize>>(&mut self, range: R) -> Option<BufferMutSlice<[T]>> {
         self.as_mut_slice().slice(range)
     }
 }
@@ -658,15 +658,16 @@ impl<'a, T> BufferSlice<'a, [T]> where [T]: Content + 'a {
     /// This method builds an object that represents a slice of the buffer. No actual operation
     /// OpenGL is performed.
     #[inline]
-    pub fn slice(&self, range: Range<usize>) -> Option<BufferSlice<'a, [T]>> {
-        if range.start > self.len() || range.end > self.len() {
+    pub fn slice<R: RangeArgument<usize>>(&self, range: R) -> Option<BufferSlice<'a, [T]>> {
+		let clos = |val: &usize| { *val };
+        if range.start().map_or(0, &clos) > self.len() || range.end().map_or(0, &clos) > self.len() {
             return None;
         }
 
         Some(BufferSlice {
             alloc: self.alloc,
-            bytes_start: self.bytes_start + range.start * mem::size_of::<T>(),
-            bytes_end: self.bytes_start + range.end * mem::size_of::<T>(),
+            bytes_start: self.bytes_start + range.start().map_or(0, &clos) * mem::size_of::<T>(),
+            bytes_end: self.bytes_start + range.end().map_or(self.len(), &clos) * mem::size_of::<T>(),
             fence: self.fence,
             marker: PhantomData,
         })
@@ -1020,15 +1021,17 @@ impl<'a, T> BufferMutSlice<'a, [T]> where [T]: Content, T: Copy + 'a {
     /// This method builds an object that represents a slice of the buffer. No actual operation
     /// OpenGL is performed.
     #[inline]
-    pub fn slice(self, range: Range<usize>) -> Option<BufferMutSlice<'a, [T]>> {
-        if range.start > self.len() || range.end > self.len() {
+    pub fn slice<R: RangeArgument<usize>>(self, range: R) -> Option<BufferMutSlice<'a, [T]>> {
+		let clos = |val: &usize| { *val };
+        if range.start().map_or(0, &clos) > self.len() || range.end().map_or(0, &clos) > self.len() {
             return None;
         }
 
+		let len = self.len();
         Some(BufferMutSlice {
             alloc: self.alloc,
-            bytes_start: self.bytes_start + range.start * mem::size_of::<T>(),
-            bytes_end: self.bytes_start + range.end * mem::size_of::<T>(),
+            bytes_start: self.bytes_start + range.start().map_or(0, &clos) * mem::size_of::<T>(),
+            bytes_end: self.bytes_start + range.end().map_or(len, &clos) * mem::size_of::<T>(),
             fence: self.fence,
             marker: PhantomData,
         })
@@ -1400,3 +1403,4 @@ impl<'a> BufferExt for BufferAnySlice<'a> {
         self.alloc.bind_to_transform_feedback(ctxt, index, 0 .. self.alloc.get_size());
     }
 }
+

--- a/src/index/buffer.rs
+++ b/src/index/buffer.rs
@@ -12,7 +12,7 @@ use index::IndexType;
 use index::PrimitiveType;
 
 use std::ops::{Deref, DerefMut};
-use ::buffer::RangeArgument;
+use utils::range::RangeArgument;
 
 /// Error that can happen while creating an index buffer.
 #[derive(Debug, Copy, Clone)]

--- a/src/index/buffer.rs
+++ b/src/index/buffer.rs
@@ -11,7 +11,8 @@ use index::Index;
 use index::IndexType;
 use index::PrimitiveType;
 
-use std::ops::{Deref, DerefMut, Range};
+use std::ops::{Deref, DerefMut};
+use ::buffer::RangeArgument;
 
 /// Error that can happen while creating an index buffer.
 #[derive(Debug, Copy, Clone)]
@@ -166,7 +167,7 @@ impl<T> IndexBuffer<T> where T: Index {
 
     /// Returns `None` if out of range.
     #[inline]
-    pub fn slice(&self, range: Range<usize>) -> Option<IndexBufferSlice<T>> {
+    pub fn slice<R: RangeArgument<usize>>(&self, range: R) -> Option<IndexBufferSlice<T>> {
         self.buffer.slice(range).map(|b| {
             IndexBufferSlice {
                 buffer: b,
@@ -251,7 +252,7 @@ impl<'a, T: 'a> IndexBufferSlice<'a, T> where T: Index {
 
     /// Returns `None` if out of range.
     #[inline]
-    pub fn slice(&self, range: Range<usize>) -> Option<IndexBufferSlice<'a, T>> {
+    pub fn slice<R: RangeArgument<usize>>(&self, range: R) -> Option<IndexBufferSlice<'a, T>> {
         self.buffer.slice(range).map(|b| {
             IndexBufferSlice {
                 buffer: b,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,1 +1,2 @@
 pub mod bitsfield;
+pub mod range;

--- a/src/utils/range.rs
+++ b/src/utils/range.rs
@@ -1,0 +1,42 @@
+use std::ops::{Range, RangeTo, RangeFrom, RangeFull};
+
+/// Temporary re-implemenation of RangeArgument from stdlib while
+/// waiting for it to become stable
+pub trait RangeArgument<T> {
+	/// Get the (possible) requested first element of a range.
+	fn start(&self) -> Option<&T>;
+	/// Get the (possible) requested last element of a range.
+	fn end(&self) -> Option<&T>;
+}
+impl<T> RangeArgument<T> for RangeFull {
+	fn start(&self) -> Option<&T> {
+		None
+	}
+	fn end(&self) -> Option<&T> {
+		None
+	}
+}
+impl<T> RangeArgument<T> for RangeFrom<T> {
+	fn start(&self) -> Option<&T> {
+		Some(&self.start)
+	}
+	fn end(&self) -> Option<&T> {
+		None
+	}
+}
+impl<T> RangeArgument<T> for RangeTo<T> {
+	fn start(&self) -> Option<&T> {
+		None
+	}
+	fn end(&self) -> Option<&T> {
+		Some(&self.end)
+	}
+}
+impl<T> RangeArgument<T> for Range<T> {
+	fn start(&self) -> Option<&T> {
+		Some(&self.start)
+	}
+	fn end(&self) -> Option<&T> {
+		Some(&self.end)
+	}
+}

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
-use buffer::RangeArgument;
+use utils::range::RangeArgument;
 
 use buffer::{Buffer, BufferSlice, BufferMutSlice, BufferAny, BufferType, BufferMode, BufferCreationError, Content};
 use vertex::{Vertex, VerticesSource, IntoVerticesSource, PerInstance};

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 use std::fmt;
-use std::ops::{Range, Deref, DerefMut};
+use std::ops::{Deref, DerefMut};
+use buffer::RangeArgument;
 
 use buffer::{Buffer, BufferSlice, BufferMutSlice, BufferAny, BufferType, BufferMode, BufferCreationError, Content};
 use vertex::{Vertex, VerticesSource, IntoVerticesSource, PerInstance};
@@ -287,7 +288,7 @@ impl<T> VertexBuffer<T> where T: Copy {
     ///
     /// Returns `None` if the slice is out of range.
     #[inline]
-    pub fn slice(&self, range: Range<usize>) -> Option<VertexBufferSlice<T>> {
+    pub fn slice<R: RangeArgument<usize>>(&self, range: R) -> Option<VertexBufferSlice<T>> {
         let slice = match self.buffer.slice(range) {
             None => return None,
             Some(s) => s


### PR DESCRIPTION
#1314

In order to avoid needing to use the unstable RangeArgument I just rewrote.  All we should need to do if/when it becomes stable is change to use glium::buffer::RangeArgument to collections::range::RangeArgument and *also* will probably be a breaking change because users will need to change that too.  Granted, we could just deprecate the glium one for a while for people to switch over, I guess.

This is also a breaking change now, because people will need to import RangeArgument to use buffer slice.