### PR TITLE
Improving error handling Issue #959

### DIFF
--- a/src/buffer/alloc.rs
+++ b/src/buffer/alloc.rs
@@ -6,6 +6,7 @@ use CapabilitiesSource;
 use ContextExt;
 use gl;
 use std::os::raw;
+use std::error::Error;
 use std::{fmt, mem, ptr};
 use std::cell::Cell;
 use std::rc::Rc;
@@ -29,11 +30,42 @@ pub enum ReadError {
     ContextLost,
 }
 
+impl fmt::Display for ReadError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.description())
+    }
+}
+
+impl Error for ReadError {
+    fn description(&self) -> &str {
+        use self::ReadError::*;
+        match *self {
+            NotSupported => "The backend doesn't support reading from a buffer",
+            ContextLost => "The context has been lost. Reading from the buffer would return garbage data",
+        }
+    }
+}
+
 /// Error that can happen when copying data between buffers.
 #[derive(Debug, Copy, Clone)]
 pub enum CopyError {
     /// The backend doesn't support copying between buffers.
     NotSupported,
+}
+
+impl fmt::Display for CopyError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.description())
+    }
+}
+
+impl Error for CopyError {
+    fn description(&self) -> &str {
+        use self::CopyError::*;
+        match *self {
+            NotSupported => "The backend doesn't support copying between buffers",
+        }
+    }
 }
 
 /// A buffer in the graphics card's memory.

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -182,8 +182,8 @@ pub enum BufferCreationError {
 }
 
 impl fmt::Display for BufferCreationError {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        self.description().fmt(formatter)
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.description())
     }
 }
 

--- a/src/draw_parameters/query.rs
+++ b/src/draw_parameters/query.rs
@@ -11,6 +11,7 @@ use std::cell::Cell;
 use std::fmt;
 use std::mem;
 use std::rc::Rc;
+use std::error::Error;
 
 use buffer::Buffer;
 use buffer::BufferSlice;
@@ -65,11 +66,41 @@ pub enum QueryCreationError {
     NotSupported,
 }
 
