### PR TITLE
Remove support for the "image" library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   matrix:
     - FEATURES='' TEST=0 COVERAGE=0
     - FEATURES='glutin' TEST=1 COVERAGE=0
-    - FEATURES='glutin image cgmath nalgebra' TEST=1 COVERAGE=1
+    - FEATURES='glutin cgmath nalgebra' TEST=1 COVERAGE=1
 
 addons:
   apt:
@@ -41,7 +41,7 @@ after_success:
         [ $TRAVIS_BRANCH = master ] &&
         [ $TRAVIS_PULL_REQUEST = false ] &&
         [ $TRAVIS_RUST_VERSION = nightly ] &&
-        cargo doc -j 1 --features "glutin image cgmath nalgebra" &&
+        cargo doc -j 1 --features "glutin cgmath nalgebra" &&
         npm install gitbook-cli -g &&
         gitbook build ./book &&
         mv ./book/_book ./target/doc/book &&

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+ - Removed the "image" feature and native support for the `image`. You now have to perform conversions yourself.
+
 ## Version 0.11.1 (2015-11-10)
 
  - Fix broken compilation after libc 0.2.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ build = "build/main.rs"
 exclude = ["doc", ".travis.yml", "circle.yml"]
 
 [features]
-default = ["glutin", "image", "nalgebra", "cgmath"]
+default = ["glutin", "nalgebra", "cgmath"]
 unstable = []       # used for benchmarks
 
 [dependencies.glutin]
@@ -39,10 +39,6 @@ optional = true
 version = "0.3"
 optional = true
 
-[dependencies.image]
-version = "0.4.0"
-optional = true
-
 [dependencies]
 backtrace = "0.1.5"
 lazy_static = "0.1"
@@ -56,5 +52,6 @@ khronos_api = "0.0.8"
 [dev-dependencies]
 clock_ticks = "0.1.0"
 genmesh = "0.2.1"
+image = "0.4.0"
 obj = "0.2.1"
 rand = "0.3"

--- a/book/tuto-06-texture.md
+++ b/book/tuto-06-texture.md
@@ -21,7 +21,9 @@ In order to load the image, we just need to use `image::load`:
 ```rust
 use std::io::Cursor;
 let image = image::load(Cursor::new(&include_bytes!("/path/to/image.png")[..]),
-                        image::PNG).unwrap();
+                        image::PNG).unwrap().to_rgba();
+let image_dimensions = image.dimensions();
+let image = glium::texture::RawImage2d::from_raw_rgba_reversed(image.into_raw(), image_dimensions);
 ```
 
 And in order to upload the image as a texture, it's as simple as:

--- a/book/tuto-14-wall.md
+++ b/book/tuto-14-wall.md
@@ -51,7 +51,9 @@ Loading the texture is done like we have already done before:
 
 ```rust
 let image = image::load(Cursor::new(&include_bytes!("../book/tuto-14-diffuse.jpg")[..]),
-                        image::JPEG).unwrap();
+                        image::JPEG).unwrap().to_rgba();
+let image_dimensions = image.dimensions();
+let image = glium::texture::RawImage2d::from_raw_rgba_reversed(image.into_raw(), image_dimensions);
 let diffuse_texture = glium::texture::SrgbTexture2d::new(&display, image).unwrap();
 ```
 

--- a/examples/blitting.rs
+++ b/examples/blitting.rs
@@ -2,26 +2,15 @@ extern crate rand;
 
 #[macro_use]
 extern crate glium;
-
-#[cfg(feature = "image")]
 extern crate image;
 
-#[cfg(feature = "image")]
 use std::io::Cursor;
-
-#[cfg(feature = "image")]
 use glium::{DisplayBuild, Surface};
 
 use glium::glutin;
 
 mod support;
 
