### PR TITLE
Add additional GL context information to capabilities struct

### DIFF
--- a/examples/info.rs
+++ b/examples/info.rs
@@ -1,0 +1,55 @@
+#[macro_use]
+extern crate glium;
+
+fn main() {
+    use glium::{Api, CapabilitiesSource, DisplayBuild, Profile, Version};
+    use glium::backend::Facade;
+    use glium::glutin;
+
+    // building the display, ie. the main object
+    let display = glutin::WindowBuilder::new()
+        .with_visibility(false)
+        .build_glium()
+        .unwrap();
+
+    let version = *display.get_opengl_version();
+    let api = match version {
+        Version(Api::Gl, _, _) => "OpenGL",
+        Version(Api::GlEs, _, _) => "OpenGL ES"
+    };
+
+    let caps = display.get_context().get_capabilities();
+
+    println!("{} context verson: {}", api, caps.version);
+
+    print!("{} context flags:", api);
+    if caps.forward_compatible {
+        print!(" forward-compatible");
+    }
+    if caps.debug {
+        print!(" debug");
+    }
+    if caps.robustness {
+        print!(" robustness");
+    }
+    print!("\n");
+
+    if version >= Version(Api::Gl, 3, 2) {
+        println!("{} profile mask: {}", api,
+                 match caps.profile {
+                     Some(Profile::Core) => "core",
+                     Some(Profile::Compatibility) => "compatibility",
+                     None => "unknown"
+                 });
+    }
+
+    println!("{} robustness strategy: {}", api,
+             if caps.can_lose_context {
+                 "lose"
+             } else {
+                 "none"
+             });
+    
+    println!("{} context renderer: {}", api, caps.renderer);
+    println!("{} context vendor: {}", api, caps.vendor);
+}

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -30,7 +30,7 @@ use texture;
 use uniforms;
 use vertex_array_object;
 
-pub use self::capabilities::{ReleaseBehavior, Capabilities};
+pub use self::capabilities::{ReleaseBehavior, Capabilities, Profile};
 pub use self::extensions::ExtensionsList;
 pub use self::state::GlState;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ extern crate smallvec;
 
 #[cfg(feature = "glutin")]
 pub use backend::glutin_backend::glutin;
+pub use context::Profile;
 pub use draw_parameters::{Blend, BlendingFunction, LinearBlendingFactor, BackfaceCullingMode};
 pub use draw_parameters::{Depth, DepthTest, PolygonMode, DrawParameters, StencilTest, StencilOperation};
 pub use draw_parameters::{Smooth};


### PR DESCRIPTION
Also added info example which outputs context information based on GLFW's glfwinfo test. Example output looks like:

```
OpenGL context verson: 4.3.0 - Build 10.18.15.4256
OpenGL context flags: debug
OpenGL profile mask: compatibility
OpenGL robustness strategy: none
OpenGL context renderer: Intel(R) HD Graphics 4600
OpenGL context vendor: Intel
```