+impl fmt::Display for QueryCreationError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.description())
+    }
+}
+
+impl Error for QueryCreationError {
+    fn description(&self) -> &str {
+        use self::QueryCreationError::*;
+        match *self {
+            NotSupported => "The given query type is not supported",
+        }
+    }
+}
+
 /// Error that can happen when writing the value of a query to a buffer.
 #[derive(Copy, Clone, Debug)]
 pub enum ToBufferError {
     /// Writing the result to a buffer is not supported.
     NotSupported,
+}
+
+impl fmt::Display for ToBufferError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.description())
+    }
+}
+
+impl Error for ToBufferError {
+    fn description(&self) -> &str {
+        use self::ToBufferError::*;
+        match *self {
+            NotSupported => "Writing the result to a buffer is not supported",
+        }
+    }
 }
 
 impl RawQuery {

--- a/src/framebuffer/render_buffer.rs
+++ b/src/framebuffer/render_buffer.rs
@@ -9,7 +9,8 @@ the data of the render buffer.
 */
 use std::rc::Rc;
 use std::ops::{Deref, DerefMut};
-use std::mem;
+use std::{ mem, fmt };
+use std::error::Error;
 
 use framebuffer::{ColorAttachment, ToColorAttachment};
 use framebuffer::{DepthAttachment, ToDepthAttachment};
@@ -33,6 +34,21 @@ use version::Api;
 pub enum CreationError {
     /// The requested format is not supported.
     FormatNotSupported,
+}
+
+impl fmt::Display for CreationError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.description())
+    }
+}
+
+impl Error for CreationError {
+    fn description(&self) -> &str {
+        use self::CreationError::*;
+        match *self {
+            FormatNotSupported => "The requested format is not supported",
+        }
+    }
 }
 
 impl From<image_format::FormatNotSupportedError> for CreationError {
@@ -303,7 +319,7 @@ impl RenderBufferAny {
                 if ctxt.version >= &Version(Api::Gl, 3, 0) ||
                    ctxt.version >= &Version(Api::GlEs, 3, 0)
                 {
-                    ctxt.gl.RenderbufferStorageMultisample(gl::RENDERBUFFER, 
+                    ctxt.gl.RenderbufferStorageMultisample(gl::RENDERBUFFER,
                                                            samples as gl::types::GLsizei,
                                                            format,
                                                            width as gl::types::GLsizei,
@@ -447,7 +463,7 @@ impl Drop for RenderBufferAny {
 
 impl GlObject for RenderBufferAny {
     type Id = gl::types::GLuint;
-    
+
     #[inline]
     fn get_id(&self) -> gl::types::GLuint {
         self.id

--- a/src/image_format.rs
+++ b/src/image_format.rs
@@ -2,6 +2,9 @@
 This private module handles the various image formats in OpenGL.
 
 */
+use std::fmt;
+use std::error::Error;
+
 use gl;
 use context::Context;
 
@@ -12,6 +15,18 @@ use version::{Api, Version};
 /// Error that is returned if the format is not supported by OpenGL.
 #[derive(Copy, Clone, Debug)]
 pub struct FormatNotSupportedError;
+
+impl fmt::Display for FormatNotSupportedError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.description())
+    }
+}
+
+impl Error for FormatNotSupportedError {
+    fn description(&self) -> &str {
+        "Format is not supported by OpenGL"
+    }
+}
 
 /// Texture format request.
 #[derive(Copy, Clone, Debug)]
@@ -815,7 +830,7 @@ impl UncompressedIntFormat {
             &UncompressedIntFormat::I32I32I32I32 => version >= &Version(Api::GlEs, 3, 0),
         }
     }
-            
+
     fn to_glenum(&self) -> gl::types::GLenum {
         match self {
             &UncompressedIntFormat::I8 => gl::R8I,
@@ -1501,7 +1516,7 @@ impl ClientFormatAny {
         }
     }
 
-    /// Gets the size in bytes of the buffer required to store a uncompressed image 
+    /// Gets the size in bytes of the buffer required to store a uncompressed image
     /// of the specified dimensions on this format.
     ///
     /// ## Panic

--- a/src/index/buffer.rs
+++ b/src/index/buffer.rs
@@ -12,6 +12,8 @@ use index::IndexType;
 use index::PrimitiveType;
 
 use std::ops::{Deref, DerefMut};
+use std::fmt;
+use std::error::Error;
 use utils::range::RangeArgument;
 
 /// Error that can happen while creating an index buffer.
@@ -25,6 +27,34 @@ pub enum CreationError {
 
     /// An error happened while creating the buffer.
     BufferCreationError(BufferCreationError),
+}
+
+impl fmt::Display for CreationError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.description())
+    }
+}
+
+impl Error for CreationError {
+    fn description(&self) -> &str {
+        use self::CreationError::*;
+        match *self {
+            IndexTypeNotSupported
+                => "The type of index is not supported by the backend",
+            PrimitiveTypeNotSupported
+                => "The type of primitives is not supported by the backend",
+            BufferCreationError(_)
+                => "An error happened while creating the buffer",
+        }
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        use self::CreationError::*;
+        match *self {
+            BufferCreationError(ref err) => Some(err),
+            _ => None,
+        }
+    }
 }
 
 impl From<BufferCreationError> for CreationError {

--- a/src/index/buffer.rs
+++ b/src/index/buffer.rs
@@ -39,12 +39,12 @@ impl Error for CreationError {
     fn description(&self) -> &str {
         use self::CreationError::*;
         match *self {
-            IndexTypeNotSupported
-                => "The type of index is not supported by the backend",
-            PrimitiveTypeNotSupported
-                => "The type of primitives is not supported by the backend",
-            BufferCreationError(_)
-                => "An error happened while creating the buffer",
+            IndexTypeNotSupported =>
+                "The type of index is not supported by the backend",
+            PrimitiveTypeNotSupported =>
+                "The type of primitives is not supported by the backend",
+            BufferCreationError(_) =>
+                "An error happened while creating the buffer",
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -914,7 +914,7 @@ impl Error for DrawError {
             InvalidDepthRange =>
                 "The depth range is outside of the `(0, 1)` range",
             UniformTypeMismatch { .. } =>
-                    "The type of a uniform doesn't match what the program requires",
+                "The type of a uniform doesn't match what the program requires",
             UniformBufferToValue { .. } =>
                 "Tried to bind a uniform buffer to a single uniform value",
             UniformValueToBlock { .. } =>

--- a/src/ops/read.rs
+++ b/src/ops/read.rs
@@ -86,12 +86,12 @@ impl Error for ReadError {
     fn description(&self) -> &str {
         use self::ReadError::*;
         match *self {
-            OutputFormatNotSupported
-                => "The implementation doesn't support converting to the requested output format",
-            AttachmentTypeNotSupported
-                => "The implementation doesn't support reading a depth, depth-stencil or stencil attachment",
-            ClampingNotSupported
-                => "Clamping the values is not supported by the implementation",
+            OutputFormatNotSupported =>
+                "The implementation doesn't support converting to the requested output format",
+            AttachmentTypeNotSupported =>
+                "The implementation doesn't support reading a depth, depth-stencil or stencil attachment",
+            ClampingNotSupported =>
+                "Clamping the values is not supported by the implementation",
         }
     }
 }

--- a/src/ops/read.rs
+++ b/src/ops/read.rs
@@ -1,4 +1,6 @@
 use std::ptr;
+use std::fmt;
+use std::error::Error;
 
 use pixel_buffer::PixelBuffer;
 use texture::ClientFormat;
@@ -72,6 +74,26 @@ pub enum ReadError {
     ClampingNotSupported,
 
     // TODO: context lost
+}
+
+impl fmt::Display for ReadError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.description())
+    }
+}
+
+impl Error for ReadError {
+    fn description(&self) -> &str {
+        use self::ReadError::*;
+        match *self {
+            OutputFormatNotSupported
+                => "The implementation doesn't support converting to the requested output format",
+            AttachmentTypeNotSupported
+                => "The implementation doesn't support reading a depth, depth-stencil or stencil attachment",
+            ClampingNotSupported
+                => "Clamping the values is not supported by the implementation",
+        }
+    }
 }
 
 /// Reads pixels from the source into the destination.
@@ -179,13 +201,13 @@ pub fn read<'a, S, D, T>(mut ctxt: &mut CommandContext, source: S, rect: &Rect, 
             client_format_to_gl_enum(&output_pixel_format, integer)
         },
         ReadSourceType::Depth => {
-            unimplemented!()        // TODO: 
+            unimplemented!()        // TODO:
             // TODO: NV_depth_buffer_float2
             //(gl::DEPTH_COMPONENT, )
         },
         ReadSourceType::DepthStencil => unimplemented!(),        // FIXME: only 24_8 is possible and there's no client format in the enum that corresponds to 24_8
         ReadSourceType::Stencil => {
-            unimplemented!()        // TODO: 
+            unimplemented!()        // TODO:
             //(gl::STENCIL_INDEX, )
         },
     };

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -72,47 +72,36 @@ pub enum ProgramCreationError {
 }
 
 impl fmt::Display for ProgramCreationError {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match self {
-            &ProgramCreationError::CompilationError(ref s) =>
-                formatter.write_fmt(format_args!("Compilation error in one of the shaders: {}", s)),
-            &ProgramCreationError::LinkingError(ref s) =>
-                formatter.write_fmt(format_args!("Error while linking shaders together: {}", s)),
-            &ProgramCreationError::ShaderTypeNotSupported =>
-                formatter.write_str("One of the request shader type is \
-                                    not supported by the backend"),
-            &ProgramCreationError::CompilationNotSupported =>
-                formatter.write_str("The backend doesn't support shaders compilation"),
-            &ProgramCreationError::TransformFeedbackNotSupported => 
-                formatter.write_str("You requested transform feedback, but this feature is not \
-                                     supported by the backend"),
-            &ProgramCreationError::PointSizeNotSupported =>
-                formatter.write_str("You requested point size setting, but it's not \
-                                     supported by the backend"),
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        use self::ProgramCreationError::*;
+        match *self {
+            CompilationError(ref s) =>
+                write!(fmt, "{}: {}", self.description(), s),
+            LinkingError(ref s) =>
+                write!(fmt, "{}: {}", self.description(), s),
+            _ =>
+                write!(fmt, "{}", self.description()),
         }
     }
 }
 
 impl Error for ProgramCreationError {
     fn description(&self) -> &str {
-        match self {
-            &ProgramCreationError::CompilationError(_) => "Compilation error in one of the \
-                                                           shaders",
-            &ProgramCreationError::LinkingError(_) => "Error while linking shaders together",
-            &ProgramCreationError::ShaderTypeNotSupported => "One of the request shader type is \
-                                                              not supported by the backend",
-            &ProgramCreationError::CompilationNotSupported => "The backend doesn't support \
-                                                               shaders compilation",
-            &ProgramCreationError::TransformFeedbackNotSupported => "Transform feedback is not \
-                                                                     supported by the backend.",
-            &ProgramCreationError::PointSizeNotSupported => "Point size is not supported by \
-                                                             the backend.",
+        use self::ProgramCreationError::*;
+        match *self {
+            CompilationError(_) =>
+                "Compilation error in one of the shaders",
+            LinkingError(_) =>
+                "Error while linking shaders together",
+            ShaderTypeNotSupported =>
+                "One of the request shader type is not supported by the backend",
+            CompilationNotSupported =>
+                "The backend doesn't support shaders compilation",
+            TransformFeedbackNotSupported =>
+                "Transform feedback is not supported by the backend.",
+            PointSizeNotSupported =>
+                "Point size is not supported by the backend.",
         }
-    }
-
-    #[inline]
-    fn cause(&self) -> Option<&Error> {
-        None
     }
 }
 
@@ -128,26 +117,27 @@ pub enum ProgramChooserCreationError {
 
 impl fmt::Display for ProgramChooserCreationError {
     #[inline]
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(formatter, "{}", self.description())
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(fmt, "{}", self.description())
     }
 }
 
 impl Error for ProgramChooserCreationError {
     #[inline]
     fn description(&self) -> &str {
-        match self {
-            &ProgramChooserCreationError::NoVersion => "No version of the program has been found \
-                                                        for the current OpenGL version.",
-            &ProgramChooserCreationError::ProgramCreationError(ref err) => err.description(),
+        use self::ProgramChooserCreationError::*;
+        match *self {
+            ProgramCreationError(ref err) => err.description(),
+            NoVersion => "No version of the program has been found for the current OpenGL version.",
         }
     }
 
     #[inline]
     fn cause(&self) -> Option<&Error> {
-        match self {
-            &ProgramChooserCreationError::NoVersion => None,
-            &ProgramChooserCreationError::ProgramCreationError(ref err) => Some(err),
+        use self::ProgramChooserCreationError::*;
+        match *self {
+            ProgramCreationError(ref err) => Some(err),
+            _ => None,
         }
     }
 }
@@ -163,6 +153,21 @@ impl From<ProgramCreationError> for ProgramChooserCreationError {
 pub enum GetBinaryError {
     /// The backend doesn't support binary.
     NotSupported,
+}
+
+impl fmt::Display for GetBinaryError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.description())
+    }
+}
+
+impl Error for GetBinaryError {
+    fn description(&self) -> &str {
+        use self::GetBinaryError::*;
+        match *self {
+            NotSupported => "The backend doesn't support binary",
+        }
+    }
 }
 
 /// Input when creating a program.

--- a/src/texture/buffer_texture.rs
+++ b/src/texture/buffer_texture.rs
@@ -101,12 +101,12 @@ impl Error for TextureCreationError {
     fn description(&self) -> &str {
         use self::TextureCreationError::*;
         match *self {
-            NotSupported
-                => "Buffer textures are not supported at all",
-            FormatNotSupported
-                => "The requested format is not supported in combination with the given texture buffer type",
-            TooLarge
-                => "The size of the buffer that you are trying to bind exceeds `GL_MAX_TEXTURE_BUFFER_SIZE`",
+            NotSupported =>
+                "Buffer textures are not supported at all",
+            FormatNotSupported =>
+                "The requested format is not supported in combination with the given texture buffer type",
+            TooLarge =>
+                "The size of the buffer that you are trying to bind exceeds `GL_MAX_TEXTURE_BUFFER_SIZE`",
         }
     }
 }
@@ -131,10 +131,10 @@ impl Error for CreationError {
     fn description(&self) -> &str {
         use self::CreationError::*;
         match *self {
-            BufferCreationError(_)
-                => "Failed to create the buffer",
-            TextureCreationError(_)
-                => "Failed to create the texture",
+            BufferCreationError(_) =>
+                "Failed to create the buffer",
+            TextureCreationError(_) =>
+                "Failed to create the texture",
         }
     }
 

--- a/src/texture/get_format.rs
+++ b/src/texture/get_format.rs
@@ -3,7 +3,8 @@ use version::Version;
 use version::Api;
 use gl;
 
-use std::mem;
+use std::{ mem, fmt };
+use std::error::Error;
 
 use texture::any::TextureAny;
 use TextureExt;
@@ -14,6 +15,22 @@ use GlObject;
 pub enum GetFormatError {
     /// The backend doesn't support retrieving the internal format.
     NotSupported,
+}
+
+impl fmt::Display for GetFormatError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.description())
+    }
+}
+
+impl Error for GetFormatError {
+    fn description(&self) -> &str {
+        use self::GetFormatError::*;
+        match *self {
+            NotSupported =>
+                "The backend doesn't support retrieving the internal format",
+        }
+    }
 }
 
 /// Internal format of a texture.
@@ -252,7 +269,7 @@ pub fn get_format(ctxt: &mut CommandContext, texture: &TextureAny)
         })
 
     } else {
-        // FIXME: GL2 
+        // FIXME: GL2
         Err(GetFormatError::NotSupported)
     }
 }

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -113,6 +113,8 @@ You can use thousands of textures if you want.
 #![allow(unreachable_code)]     // TODO: remove
 
 use std::borrow::Cow;
