### PR TITLE
Add dimensions-related functions to texture types

### DIFF
--- a/build/textures.rs
+++ b/build/textures.rs
@@ -1440,4 +1440,36 @@ fn write_dimensions_getters<W: Write>(mut dest: &mut W, dimensions: TextureDimen
         },
         _ => ()
     };
+
+    match dimensions {
+        TextureDimensions::Texture2d | TextureDimensions::Texture2dMultisample |
+        TextureDimensions::Texture2dArray | TextureDimensions::Texture2dMultisampleArray => {
+            writeln!(dest, r#"
+                /// Returns the width and height of that image.
+                #[inline]
+                pub fn dimensions(&self) -> (u32, u32) {{
+                    (self.width(), self.height())
+                }}
+            "#).unwrap();
+        },
+        TextureDimensions::Texture3d => {
+            writeln!(dest, r#"
+                /// Returns the width, height and depth of that image.
+                #[inline]
+                pub fn dimensions(&self) -> (u32, u32, u32) {{
+                    (self.width(), self.height(), self.depth())
+                }}
+            "#).unwrap();
+        },
+        TextureDimensions::Cubemap | TextureDimensions::CubemapArray => {
+            writeln!(dest, r#"
+                /// Returns the dimension of that image.
+                #[inline]
+                pub fn dimensions(&self) -> u32 {{
+                    self.width()
+                }}
+            "#).unwrap();
+        },
+        _ => ()
+    };
 }

--- a/src/texture/any.rs
+++ b/src/texture/any.rs
@@ -877,6 +877,12 @@ impl<'a> TextureAnyMipmap<'a> {
         })
     }
 
+    /// Returns the array size of the texture.
+    #[inline]
+    pub fn get_array_size(&self) -> Option<u32> {
+        self.texture.get_array_size()
+    }
+
     /// Uploads data to the texture from a buffer.
     ///
     /// # Panic

--- a/src/texture/any.rs
+++ b/src/texture/any.rs
@@ -552,6 +552,12 @@ impl TextureAny {
         }
     }
 
+    /// Returns the dimensions of the texture.
+    #[inline]
+    pub fn dimensions(&self) -> Dimensions {
+        self.ty.clone()
+    }
+
     /// Returns the array size of the texture.
     #[inline]
     pub fn get_array_size(&self) -> Option<u32> {


### PR DESCRIPTION
For example adds `height()` to `Texture2d`.

Before this PR, you could get the height of a 2D texture with `get_height().unwrap()`. `get_height` comes from the deref to `TextureAny`.
This PR adds proper methods that don't return an `Option`.

This ultimate goal is to remove the `Deref` to `TextureAny` (replace it with `AsRef` for example).
