### PR TITLE
Fix missing write() on some texture types.

### DIFF
--- a/build/textures.rs
+++ b/build/textures.rs
@@ -823,7 +823,7 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
     // writing the `read` functions
     // TODO: implement for other types too
     if dimensions == TextureDimensions::Texture2d &&
-       (ty == TextureType::Regular || is_compressed)
+       (ty == TextureType::Regular || ty == TextureType::Srgb || is_compressed)
     {
         (write!(dest, r#"
                 /// Reads the content of the texture to RAM.
@@ -879,7 +879,7 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
     // writing the `write` function
     // TODO: implement for other types too
     if dimensions == TextureDimensions::Texture2d &&
-            (ty == TextureType::Regular || is_compressed)
+            (ty == TextureType::Regular || ty == TextureType::Srgb || is_compressed)
     {
         let compressed_restrictions = if is_compressed {
             r#" ///
@@ -1074,7 +1074,7 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
         // writing the `write` function for mipmaps.
         // TODO: implement for other types too
         if dimensions == TextureDimensions::Texture2d &&
-                (ty == TextureType::Regular || is_compressed)
+                (ty == TextureType::Regular || ty == TextureType::Srgb || is_compressed)
         {
             let compressed_restrictions = if is_compressed {
                 r#" ///

--- a/src/buffer/view.rs
+++ b/src/buffer/view.rs
@@ -1025,7 +1025,7 @@ impl<'a, T> BufferMutSlice<'a, [T]> where [T]: Content, T: Copy + 'a {
             return None;
         }
 
-		let len = self.len();
+        let len = self.len();
         Some(BufferMutSlice {
             alloc: self.alloc,
             bytes_start: self.bytes_start + range.start().map_or(0, |e| *e) * mem::size_of::<T>(),

--- a/src/utils/range.rs
+++ b/src/utils/range.rs
@@ -3,40 +3,40 @@ use std::ops::{Range, RangeTo, RangeFrom, RangeFull};
 /// Temporary re-implemenation of RangeArgument from stdlib while
 /// waiting for it to become stable
 pub trait RangeArgument<T> {
-	/// Get the (possible) requested first element of a range.
-	fn start(&self) -> Option<&T>;
-	/// Get the (possible) requested last element of a range.
-	fn end(&self) -> Option<&T>;
+    /// Get the (possible) requested first element of a range.
+    fn start(&self) -> Option<&T>;
+    /// Get the (possible) requested last element of a range.
+    fn end(&self) -> Option<&T>;
 }
 impl<T> RangeArgument<T> for RangeFull {
-	fn start(&self) -> Option<&T> {
-		None
-	}
-	fn end(&self) -> Option<&T> {
-		None
-	}
+    fn start(&self) -> Option<&T> {
+        None
+    }
+    fn end(&self) -> Option<&T> {
+        None
+    }
 }
 impl<T> RangeArgument<T> for RangeFrom<T> {
-	fn start(&self) -> Option<&T> {
-		Some(&self.start)
-	}
-	fn end(&self) -> Option<&T> {
-		None
-	}
+    fn start(&self) -> Option<&T> {
+        Some(&self.start)
+    }
+    fn end(&self) -> Option<&T> {
+        None
+    }
 }
 impl<T> RangeArgument<T> for RangeTo<T> {
-	fn start(&self) -> Option<&T> {
-		None
-	}
-	fn end(&self) -> Option<&T> {
-		Some(&self.end)
-	}
+    fn start(&self) -> Option<&T> {
+        None
+    }
+    fn end(&self) -> Option<&T> {
+        Some(&self.end)
+    }
 }
 impl<T> RangeArgument<T> for Range<T> {
-	fn start(&self) -> Option<&T> {
-		Some(&self.start)
-	}
-	fn end(&self) -> Option<&T> {
-		Some(&self.end)
-	}
+    fn start(&self) -> Option<&T> {
+        Some(&self.start)
+    }
+    fn end(&self) -> Option<&T> {
+        Some(&self.end)
+    }
 }


### PR DESCRIPTION
#1284

While this is being touched, before merging this is there any other `TextureType` that should have `write()`? Currently it's just `Regular` and `Srgb` along with the Compressed equivalents of those two.  I'm not really sure about `Depth`/`Stencil`/etc should have them.

Also, this fixes some screw-ups from my last PR (I use tabs personally, I finally got `git config` set up correctly so it will auto-convert tabs/spaces for me... sorry about that.)