+use std::fmt;
+use std::error::Error;
 
 use image_format::FormatNotSupportedError;
 
@@ -606,6 +608,26 @@ pub enum TextureCreationError {
 
     /// The texture format is not supported by the backend.
     TypeNotSupported,
+}
+
+impl fmt::Display for TextureCreationError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.description())
+    }
+}
+
+impl Error for TextureCreationError {
+    fn description(&self) -> &str {
+        use self::TextureCreationError::*;
+        match *self {
+            FormatNotSupported
+                => "The requested format is not supported by the backend",
+            DimensionsNotSupported
+                => "The requested texture dimensions are not supported",
+            TypeNotSupported
+                => "The texture format is not supported by the backend",
+        }
+    }
 }
 
 impl From<FormatNotSupportedError> for TextureCreationError {

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -620,12 +620,12 @@ impl Error for TextureCreationError {
     fn description(&self) -> &str {
         use self::TextureCreationError::*;
         match *self {
-            FormatNotSupported
-                => "The requested format is not supported by the backend",
-            DimensionsNotSupported
-                => "The requested texture dimensions are not supported",
-            TypeNotSupported
-                => "The texture format is not supported by the backend",
+            FormatNotSupported =>
+                "The requested format is not supported by the backend",
+            DimensionsNotSupported =>
+                "The requested texture dimensions are not supported",
+            TypeNotSupported =>
+                "The texture format is not supported by the backend",
         }
     }
 }

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -31,28 +31,25 @@ impl From<BufferCreationError> for CreationError {
 }
 
 impl fmt::Display for CreationError {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            &CreationError::FormatNotSupported => "The vertex format is not supported by the \
-                                                   backend".fmt(formatter),
-            &CreationError::BufferCreationError(error) => error.fmt(formatter),
-        }
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.description())
     }
 }
 
 impl Error for CreationError {
     fn description(&self) -> &str {
-        match self {
-            &CreationError::FormatNotSupported => "The vertex format is not supported by the \
-                                                   backend",
-            &CreationError::BufferCreationError(..) => "Error while creating the vertex buffer",
+        use self::CreationError::*;
+        match *self {
+            FormatNotSupported => "The vertex format is not supported by the backend",
+            BufferCreationError(_) => "Error while creating the vertex buffer",
         }
     }
 
     fn cause(&self) -> Option<&Error> {
-        match self {
-            &CreationError::FormatNotSupported => None,
-            &CreationError::BufferCreationError(ref error) => Some(error),
+        use self::CreationError::*;
+        match *self {
+            BufferCreationError(ref error) => Some(error),
+            FormatNotSupported => None,
         }
     }
 }
@@ -73,10 +70,10 @@ pub struct VertexBufferSlice<'b, T: 'b> where T: Copy {
 impl<'b, T: 'b> VertexBufferSlice<'b, T> where T: Copy + Content {
     /// Creates a marker that instructs glium to use multiple instances.
     ///
-    /// Instead of calling `surface.draw(&vertex_buffer.slice(...).unwrap(), ...)` 
-    /// you can call `surface.draw(vertex_buffer.slice(...).unwrap().per_instance(), ...)`. 
-    /// This will draw one instance of the geometry for each element in this buffer slice. 
-    /// The attributes are still passed to the vertex shader, but each entry is passed 
+    /// Instead of calling `surface.draw(&vertex_buffer.slice(...).unwrap(), ...)`
+    /// you can call `surface.draw(vertex_buffer.slice(...).unwrap().per_instance(), ...)`.
+    /// This will draw one instance of the geometry for each element in this buffer slice.
+    /// The attributes are still passed to the vertex shader, but each entry is passed
     /// for each different instance.
     #[inline]
     pub fn per_instance(&'b self) -> Result<PerInstance, InstancingNotSupported> {

--- a/src/vertex/transform_feedback.rs
+++ b/src/vertex/transform_feedback.rs
@@ -1,4 +1,5 @@
-use std::mem;
+use std::{ mem, fmt };
+use std::error::Error;
 
 use version::Api;
 use version::Version;
@@ -99,9 +100,27 @@ pub struct TransformFeedbackSession<'a> {
 pub enum TransformFeedbackSessionCreationError {
     /// Transform feedback is not supported by the OpenGL implementation.
     NotSupported,
-    
+
     /// The format of the output doesn't match what the program is expected to output.
     WrongVertexFormat,
+}
+
+impl fmt::Display for TransformFeedbackSessionCreationError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.description())
+    }
+}
+
+impl Error for TransformFeedbackSessionCreationError {
+    fn description(&self) -> &str {
+        use self::TransformFeedbackSessionCreationError::*;
+        match *self {
+            NotSupported =>
+                "Transform feedback is not supported by the OpenGL implementation",
+            WrongVertexFormat =>
+                "The format of the output doesn't match what the program is expected to output",
+        }
+    }
 }
 
 /// Returns true if transform feedback is supported by the OpenGL implementation.
@@ -127,10 +146,10 @@ impl<'a> TransformFeedbackSession<'a> {
             return Err(TransformFeedbackSessionCreationError::NotSupported);
         }
 
-        if !program.transform_feedback_matches(&<V as Vertex>::build_bindings(), 
+        if !program.transform_feedback_matches(&<V as Vertex>::build_bindings(),
                                                mem::size_of::<V>())
         {
-            return Err(TransformFeedbackSessionCreationError::WrongVertexFormat); 
+            return Err(TransformFeedbackSessionCreationError::WrongVertexFormat);
         }
 
         Ok(TransformFeedbackSession {


### PR DESCRIPTION
Added Display and Error traits to all Errors

Ref: #959 

- Errors:
    - [x] src/buffer/alloc.rs: ReadError
    - [x] src/buffer/alloc.rs: CopyError
    - [x] src/buffer/mod.rs: BufferCreationError
    - [x] src/ops/read.rs: ReadError
    - [x] src/uniforms/mod.rs: LayoutMismatchError
    - [x] src/index/buffer.rs: CreationError
    - [x] src/texture/buffer_texture.rs: TextureCreationError
    - [x] src/texture/buffer_texture.rs: CreationError
    - [x] src/texture/mod.rs: TextureCreationError
    - [x] src/texture/get_format.rs: GetFormatError
    - [x] src/program/mod.rs: ProgramCreationError
    - [x] src/program/mod.rs: ProgramChooserCreationError
    - [x] src/program/mod.rs: GetBinaryError
    - [x] src/vertex/buffer.rs: CreationError
    - [x] src/vertex/transform_feedback.rs: TransformFeedbackSessionCreationError
    - [x] src/framebuffer/render_buffer.rs: CreationError
    - [x] src/draw_parameters/query.rs: QueryCreationError
    - [x] src/draw_parameters/query.rs: ToBufferError
    - [x] src/image_format.rs: FormatNotSupportedError
    - [x] src/lib.rs: DrawError
    - [x] src/lib.rs: SwapBuffersError
    - [x] src/fbo.rs: ValidationError
