### PR TITLE
Update image dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ version = "0.3"
 optional = true
 
 [dependencies.image]
-version = "0.4.0"
+version = "0.5.0"
 optional = true
 
 [dependencies]


### PR DESCRIPTION
This seems to be necessary to work around rust-lang/cargo#2132