-#[cfg(not(feature = "image"))]
-fn main() {
-    println!("This example requires the `image` feature to be enabled");
-}
-
-#[cfg(feature = "image")]
 fn main() {
     // building the display, ie. the main object
     let display = glutin::WindowBuilder::new()
@@ -31,7 +20,9 @@ fn main() {
 
     // building a texture with "OpenGL" drawn on it
     let image = image::load(Cursor::new(&include_bytes!("../tests/fixture/opengl.png")[..]),
-        image::PNG).unwrap();
+                            image::PNG).unwrap().to_rgba();
+    let image_dimensions = image.dimensions();
+    let image = glium::texture::RawImage2d::from_raw_rgba_reversed(image.into_raw(), image_dimensions);
     let opengl_texture = glium::Texture2d::new(&display, image).unwrap();
 
     // building a 1024x1024 empty texture

--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -2,7 +2,6 @@
 extern crate glium;
 #[cfg(feature = "cgmath")]
 extern crate cgmath;
-#[cfg(feature = "image")]
 extern crate image;
 
 use glium::glutin;
@@ -14,12 +13,12 @@ use std::io::Cursor;
 
 mod support;
 
-#[cfg(not(all(feature = "cgmath", feature = "image")))]
+#[cfg(not(feature = "cgmath"))]
 fn main() {
     println!("This example requires the `cgmath` and `image` features to be enabled");
 }
 
-#[cfg(all(feature = "cgmath", feature = "image"))]
+#[cfg(feature = "cgmath")]
 fn main() {
     use glium::DisplayBuild;
 
@@ -30,7 +29,9 @@ fn main() {
         .build_glium()
         .unwrap();
 
-    let image = image::load(Cursor::new(&include_bytes!("../tests/fixture/opengl.png")[..]), image::PNG).unwrap();
+    let image = image::load(Cursor::new(&include_bytes!("../tests/fixture/opengl.png")[..]), image::PNG).unwrap().to_rgba();
+    let image_dimensions = image.dimensions();
+    let image = glium::texture::RawImage2d::from_raw_rgba_reversed(image.into_raw(), image_dimensions);
     let opengl_texture = glium::texture::Texture2d::new(&display, image).unwrap();
 
     let floor_vertex_buffer = {

--- a/examples/displacement_mapping.rs
+++ b/examples/displacement_mapping.rs
@@ -1,23 +1,19 @@
-#[cfg(feature = "image")]
 extern crate image;
-
 #[macro_use]
 extern crate glium;
 
 use glium::glutin;
-#[cfg(feature = "image")]
 use std::io::Cursor;
-#[cfg(feature = "image")]
 use glium::Surface;
 
 mod support;
 
-#[cfg(not(all(feature = "image", feature = "nalgebra")))]
+#[cfg(not(feature = "nalgebra"))]
 fn main() {
-    println!("This example requires the `image` feature to be enabled");
+    println!("This example requires the `nalgebra` feature to be enabled");
 }
 
-#[cfg(all(feature = "image", feature = "nalgebra"))]
+#[cfg(feature = "nalgebra")]
 fn main() {
     use glium::DisplayBuild;
 
@@ -27,7 +23,9 @@ fn main() {
         .unwrap();
 
     let image = image::load(Cursor::new(&include_bytes!("../tests/fixture/opengl.png")[..]),
-        image::PNG).unwrap();
+                            image::PNG).unwrap().to_rgba();
+    let image_dimensions = image.dimensions();
+    let image = glium::texture::RawImage2d::from_raw_rgba_reversed(image.into_raw(), image_dimensions);
     let opengl_texture = glium::texture::CompressedSrgbTexture2d::new(&display, image).unwrap();
 
     // building the vertex buffer, which contains all the vertices that we will draw

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -1,32 +1,25 @@
 #[macro_use]
 extern crate glium;
 
-#[cfg(feature = "image")]
 extern crate image;
 
-#[cfg(feature = "image")]
 use std::io::Cursor;
 
-#[cfg(feature = "image")]
 use glium::{DisplayBuild, Surface};
 use glium::glutin;
 use glium::index::PrimitiveType;
 
 mod support;
 
-#[cfg(not(feature = "image"))]
-fn main() {
-    println!("This example requires the `image` feature to be enabled");
-}
-
-#[cfg(feature = "image")]
 fn main() {
     // building the display, ie. the main object
     let display = glutin::WindowBuilder::new().build_glium().unwrap();
 
     // building a texture with "OpenGL" drawn on it
     let image = image::load(Cursor::new(&include_bytes!("../tests/fixture/opengl.png")[..]),
-        image::PNG).unwrap();
+                            image::PNG).unwrap().to_rgba();
+    let image_dimensions = image.dimensions();
+    let image = glium::texture::RawImage2d::from_raw_rgba_reversed(image.into_raw(), image_dimensions);
     let opengl_texture = glium::texture::CompressedTexture2d::new(&display, image).unwrap();
 
     // building the vertex buffer, which contains all the vertices that we will draw

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -1,25 +1,15 @@
 #[macro_use]
 extern crate glium;
-
-#[cfg(feature = "image")]
 extern crate image;
 
-#[cfg(feature = "image")]
 use std::io::Cursor;
 
-#[cfg(feature = "image")]
 use glium::{DisplayBuild, Surface};
 use glium::glutin;
 use glium::index::PrimitiveType;
 
 mod support;
 
-#[cfg(not(feature = "image"))]
-fn main() {
-    println!("This example requires the `image` feature to be enabled");
-}
-
-#[cfg(feature = "image")]
 fn main() {
     // building the display, ie. the main object
     let display = glutin::WindowBuilder::new()
@@ -29,7 +19,9 @@ fn main() {
 
     // building a texture with "OpenGL" drawn on it
     let image = image::load(Cursor::new(&include_bytes!("../tests/fixture/opengl.png")[..]),
-        image::PNG).unwrap();
+                            image::PNG).unwrap().to_rgba();
+    let image_dimensions = image.dimensions();
+    let image = glium::texture::RawImage2d::from_raw_rgba_reversed(image.into_raw(), image_dimensions);
     let opengl_texture = glium::texture::CompressedSrgbTexture2d::new(&display, image).unwrap();
 
     // building the vertex buffer, which contains all the vertices that we will draw

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -1,7 +1,5 @@
 #[macro_use]
 extern crate glium;
-
-#[cfg(feature = "image")]
 extern crate image;
 
 use glium::Surface;
@@ -9,12 +7,6 @@ use glium::glutin;
 use glium::index::PrimitiveType;
 use std::path::Path;
 
-#[cfg(not(feature = "image"))]
-fn main() {
-    println!("You need to compile glium with the `image` feature in order to run this example");
-}
-
-#[cfg(feature = "image")]
 fn main() {
     use glium::DisplayBuild;
 
@@ -124,7 +116,9 @@ fn main() {
     target.finish().unwrap();
 
     // reading the front buffer into an image
-    let image: image::DynamicImage = display.read_front_buffer();
+    let image: glium::texture::RawImage2d<u8> = display.read_front_buffer();
+    let image = image::ImageBuffer::from_raw(image.width, image.height, image.data.into_owned()).unwrap();
+    let image = image::DynamicImage::ImageRgba8(image);
     let mut output = std::fs::File::create(&Path::new("glium-example-screenshot.png")).unwrap();
     image.save(&mut output, image::ImageFormat::PNG).unwrap();
 }

--- a/examples/tutorial-06.rs
+++ b/examples/tutorial-06.rs
@@ -1,20 +1,17 @@
 #[macro_use]
 extern crate glium;
-
-#[cfg(feature = "image")]
 extern crate image;
 
 use std::io::Cursor;
 
-#[cfg(not(feature = "image"))]
-fn main() { println!("This example requires the `image` feature to be enabled"); }
-#[cfg(feature = "image")]
 fn main() {
     use glium::{DisplayBuild, Surface};
     let display = glium::glutin::WindowBuilder::new().build_glium().unwrap();
 
     let image = image::load(Cursor::new(&include_bytes!("../tests/fixture/opengl.png")[..]),
-                            image::PNG).unwrap();
+                            image::PNG).unwrap().to_rgba();
+    let image_dimensions = image.dimensions();
+    let image = glium::texture::RawImage2d::from_raw_rgba_reversed(image.into_raw(), image_dimensions);
     let texture = glium::texture::Texture2d::new(&display, image).unwrap();
 
     #[derive(Copy, Clone)]

--- a/examples/tutorial-14.rs
+++ b/examples/tutorial-14.rs
@@ -1,13 +1,9 @@
 #[macro_use]
 extern crate glium;
-#[cfg(feature = "image")]
 extern crate image;
 
 use std::io::Cursor;
 
-#[cfg(not(feature = "image"))]
-fn main() { println!("This example requires the `image` feature to be enabled"); }
-#[cfg(feature = "image")]
 fn main() {
     use glium::{DisplayBuild, Surface};
     let display = glium::glutin::WindowBuilder::new()
@@ -33,11 +29,15 @@ fn main() {
 
 
     let image = image::load(Cursor::new(&include_bytes!("../book/tuto-14-diffuse.jpg")[..]),
-                            image::JPEG).unwrap();
+                            image::JPEG).unwrap().to_rgba();
+    let image_dimensions = image.dimensions();
+    let image = glium::texture::RawImage2d::from_raw_rgba_reversed(image.into_raw(), image_dimensions);
     let diffuse_texture = glium::texture::SrgbTexture2d::new(&display, image).unwrap();
 
     let image = image::load(Cursor::new(&include_bytes!("../book/tuto-14-normal.png")[..]),
-                            image::PNG).unwrap();
+                            image::PNG).unwrap().to_rgba();
+    let image_dimensions = image.dimensions();
+    let image = glium::texture::RawImage2d::from_raw_rgba_reversed(image.into_raw(), image_dimensions);
     let normal_map = glium::texture::Texture2d::new(&display, image).unwrap();
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,8 +95,6 @@ extern crate lazy_static;
 
 #[cfg(feature = "cgmath")]
 extern crate cgmath;
-#[cfg(feature = "image")]
-extern crate image;
 extern crate libc;
 #[cfg(feature = "nalgebra")]
 extern crate nalgebra;


### PR DESCRIPTION
Does not compile. I'm waiting for https://github.com/rust-lang/cargo/pull/2134 to be merged and published in a nightly before finishing it.

Entirely removes the dependency towards `image` in glium. Image is still used as a dev dependency in the examples.
