### PR TITLE
Creating a MultiOutputFrameBuffer now requires an iterator

### DIFF
--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -272,7 +272,7 @@ fn main() {
     let texture4 = glium::texture::Texture2d::empty_with_format(&display, glium::texture::UncompressedFloatFormat::F32F32F32F32, glium::texture::MipmapsOption::NoMipmap, 800, 500).unwrap();
     let depthtexture = glium::texture::DepthTexture2d::empty_with_format(&display, glium::texture::DepthFormat::F32, glium::texture::MipmapsOption::NoMipmap, 800, 500).unwrap();
     let output = &[("output1", &texture1), ("output2", &texture2), ("output3", &texture3), ("output4", &texture4)];
-    let mut framebuffer = glium::framebuffer::MultiOutputFrameBuffer::with_depth_buffer(&display, output, &depthtexture).unwrap();
+    let mut framebuffer = glium::framebuffer::MultiOutputFrameBuffer::with_depth_buffer(&display, output.iter().cloned(), &depthtexture).unwrap();
 
     let light_texture = glium::texture::Texture2d::empty_with_format(&display, glium::texture::UncompressedFloatFormat::F32F32F32F32, glium::texture::MipmapsOption::NoMipmap, 800, 500).unwrap();
     let mut light_buffer = glium::framebuffer::SimpleFrameBuffer::with_depth_buffer(&display, &light_texture, &depthtexture).unwrap();

--- a/tests/framebuffer.rs
+++ b/tests/framebuffer.rs
@@ -229,7 +229,7 @@ fn multioutput() {
 
     // building the framebuffer
     let mut framebuffer = glium::framebuffer::MultiOutputFrameBuffer::new(&display,
-                                             &[("color1", &color1), ("color2", &color2)]).unwrap();
+                               [("color1", &color1), ("color2", &color2)].iter().cloned()).unwrap();
 
     framebuffer.draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms,
                      &Default::default()).unwrap();
@@ -318,9 +318,8 @@ fn multi_color_attachments_maximum() {
         })
         .collect::<Vec<_>>();
 
-    let colors = (0 .. color_textures.len()).map(|i| {("attachment", &color_textures[i])} ).collect::<Vec<_>>();
-
-    glium::framebuffer::MultiOutputFrameBuffer::new(&display, &colors[..]).unwrap();
+    let colors = (0 .. color_textures.len()).map(|i| {("attachment", &color_textures[i])} );
+    glium::framebuffer::MultiOutputFrameBuffer::new(&display, colors).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
Needs a line in the changelog.

This allows one to use other attachments than just `Texture2d`s.
