### PR TITLE
No longer use a *const libc::c_void for OpenGL pointers

### DIFF
--- a/examples/manual-creation.rs
+++ b/examples/manual-creation.rs
@@ -16,7 +16,6 @@ There are three concepts in play:
    means that you can direct pass the context.
 
 */
-extern crate libc;
 extern crate glium;
 
 use glium::Surface;
@@ -45,7 +44,7 @@ fn main() {
         }
 
         // this function is called only after the OpenGL context has been made current
-        unsafe fn get_proc_address(&self, symbol: &str) -> *const libc::c_void {
+        unsafe fn get_proc_address(&self, symbol: &str) -> *const () {
             self.window.get_proc_address(symbol) as *const _
         }
 

--- a/src/backend/glutin_backend.rs
+++ b/src/backend/glutin_backend.rs
@@ -10,8 +10,6 @@ Only available if the 'glutin' feature is enabled.
 */
 extern crate glutin;
 
-use libc;
-
 use DisplayBuild;
 use Frame;
 use GliumCreationError;
@@ -232,7 +230,7 @@ unsafe impl Backend for GlutinWindowBackend {
     }
 
     #[inline]
-    unsafe fn get_proc_address(&self, symbol: &str) -> *const libc::c_void {
+    unsafe fn get_proc_address(&self, symbol: &str) -> *const () {
         self.window.get_proc_address(symbol) as *const _
     }
 
@@ -305,7 +303,7 @@ unsafe impl Backend for GlutinHeadlessBackend {
     }
 
     #[inline]
-    unsafe fn get_proc_address(&self, symbol: &str) -> *const libc::c_void {
+    unsafe fn get_proc_address(&self, symbol: &str) -> *const () {
         self.context.get_proc_address(symbol) as *const _
     }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -15,7 +15,6 @@ There are three concepts in play:
 use std::rc::Rc;
 use std::ops::Deref;
 
-use libc;
 use CapabilitiesSource;
 use SwapBuffersError;
 
@@ -40,7 +39,7 @@ pub unsafe trait Backend {
     /// Returns the address of an OpenGL function.
     ///
     /// Supposes that the context has been made current before this function is called.
-    unsafe fn get_proc_address(&self, symbol: &str) -> *const libc::c_void;
+    unsafe fn get_proc_address(&self, symbol: &str) -> *const ();
 
     /// Returns the dimensions of the window, or screen, etc.
     fn get_framebuffer_dimensions(&self) -> (u32, u32);
@@ -57,7 +56,7 @@ unsafe impl<T> Backend for Rc<T> where T: Backend {
         self.deref().swap_buffers()
     }
 
-    unsafe fn get_proc_address(&self, symbol: &str) -> *const libc::c_void {
+    unsafe fn get_proc_address(&self, symbol: &str) -> *const () {
         self.deref().get_proc_address(symbol)
     }
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -157,7 +157,7 @@ impl Context {
     {
         backend.make_current();
 
-        let gl = gl::Gl::load_with(|symbol| backend.get_proc_address(symbol));
+        let gl = gl::Gl::load_with(|symbol| backend.get_proc_address(symbol) as *const _);
         let gl_state: RefCell<GlState> = RefCell::new(Default::default());
 
         let version = version::get_gl_version(&gl);


### PR DESCRIPTION
Needs a line in the changelog.

Close #1333 