### PR TITLE
Update cgmath, genmesh, and obj

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ khronos_api = "0.0.8"
 
 [dev-dependencies]
 clock_ticks = "0.1.0"
-cgmath = "0.4"
-genmesh = "0.2.1"
+cgmath = "0.7"
+genmesh = "0.4"
 image = "0.4.0"
-obj = "0.2.1"
+obj = { version = "0.5", features = ["usegenmesh"] }
 rand = "0.3"

--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -276,8 +276,8 @@ fn main() {
     let view_eye: cgmath::Point3<f32> = cgmath::Point3::new(0.0, 2.0, -2.0);
     let view_center: cgmath::Point3<f32> = cgmath::Point3::new(0.0, 0.0, 0.0);
     let view_up: cgmath::Vector3<f32> = cgmath::Vector3::new(0.0, 1.0, 0.0);
-    let view_matrix: cgmath::Matrix4<f32> = cgmath::Matrix4::look_at(&view_eye, &view_center, &view_up);
-    let model_matrix: cgmath::Matrix4<f32> = cgmath::Matrix::one();
+    let view_matrix: cgmath::Matrix4<f32> = cgmath::Matrix4::look_at(view_eye, view_center, view_up);
+    let model_matrix: cgmath::Matrix4<f32> = cgmath::Matrix4::from_scale(1.0);
 
     let lights = [
         Light {


### PR DESCRIPTION
Hi,


Currently Travis fails to test the master branch on nightly when `glutin` is enabled, which is due to the outdated dependency on `genmesh`.

Note that I am not able to run the test suite on my mac; some of the test binaries crash. However, this is also the case when testing v0.13.2 on stable. Therefore, I assume that this is orthogonal to the updated dependencies.


Best,
Ivan