### PR TITLE
Subroutines

### DIFF
--- a/examples/subroutines.rs
+++ b/examples/subroutines.rs
@@ -91,7 +91,7 @@ fn main() {
     let mut i = 0;
     // the main loop
     support::start_loop(|| {
-
+        if i == 120 { i = 0; }
         let subroutine = if i % 120 < 40 {
             "ColorYellow"
         } else if i % 120 < 80{

--- a/examples/subroutines.rs
+++ b/examples/subroutines.rs
@@ -56,7 +56,6 @@ fn main() {
             fragment: "
                 #version 330
                 #extension GL_ARB_shader_subroutine : require
-                #extension GL_ARB_explicit_uniform_location : require
 
                 out vec4 fragColor;
                 subroutine vec4 color_t();

--- a/examples/subroutines.rs
+++ b/examples/subroutines.rs
@@ -1,0 +1,120 @@
+#[macro_use]
+extern crate glium;
+
+mod support;
+
+use glium::Surface;
+use glium::glutin;
+use glium::index::PrimitiveType;
+
+fn main() {
+    use glium::DisplayBuild;
+
+    // building the display, ie. the main object
+    let display = glutin::WindowBuilder::new()
+        .build_glium()
+        .unwrap();
+
+    // building the vertex buffer, which contains all the vertices that we will draw
+    let vertex_buffer = {
+        #[derive(Copy, Clone)]
+        struct Vertex {
+            position: [f32; 2],
+        }
+
+        implement_vertex!(Vertex, position);
+
+        glium::VertexBuffer::new(&display,
+            &[
+                Vertex { position: [-0.5, -0.5] },
+                Vertex { position: [ 0.0,  0.5] },
+                Vertex { position: [ 0.5, -0.5] },
+            ]
+        ).unwrap()
+    };
+
+    // building the index buffer
+    let index_buffer = glium::IndexBuffer::new(&display, PrimitiveType::TrianglesList,
+                                               &[0u16, 1, 2]).unwrap();
+
+    // compiling shaders and linking them together
+    let program = program!(&display,
+        330 => {
+            vertex: "
+                #version 330
+
+                uniform mat4 matrix;
+
+                in vec2 position;
+
+                void main() {
+                    gl_Position = vec4(position, 0.0, 1.0) * matrix;
+                }
+            ",
+
+            fragment: "
+                #version 330
+                #extension GL_ARB_shader_subroutine : require
+                #extension GL_ARB_explicit_uniform_location : require
+
+                out vec4 fragColor;
+                subroutine vec4 color_t();
+
+                layout(location = 5) subroutine uniform color_t Color;
+
+                subroutine(color_t)
+                vec4 ColorRed()
+                {
+                  return vec4(1, 0, 0, 1);
+                }
+
+                subroutine(color_t)
+                vec4 ColorBlue()
+                {
+                  return vec4(0, 0.4, 1, 1);
+                }
+
+                subroutine(color_t)
+                vec4 ColorYellow()
+                {
+                  return vec4(1, 1, 0, 1);
+                }
+
+                void main()
+                {
+                    fragColor = Color();
+                }
+            "
+        },
+    ).unwrap();
+
+    println!("{:#?}", program.get_subroutine_data());
+    // the main loop
+    support::start_loop(|| {
+        // building the uniforms
+        let uniforms = uniform! {
+            matrix: [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0f32]
+            ]
+        };
+
+        // drawing a frame
+        let mut target = display.draw();
+        target.clear_color(0.0, 0.0, 0.0, 0.0);
+        target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &Default::default()).unwrap();
+        target.finish().unwrap();
+
+        // polling and handling the events received by the window
+        for event in display.poll_events() {
+            match event {
+                glutin::Event::Closed => return support::Action::Stop,
+                _ => ()
+            }
+        }
+
+        support::Action::Continue
+    });
+}

--- a/examples/subroutines.rs
+++ b/examples/subroutines.rs
@@ -6,6 +6,7 @@ mod support;
 use glium::Surface;
 use glium::glutin;
 use glium::index::PrimitiveType;
+use glium::program::ShaderStage;
 
 fn main() {
     use glium::DisplayBuild;
@@ -60,7 +61,7 @@ fn main() {
                 out vec4 fragColor;
                 subroutine vec4 color_t();
 
-                layout(location = 5) subroutine uniform color_t Color;
+                subroutine uniform color_t Color;
 
                 subroutine(color_t)
                 vec4 ColorRed()
@@ -88,9 +89,18 @@ fn main() {
         },
     ).unwrap();
 
-    println!("{:#?}", program.get_subroutine_data());
+    let mut i = 0;
     // the main loop
     support::start_loop(|| {
+
+        let subroutine = if i % 120 < 40 {
+            "ColorYellow"
+        } else if i % 120 < 80{
+            "ColorBlue"
+        } else {
+            "ColorRed"
+        };
+
         // building the uniforms
         let uniforms = uniform! {
             matrix: [
@@ -98,7 +108,8 @@ fn main() {
                 [0.0, 1.0, 0.0, 0.0],
                 [0.0, 0.0, 1.0, 0.0],
                 [0.0, 0.0, 0.0, 1.0f32]
-            ]
+            ],
+            Color: (subroutine, ShaderStage::Fragment)
         };
 
         // drawing a frame
@@ -114,7 +125,7 @@ fn main() {
                 _ => ()
             }
         }
-
+        i += 1;
         support::Action::Continue
     });
 }

--- a/src/context/extensions.rs
+++ b/src/context/extensions.rs
@@ -94,6 +94,7 @@ extensions! {
     "GL_ARB_shader_image_load_store" => gl_arb_shader_image_load_store,
     "GL_ARB_shader_objects" => gl_arb_shader_objects,
     "GL_ARB_shader_storage_buffer_object" => gl_arb_shader_storage_buffer_object,
+    "GL_ARB_shader_subroutine" => gl_arb_shader_subroutine,
     "GL_ARB_sync" => gl_arb_sync,
     "GL_ARB_tessellation_shader" => gl_arb_tessellation_shader,
     "GL_ARB_texture_buffer_object" => gl_arb_texture_buffer_object,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,11 +293,18 @@ trait ProgramExt {
                                         block_location: gl::types::GLuint,
                                         value: gl::types::GLuint);
 
+    /// Changes the subroutine uniform bindings of a program.
+    fn set_subroutine_uniforms_for_stage(&self, ctxt: &mut context::CommandContext,
+                                         stage: program::ShaderStage,
+                                         indices: &[gl::types::GLuint]);
+
     fn get_uniform(&self, name: &str) -> Option<&program::Uniform>;
 
     fn get_uniform_blocks(&self) -> &HashMap<String, program::UniformBlock>;
 
     fn get_shader_storage_blocks(&self) -> &HashMap<String, program::UniformBlock>;
+
+    fn get_subroutine_data(&self) -> &program::SubroutineData;
 }
 
 /// Internal trait for queries.
@@ -860,6 +867,31 @@ pub enum DrawError {
         err: uniforms::LayoutMismatchError,
     },
 
+    /// Tried to bind a subroutine uniform like a regular uniform value.
+    SubroutineUniformToValue {
+        /// Name of the uniform you are trying to bind.
+        name: String,
+    },
+
+    /// Not all subroutine uniforms of a shader stage were set.
+    SubroutineUniformMissing {
+        /// Shader stage with missing bindings.
+        stage: program::ShaderStage,
+        /// The expected number of bindings.
+        expected_count: usize,
+        /// The number of bindings defined by the user.
+        real_count: usize,
+
+    },
+
+    /// A non-existant subroutine was referenced.
+    SubroutineNotFound {
+        /// The stage the subroutine was searched for.
+        stage: program::ShaderStage,
+        /// The invalid name of the subroutine.
+        name: String
+    },
+
     /// The number of vertices per patch that has been requested is not supported.
     UnsupportedVerticesPerPatch,
 
@@ -922,6 +954,12 @@ impl Error for DrawError {
                 "Tried to bind a single uniform value to a uniform block",
             UniformBlockLayoutMismatch { .. } =>
                 "The layout of the content of the uniform buffer does not match the layout of the block",
+            SubroutineUniformToValue { .. } =>
+                "Tried to bind a subroutine uniform like a regular uniform value",
+            SubroutineUniformMissing { .. } =>
+                "Not all subroutine uniforms of a shader stage were set",
+            SubroutineNotFound { .. } =>
+                "A non-existant subroutine was referenced",
             UnsupportedVerticesPerPatch =>
                 "The number of vertices per patch that has been requested is not supported",
             TessellationNotSupported =>

--- a/src/program/binary_header.rs
+++ b/src/program/binary_header.rs
@@ -1,0 +1,37 @@
+use program::raw::RawProgram;
+
+
+const MASK_HAS_TESS_EVAL: u8 = 0b00000001;
+const MASK_HAS_TESS_CONTROL: u8 = 0b00000010;
+const MASK_HAS_GEOMETRY: u8 = 0b00000100;
+
+/// Glium attaches internal information to a binary to be able to fully restore the program.
+pub fn attach_glium_header(raw: &RawProgram, data: &mut Vec<u8>) {
+    let mut header_byte = 0u8;
+    if raw.has_tessellation_evaluation_shader() {
+        header_byte = header_byte ^ MASK_HAS_TESS_EVAL;
+    }
+    if raw.has_tessellation_control_shader() {
+        header_byte = header_byte ^ MASK_HAS_TESS_CONTROL;
+    }
+    if raw.has_geometry_shader() {
+        header_byte = header_byte ^ MASK_HAS_GEOMETRY;
+    }
+    // TODO kind of inefficient.
+    data.reserve(1);
+    data.insert(0, header_byte);
+}
+
+/// Reads the first byte of the data (=glium header) and returns the corresponding shader flags.
+/// If the header is not valid, returns None.
+pub fn process_glium_header(data: &[u8]) -> Option<(bool, bool, bool)> {
+    let header_byte = data[0];
+    if header_byte >> 3 == 0 {
+        let has_geometry_shader =                (header_byte & MASK_HAS_GEOMETRY) != 0;
+        let has_tessellation_control_shader =    (header_byte & MASK_HAS_TESS_CONTROL) != 0;
+        let has_tessellation_evaluation_shader = (header_byte & MASK_HAS_TESS_EVAL) != 0;
+        Some((has_geometry_shader, has_tessellation_control_shader, has_tessellation_evaluation_shader))
+    } else {
+        None
+    }
+}

--- a/src/program/compute.rs
+++ b/src/program/compute.rs
@@ -47,7 +47,7 @@ impl ComputeShader {
         let shader = try!(build_shader(facade, gl::COMPUTE_SHADER, src));
 
         Ok(ComputeShader {
-            raw: try!(RawProgram::from_shaders(facade, &[shader], false, false, None))
+            raw: try!(RawProgram::from_shaders(facade, &[shader], false, false, false, None))
         })
     }
 

--- a/src/program/compute.rs
+++ b/src/program/compute.rs
@@ -17,6 +17,7 @@ use RawUniformValue;
 use program::{COMPILER_GLOBAL_LOCK, ProgramCreationError, Binary, GetBinaryError};
 
 use program::reflection::{Uniform, UniformBlock};
+use program::reflection::{ShaderStage, SubroutineData};
 use program::shader::{build_shader, check_shader_type_compatibility};
 
 use program::raw::RawProgram;
@@ -96,7 +97,7 @@ impl ComputeShader {
     pub fn get_uniform(&self, name: &str) -> Option<&Uniform> {
         self.raw.get_uniform(name)
     }
-    
+
     /// Returns an iterator to the list of uniforms.
     ///
     /// ## Example
@@ -111,7 +112,7 @@ impl ComputeShader {
     pub fn uniforms(&self) -> hash_map::Iter<String, Uniform> {
         self.raw.uniforms()
     }
-    
+
     /// Returns a list of uniform blocks.
     ///
     /// ## Example
@@ -188,6 +189,14 @@ impl ProgramExt for ComputeShader {
     }
 
     #[inline]
+    fn set_subroutine_uniforms_for_stage(&self, ctxt: &mut CommandContext,
+                                         stage: ShaderStage,
+                                         indices: &[gl::types::GLuint])
+    {
+        self.raw.set_subroutine_uniforms_for_stage(ctxt, stage, indices);
+    }
+
+    #[inline]
     fn get_uniform(&self, name: &str) -> Option<&Uniform> {
         self.raw.get_uniform(name)
     }
@@ -200,6 +209,11 @@ impl ProgramExt for ComputeShader {
     #[inline]
     fn get_shader_storage_blocks(&self) -> &HashMap<String, UniformBlock> {
         self.raw.get_shader_storage_blocks()
+    }
+
+    #[inline]
+    fn get_subroutine_data(&self) -> &SubroutineData {
+        self.raw.get_subroutine_data()
     }
 }
 

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -39,6 +39,12 @@ pub fn is_binary_supported<C>(ctxt: &C) -> bool where C: CapabilitiesSource {
         || ctxt.get_extensions().gl_arb_get_programy_binary
 }
 
+/// Returns true if the backend supports shader subroutines.
+#[inline]
+pub fn is_subroutine_supported<C>(ctxt: &C) -> bool where C: CapabilitiesSource {
+    ctxt.get_version() >= &Version(Api::Gl, 4, 0) || ctxt.get_extensions().gl_arb_shader_subroutine
+}
+
 /// Some shader compilers have race-condition issues, so we lock this mutex
 /// in the GL thread every time we compile a shader or link a program.
 // TODO: replace by a StaticMutex

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -19,6 +19,7 @@ mod raw;
 mod reflection;
 mod shader;
 mod uniforms_storage;
+mod binary_header;
 
 /// Returns true if the backend supports geometry shaders.
 #[inline]
@@ -76,6 +77,9 @@ pub enum ProgramCreationError {
     /// You have requested point size setting from the shader, but it's not
     /// supported by the backend.
     PointSizeNotSupported,
+
+    /// The glium-specific binary header was not found or is corrupt.
+    BinaryHeaderError,
 }
 
 impl fmt::Display for ProgramCreationError {
@@ -108,6 +112,8 @@ impl Error for ProgramCreationError {
                 "Transform feedback is not supported by the backend.",
             PointSizeNotSupported =>
                 "Point size is not supported by the backend.",
+            BinaryHeaderError =>
+                "The glium-specific binary header was not found or is corrupt.",
         }
     }
 }
@@ -160,6 +166,8 @@ impl From<ProgramCreationError> for ProgramChooserCreationError {
 pub enum GetBinaryError {
     /// The backend doesn't support binary.
     NotSupported,
+    /// The backend does not supply any binary formats.
+    NoFormats,
 }
 
 impl fmt::Display for GetBinaryError {
@@ -173,6 +181,7 @@ impl Error for GetBinaryError {
         use self::GetBinaryError::*;
         match *self {
             NotSupported => "The backend doesn't support binary",
+            NoFormats => "The backend does not supply any binary formats.",
         }
     }
 }

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -11,6 +11,7 @@ pub use self::compute::{ComputeShader, ComputeCommand};
 pub use self::program::Program;
 pub use self::reflection::{Uniform, UniformBlock, BlockLayout, OutputPrimitives};
 pub use self::reflection::{Attribute, TransformFeedbackVarying, TransformFeedbackBuffer, TransformFeedbackMode};
+pub use self::reflection::{ShaderStage, SubroutineData, SubroutineUniform};
 
 mod compute;
 mod program;

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -49,7 +49,8 @@ impl Program {
                                                outputs_srgb, uses_point_size } =>
             {
                 let mut has_geometry_shader = false;
-                let mut has_tessellation_shaders = false;
+                let mut has_tessellation_control_shader = false;
+                let mut has_tessellation_evaluation_shader = false;
 
                 let mut shaders = vec![
                     (vertex_shader, gl::VERTEX_SHADER),
@@ -63,12 +64,12 @@ impl Program {
 
                 if let Some(ts) = tessellation_control_shader {
                     shaders.push((ts, gl::TESS_CONTROL_SHADER));
-                    has_tessellation_shaders = true;
+                    has_tessellation_control_shader = true;
                 }
 
                 if let Some(ts) = tessellation_evaluation_shader {
                     shaders.push((ts, gl::TESS_EVALUATION_SHADER));
-                    has_tessellation_shaders = true;
+                    has_tessellation_evaluation_shader = true;
                 }
 
                 // TODO: move somewhere else
@@ -94,7 +95,8 @@ impl Program {
                 };
 
                 (try!(RawProgram::from_shaders(facade, &shaders_store, has_geometry_shader,
-                                               has_tessellation_shaders, transform_feedback_varyings)),
+                                               has_tessellation_control_shader, has_tessellation_evaluation_shader,
+                                               transform_feedback_varyings)),
                  outputs_srgb, uses_point_size)
             },
 
@@ -239,6 +241,24 @@ impl Program {
     #[inline]
     pub fn has_tessellation_shaders(&self) -> bool {
         self.raw.has_tessellation_shaders()
+    }
+
+    /// Returns true if the program contains a tessellation control stage.
+    #[inline]
+    pub fn has_tessellation_control_shader(&self) -> bool {
+        self.raw.has_tessellation_control_shader()
+    }
+
+    /// Returns true if the program contains a tessellation evaluation stage.
+    #[inline]
+    pub fn has_tessellation_evaluation_shader(&self) -> bool {
+        self.raw.has_tessellation_evaluation_shader()
+    }
+
+    /// Returns true if the program contains a geometry shader.
+    #[inline]
+    pub fn has_geometry_shader(&self) -> bool {
+        self.raw.has_geometry_shader()
     }
 
     /// Returns informations about an attribute, if it exists.

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -21,6 +21,7 @@ use program::GetBinaryError;
 
 use program::reflection::{Uniform, UniformBlock, OutputPrimitives};
 use program::reflection::{Attribute, TransformFeedbackBuffer};
+use program::reflection::{SubroutineData};
 use program::shader::build_shader;
 
 use program::raw::RawProgram;
@@ -105,7 +106,6 @@ impl Program {
                 (try!(RawProgram::from_binary(facade, data)), outputs_srgb, uses_point_size)
             },
         };
-        println!("{:?}", raw.get_subroutine_data());
         Ok(Program {
             raw: raw,
             outputs_srgb: outputs_srgb,
@@ -290,6 +290,12 @@ impl Program {
     #[inline]
     pub fn uses_point_size(&self) -> bool {
       self.uses_point_size
+    }
+
+    /// Returns data associated with the programs subroutines.
+    #[inline]
+    pub fn get_subroutine_data(&self) -> &Option<SubroutineData> {
+        &self.raw.get_subroutine_data()
     }
 }
 

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -105,7 +105,7 @@ impl Program {
                 (try!(RawProgram::from_binary(facade, data)), outputs_srgb, uses_point_size)
             },
         };
-
+        println!("{:?}", raw.get_subroutine_data());
         Ok(Program {
             raw: raw,
             outputs_srgb: outputs_srgb,
@@ -179,7 +179,7 @@ impl Program {
     pub fn get_uniform(&self, name: &str) -> Option<&Uniform> {
         self.raw.get_uniform(name)
     }
-    
+
     /// Returns an iterator to the list of uniforms.
     ///
     /// ## Example
@@ -194,7 +194,7 @@ impl Program {
     pub fn uniforms(&self) -> hash_map::Iter<String, Uniform> {
         self.raw.uniforms()
     }
-    
+
     /// Returns a list of uniform blocks.
     ///
     /// ## Example
@@ -267,7 +267,7 @@ impl Program {
     pub fn has_srgb_output(&self) -> bool {
         self.outputs_srgb
     }
-    
+
     /// Returns the list of shader storage blocks.
     ///
     /// ## Example

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -21,7 +21,7 @@ use program::GetBinaryError;
 
 use program::reflection::{Uniform, UniformBlock, OutputPrimitives};
 use program::reflection::{Attribute, TransformFeedbackBuffer};
-use program::reflection::{SubroutineData};
+use program::reflection::{SubroutineData, ShaderStage};
 use program::shader::build_shader;
 
 use program::raw::RawProgram;
@@ -291,12 +291,6 @@ impl Program {
     pub fn uses_point_size(&self) -> bool {
       self.uses_point_size
     }
-
-    /// Returns data associated with the programs subroutines.
-    #[inline]
-    pub fn get_subroutine_data(&self) -> &Option<SubroutineData> {
-        &self.raw.get_subroutine_data()
-    }
 }
 
 impl fmt::Debug for Program {
@@ -364,6 +358,14 @@ impl ProgramExt for Program {
     }
 
     #[inline]
+    fn set_subroutine_uniforms_for_stage(&self, ctxt: &mut CommandContext,
+                                         stage: ShaderStage,
+                                         indices: &[gl::types::GLuint])
+    {
+        self.raw.set_subroutine_uniforms_for_stage(ctxt, stage, indices);
+    }
+
+    #[inline]
     fn get_uniform(&self, name: &str) -> Option<&Uniform> {
         self.raw.get_uniform(name)
     }
@@ -376,5 +378,10 @@ impl ProgramExt for Program {
     #[inline]
     fn get_shader_storage_blocks(&self) -> &HashMap<String, UniformBlock> {
         self.raw.get_shader_storage_blocks()
+    }
+
+    #[inline]
+    fn get_subroutine_data(&self) -> &SubroutineData {
+        self.raw.get_subroutine_data()
     }
 }

--- a/src/program/raw.rs
+++ b/src/program/raw.rs
@@ -443,6 +443,7 @@ impl RawProgram {
         &self.ssbos
     }
 
+    /// Returns data associated with the programs subroutines.
     #[inline]
     pub fn get_subroutine_data(&self) -> &Option<SubroutineData> {
         &self.subroutine_data

--- a/src/program/raw.rs
+++ b/src/program/raw.rs
@@ -54,7 +54,7 @@ pub struct RawProgram {
     uniform_values: UniformsStorage,
     uniforms: HashMap<String, Uniform>,
     uniform_blocks: HashMap<String, UniformBlock>,
-    subroutine_data: Option<SubroutineData>,
+    subroutine_data: SubroutineData,
     attributes: HashMap<String, Attribute>,
     frag_data_locations: RefCell<HashMap<String, Option<u32>>>,
     tf_buffers: Vec<TransformFeedbackBuffer>,
@@ -445,7 +445,7 @@ impl RawProgram {
 
     /// Returns data associated with the programs subroutines.
     #[inline]
-    pub fn get_subroutine_data(&self) -> &Option<SubroutineData> {
+    pub fn get_subroutine_data(&self) -> &SubroutineData {
         &self.subroutine_data
     }
 
@@ -583,6 +583,14 @@ impl ProgramExt for RawProgram {
     }
 
     #[inline]
+    fn set_subroutine_uniforms_for_stage(&self, ctxt: &mut CommandContext,
+                                         stage: ShaderStage,
+                                         indices: &[gl::types::GLuint])
+    {
+        self.uniform_values.set_subroutine_uniforms_for_stage(ctxt, self.id, stage, indices);
+    }
+
+    #[inline]
     fn get_uniform(&self, name: &str) -> Option<&Uniform> {
         self.uniforms.get(name)
     }
@@ -595,6 +603,11 @@ impl ProgramExt for RawProgram {
     #[inline]
     fn get_shader_storage_blocks(&self) -> &HashMap<String, UniformBlock> {
         &self.ssbos
+    }
+
+    #[inline]
+    fn get_subroutine_data(&self) -> &SubroutineData {
+        &self.subroutine_data
     }
 }
 

--- a/src/program/reflection.rs
+++ b/src/program/reflection.rs
@@ -1031,7 +1031,7 @@ pub struct SubroutineData {
     pub subroutine_uniforms: HashMap<(String, ShaderStage), SubroutineUniform>,
 }
 
-/// Information about a Subroutine Uniform (except name and shaderstage)
+/// Information about a Subroutine Uniform (except name)
 #[derive(Debug, Clone)]
 pub struct SubroutineUniform {
 
@@ -1057,6 +1057,8 @@ pub struct Subroutine {
     pub name: String,
 }
 
+/// The different stages of the program pipeline.
+#[allow(missing_docs)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ShaderStage {
     Vertex,
@@ -1070,6 +1072,7 @@ pub enum ShaderStage {
 }
 
 impl ShaderStage {
+    /// Converts the `ShaderStage` to its GLenum equivalent
     pub fn to_gl_enum(&self) -> gl::types::GLenum {
         match *self {
             ShaderStage::Vertex => gl::VERTEX_SHADER,
@@ -1095,17 +1098,22 @@ fn get_supported_shader_stages(ctxt: &mut CommandContext) -> Vec<ShaderStage> {
 }
 
 /// Returns the data associated with a programs subroutines.
-/// Returns `None` if subroutines are not supported by the backend.
 pub unsafe fn reflect_subroutine_data(ctxt: &mut CommandContext, program: Handle)
-                               -> Option<SubroutineData>
+                               -> SubroutineData
 {
     if !ctxt.extensions.gl_arb_shader_subroutine {
-        return None
+        return SubroutineData {
+            location_counts: HashMap::with_capacity(0),
+            subroutine_uniforms: HashMap::with_capacity(0),
+        }
     }
 
     let program = match program {
         // subroutines not supported.
-        Handle::Handle(_) => return None,
+        Handle::Handle(_) => return SubroutineData {
+            location_counts: HashMap::with_capacity(0),
+            subroutine_uniforms: HashMap::with_capacity(0),
+        },
         Handle::Id(id) => id
     };
 
@@ -1166,8 +1174,8 @@ pub unsafe fn reflect_subroutine_data(ctxt: &mut CommandContext, program: Handle
             subroutine_uniforms.insert((uniform_name, *stage), subroutine_uniform);
         }
     }
-    Some(SubroutineData {
+    SubroutineData {
         location_counts: location_counts,
         subroutine_uniforms: subroutine_uniforms
-    })
+    }
 }

--- a/src/program/reflection.rs
+++ b/src/program/reflection.rs
@@ -1017,3 +1017,157 @@ fn glenum_to_transform_feedback_mode(value: gl::types::GLenum) -> TransformFeedb
         v => panic!("Unknown value returned by OpenGL varying mode: {}", v)
     }
 }
+
+/// Contains all subroutine data of a program.
+#[derive(Debug, Clone)]
+pub struct SubroutineData {
+    /// Number of subroutine uniform locations per shader stage.
+    /// This is *not* equal to the number of subroutine uniforms per stage,
+    /// because users can use `#layout(location=...)`.
+    pub location_counts: HashMap<ShaderStage, usize>,
+
+    /// The list of all subroutine uniforms of the program stored in a structured way to enable fast lookups.
+    /// A subroutine uniform is uniquely defined by a name and a shader stage.
+    pub subroutine_uniforms: HashMap<(String, ShaderStage), SubroutineUniform>,
+}
+
+/// Information about a Subroutine Uniform (except name and shaderstage)
+#[derive(Debug, Clone)]
+pub struct SubroutineUniform {
+
+    /// The index of the subroutine uniform.
+    /// Needed to query information from the OpenGL backend.
+    pub index: u32,
+
+    /// The location of the uniform.
+    /// This is used to bind subroutines to this subroutine uniform.
+    pub location: i32,
+
+    /// A list of subroutines that can potentially be used with this uniform.
+    pub compatible_subroutines: Vec<Subroutine>,
+}
+
+/// Information about a subroutine.
+#[derive(Debug, Clone)]
+pub struct Subroutine {
+    /// The index of the subroutine, needed to bind this to a subroutine uniform.
+    pub index: u32,
+
+    /// The name of the subroutine.
+    pub name: String,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum ShaderStage {
+    Vertex,
+    Fragment,
+    TessellationControl,
+    TessellationEvaluation,
+    Geometry,
+    // FIXME? According to https://www.opengl.org/sdk/docs/man/html/glUniformSubroutines.xhtml ,
+    // compute shaders are not supported.
+    // Compute,
+}
+
+impl ShaderStage {
+    pub fn to_gl_enum(&self) -> gl::types::GLenum {
+        match *self {
+            ShaderStage::Vertex => gl::VERTEX_SHADER,
+            ShaderStage::Fragment => gl::FRAGMENT_SHADER,
+            ShaderStage::TessellationControl => gl::TESS_CONTROL_SHADER,
+            ShaderStage::TessellationEvaluation => gl::TESS_EVALUATION_SHADER,
+            ShaderStage::Geometry => gl::GEOMETRY_SHADER,
+            // Compute => gl::COMPUTE_SHADER,
+        }
+    }
+}
+
+fn get_supported_shader_stages(ctxt: &mut CommandContext) -> Vec<ShaderStage> {
+    let mut stages = vec![ShaderStage::Vertex, ShaderStage::Fragment];
+    if ctxt.extensions.gl_arb_tessellation_shader {
+        stages.push(ShaderStage::TessellationControl);
+        stages.push(ShaderStage::TessellationEvaluation);
+    }
+    if ctxt.extensions.gl_arb_geometry_shader4 {
+        stages.push(ShaderStage::Geometry);
+    }
+    stages
+}
+
+/// Returns the data associated with a programs subroutines.
+/// Returns `None` if subroutines are not supported by the backend.
+pub unsafe fn reflect_subroutine_data(ctxt: &mut CommandContext, program: Handle)
+                               -> Option<SubroutineData>
+{
+    if !ctxt.extensions.gl_arb_shader_subroutine {
+        return None
+    }
+
+    let program = match program {
+        // subroutines not supported.
+        Handle::Handle(_) => return None,
+        Handle::Id(id) => id
+    };
+
+    let shader_stages = get_supported_shader_stages(ctxt);
+    let mut subroutine_uniforms = HashMap::new();
+    let mut location_counts = HashMap::new();
+    for stage in shader_stages.iter() {
+        let mut location_count: gl::types::GLint = mem::uninitialized();
+        ctxt.gl.GetProgramStageiv(program, stage.to_gl_enum(), gl::ACTIVE_SUBROUTINE_UNIFORM_LOCATIONS, &mut location_count);
+        location_counts.insert(*stage, location_count as usize);
+
+        let mut subroutine_count: gl::types::GLint = mem::uninitialized();
+        ctxt.gl.GetProgramStageiv(program, stage.to_gl_enum(), gl::ACTIVE_SUBROUTINE_UNIFORMS, &mut subroutine_count);
+        for i in 0..subroutine_count {
+            // Get the name of the uniform
+            let mut uniform_name_tmp: Vec<u8> = vec![0; 64];
+            let mut name_len: gl::types::GLsizei = mem::uninitialized();
+            ctxt.gl.GetActiveSubroutineUniformName(program, stage.to_gl_enum(), i as u32, uniform_name_tmp.len() as i32,
+                                                   &mut name_len, uniform_name_tmp.as_mut_ptr() as *mut gl::types::GLchar);
+            uniform_name_tmp.set_len(name_len as usize);
+            // Get the location of the uniform
+            // TODO Not sure if this is completely correct. Do we have to append '\0' ?
+            let location = ctxt.gl.GetSubroutineUniformLocation(program, stage.to_gl_enum(), uniform_name_tmp.as_ptr() as *const gl::types::GLchar);
+
+            let uniform_name = String::from_utf8(uniform_name_tmp).unwrap();
+
+            // Get the number of compatible subroutines.
+            let mut compatible_count: gl::types::GLint = mem::uninitialized();
+            ctxt.gl.GetActiveSubroutineUniformiv(program, stage.to_gl_enum(), i as u32, gl::NUM_COMPATIBLE_SUBROUTINES, &mut compatible_count);
+
+            // Get the indices of compatible subroutines.
+            let mut compatible_sr_indices: Vec<gl::types::GLuint> = Vec::with_capacity(compatible_count as usize);
+            ctxt.gl.GetActiveSubroutineUniformiv(program, stage.to_gl_enum(), i as u32, gl::COMPATIBLE_SUBROUTINES,
+                                                 compatible_sr_indices.as_mut_ptr() as *mut gl::types::GLint);
+            compatible_sr_indices.set_len(compatible_count as usize);
+            let mut compatible_subroutines: Vec<Subroutine> = Vec::new();
+            for j in 0..compatible_count {
+                // Get the names of compatible subroutines.
+                let mut subroutine_name_tmp: Vec<u8> = vec![0; 64];;
+                let mut name_len: gl::types::GLsizei = mem::uninitialized();
+                ctxt.gl.GetActiveSubroutineName(program, stage.to_gl_enum(), compatible_sr_indices[j as usize], subroutine_name_tmp.len() as i32,
+                                                &mut name_len, subroutine_name_tmp.as_mut_ptr() as *mut gl::types::GLchar);
+                subroutine_name_tmp.set_len(name_len as usize);
+                let subroutine_name = String::from_utf8(subroutine_name_tmp).unwrap();
+                compatible_subroutines.push(
+                    Subroutine {
+                        index: compatible_sr_indices[j as usize],
+                        name: subroutine_name,
+                    }
+                );
+            }
+
+            let subroutine_uniform = SubroutineUniform {
+                index: i as u32,
+                location: location,
+                compatible_subroutines: compatible_subroutines,
+            };
+            subroutine_uniforms.insert((uniform_name, *stage), subroutine_uniform);
+        }
+    }
+    Some(SubroutineData {
+        location_counts: location_counts,
+        subroutine_uniforms: subroutine_uniforms
+    })
+}

--- a/src/program/reflection.rs
+++ b/src/program/reflection.rs
@@ -1124,14 +1124,13 @@ pub unsafe fn reflect_subroutine_data(ctxt: &mut CommandContext, program: Handle
         let mut location_count: gl::types::GLint = mem::uninitialized();
         ctxt.gl.GetProgramStageiv(program, stage.to_gl_enum(), gl::ACTIVE_SUBROUTINE_UNIFORM_LOCATIONS, &mut location_count);
         location_counts.insert(*stage, location_count as usize);
-
         let mut subroutine_count: gl::types::GLint = mem::uninitialized();
         ctxt.gl.GetProgramStageiv(program, stage.to_gl_enum(), gl::ACTIVE_SUBROUTINE_UNIFORMS, &mut subroutine_count);
         for i in 0..subroutine_count {
             // Get the name of the uniform
             let mut uniform_name_tmp: Vec<u8> = vec![0; 64];
             let mut name_len: gl::types::GLsizei = mem::uninitialized();
-            ctxt.gl.GetActiveSubroutineUniformName(program, stage.to_gl_enum(), i as u32, uniform_name_tmp.len() as i32,
+            ctxt.gl.GetActiveSubroutineUniformName(program, stage.to_gl_enum(), i as gl::types::GLuint, uniform_name_tmp.len() as gl::types::GLint,
                                                    &mut name_len, uniform_name_tmp.as_mut_ptr() as *mut gl::types::GLchar);
             uniform_name_tmp.set_len(name_len as usize);
             // Get the location of the uniform
@@ -1146,7 +1145,7 @@ pub unsafe fn reflect_subroutine_data(ctxt: &mut CommandContext, program: Handle
 
             // Get the indices of compatible subroutines.
             let mut compatible_sr_indices: Vec<gl::types::GLuint> = Vec::with_capacity(compatible_count as usize);
-            ctxt.gl.GetActiveSubroutineUniformiv(program, stage.to_gl_enum(), i as u32, gl::COMPATIBLE_SUBROUTINES,
+            ctxt.gl.GetActiveSubroutineUniformiv(program, stage.to_gl_enum(), i as gl::types::GLuint, gl::COMPATIBLE_SUBROUTINES,
                                                  compatible_sr_indices.as_mut_ptr() as *mut gl::types::GLint);
             compatible_sr_indices.set_len(compatible_count as usize);
             let mut compatible_subroutines: Vec<Subroutine> = Vec::new();
@@ -1154,7 +1153,7 @@ pub unsafe fn reflect_subroutine_data(ctxt: &mut CommandContext, program: Handle
                 // Get the names of compatible subroutines.
                 let mut subroutine_name_tmp: Vec<u8> = vec![0; 64];;
                 let mut name_len: gl::types::GLsizei = mem::uninitialized();
-                ctxt.gl.GetActiveSubroutineName(program, stage.to_gl_enum(), compatible_sr_indices[j as usize], subroutine_name_tmp.len() as i32,
+                ctxt.gl.GetActiveSubroutineName(program, stage.to_gl_enum(), compatible_sr_indices[j as usize], subroutine_name_tmp.len() as gl::types::GLint,
                                                 &mut name_len, subroutine_name_tmp.as_mut_ptr() as *mut gl::types::GLchar);
                 subroutine_name_tmp.set_len(name_len as usize);
                 let subroutine_name = String::from_utf8(subroutine_name_tmp).unwrap();

--- a/src/program/shader.rs
+++ b/src/program/shader.rs
@@ -188,7 +188,7 @@ pub fn check_shader_type_compatibility<C>(ctxt: &C, shader_type: gl::types::GLen
     match shader_type {
         gl::VERTEX_SHADER | gl::FRAGMENT_SHADER => (),
         gl::GEOMETRY_SHADER => {
-            if !(ctxt.get_version() >= &Version(Api::Gl, 3, 0))
+            if !(ctxt.get_version() >= &Version(Api::Gl, 3, 2))
                 && !(ctxt.get_version() >= &Version(Api::GlEs, 3, 2))
                 && !ctxt.get_extensions().gl_arb_geometry_shader4
                 && !ctxt.get_extensions().gl_ext_geometry_shader4

--- a/src/uniforms/mod.rs
+++ b/src/uniforms/mod.rs
@@ -88,6 +88,8 @@ let uniforms = uniform! {
 # }
 ```
 
+## Subroutines
+TODO
 */
 pub use self::buffer::UniformBuffer;
 pub use self::sampler::{SamplerWrapFunction, MagnifySamplerFilter, MinifySamplerFilter};

--- a/src/uniforms/value.rs
+++ b/src/uniforms/value.rs
@@ -1,5 +1,6 @@
 use program;
 use program::BlockLayout;
+use program::ShaderStage;
 use texture;
 
 use uniforms::AsUniformValue;
@@ -141,6 +142,7 @@ pub enum UniformValue<'a> {
     /// The last parameter is a sender which must be used to send a `SyncFence` that expires when
     /// the buffer has finished being used.
     Block(BufferAnySlice<'a>, fn(&program::UniformBlock) -> Result<(), LayoutMismatchError>),
+    Subroutine(ShaderStage, &'a str),
     SignedInt(i32),
     UnsignedInt(u32),
     Float(f32),
@@ -962,3 +964,17 @@ impl AsUniformValue for (u64, u64, u64, u64) {
 }
 
 impl_uniform_block_basic!((u64, u64, u64, u64), UniformType::UnsignedInt64Vec4);
+
+impl<'a> AsUniformValue for (ShaderStage, &'a str) {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::Subroutine(self.0, self.1)
+    }
+}
+
+impl<'a> AsUniformValue for (&'a str, ShaderStage) {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue {
+        UniformValue::Subroutine(self.1, self.0)
+    }
+}

--- a/src/uniforms/value.rs
+++ b/src/uniforms/value.rs
@@ -965,13 +965,7 @@ impl AsUniformValue for (u64, u64, u64, u64) {
 
 impl_uniform_block_basic!((u64, u64, u64, u64), UniformType::UnsignedInt64Vec4);
 
-impl<'a> AsUniformValue for (ShaderStage, &'a str) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Subroutine(self.0, self.1)
-    }
-}
-
+// Subroutines
 impl<'a> AsUniformValue for (&'a str, ShaderStage) {
     #[inline]
     fn as_uniform_value(&self) -> UniformValue {

--- a/tests/shaders.rs
+++ b/tests/shaders.rs
@@ -231,7 +231,6 @@ fn get_uniform_blocks() {
 }
 
 #[test]
-#[ignore]       // TODO: doesn't work with some versions of MESA
 fn get_program_binary() {
     let display = support::build_display();
 
@@ -272,7 +271,6 @@ fn get_program_binary() {
 }
 
 #[test]
-#[ignore]       // TODO: doesn't work with some versions of MESA
 fn program_binary_reload() {
     let display = support::build_display();
 
@@ -313,7 +311,6 @@ fn program_binary_reload() {
 }
 
 #[test]
-#[ignore]       // TODO: doesn't work with some versions of MESA
 fn program_binary_working() {
     let display = support::build_display();
     let (vb, ib) = support::build_rectangle_vb_ib(&display);

--- a/tests/subroutines.rs
+++ b/tests/subroutines.rs
@@ -1,0 +1,372 @@
+#[macro_use]
+extern crate glium;
+
+use glium::{index, Surface};
+use glium::index::PrimitiveType;
+use glium::program::ShaderStage;
+use glium::backend::Facade;
+use glium::CapabilitiesSource;
+use glium::DrawError;
+
+mod support;
+
+#[derive(Copy, Clone)]
+struct Vertex {
+    position: [f32; 2],
+}
+
+implement_vertex!(Vertex, position);
+
+#[test]
+fn subroutine_bindings_simple() {
+    let display = support::build_display();
+    if !display.get_context().get_extensions().gl_arb_shader_subroutine {
+        println!("Backend does not support subroutines");
+        return
+    };
+
+    let program = program!(&display,
+        330 => {
+            vertex: "
+                #version 330
+
+                in vec2 position;
+
+                void main() {
+                    gl_Position = vec4(position, 0.0, 1.0);
+                }
+            ",
+
+            fragment: "
+                #version 330
+                #extension GL_ARB_shader_subroutine : require
+
+                out vec4 fragColor;
+                subroutine vec4 color_t();
+
+                subroutine uniform color_t Color;
+
+                subroutine(color_t)
+                vec4 ColorRed()
+                {
+                  return vec4(1, 0, 0, 1);
+                }
+
+                subroutine(color_t)
+                vec4 ColorBlue()
+                {
+                  return vec4(0, 0, 1, 1);
+                }
+
+                void main()
+                {
+                    fragColor = Color();
+                }
+            "
+        },
+    ).unwrap();
+    let vb = glium::VertexBuffer::new(&display, &[
+        Vertex { position: [-1.0,  1.0] }, Vertex { position: [1.0,  1.0] },
+        Vertex { position: [-1.0, -1.0] }, Vertex { position: [1.0, -1.0] },
+    ]).unwrap();
+
+    let indices = glium::IndexBuffer::new(&display, PrimitiveType::TrianglesList,
+                                          &[0u16, 1, 2, 2, 1, 3]).unwrap();
+
+    let texture = support::build_renderable_texture(&display);
+
+    let uniforms = uniform!(
+        Color: ("ColorBlue", ShaderStage::Fragment),
+    );
+    texture.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
+    texture.as_surface().draw(&vb, &indices, &program, &uniforms,
+                              &Default::default()).unwrap();
+
+    let data: Vec<Vec<(u8, u8, u8, u8)>> = texture.read();
+
+    assert_eq!(data[0][0], (0, 0, 255, 255));
+    assert_eq!(data.last().unwrap().last().unwrap(), &(0, 0, 255, 255));
+
+    display.assert_no_error(None);
+
+    let uniforms = uniform!(
+        Color: ("ColorRed", ShaderStage::Fragment),
+    );
+    texture.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
+    texture.as_surface().draw(&vb, &indices, &program, &uniforms,
+                              &Default::default()).unwrap();
+
+    let data: Vec<Vec<(u8, u8, u8, u8)>> = texture.read();
+
+    assert_eq!(data[0][0], (255, 0, 0, 255));
+    assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0, 255));
+
+    display.assert_no_error(None);
+}
+
+#[test]
+fn subroutine_bindings_explicit_location() {
+    let display = support::build_display();
+    if !display.get_context().get_extensions().gl_arb_shader_subroutine {
+        println!("Backend does not support subroutines");
+        return
+    };
+
+    let program = program!(&display,
+        330 => {
+            vertex: "
+                #version 330
+
+                in vec2 position;
+
+                void main() {
+                    gl_Position = vec4(position, 0.0, 1.0);
+                }
+            ",
+
+            fragment: "
+                #version 330
+                #extension GL_ARB_shader_subroutine : require
+                #extension GL_ARB_explicit_uniform_location : require
+
+                out vec4 fragColor;
+                subroutine vec4 color_t();
+
+                layout(location = 5) subroutine uniform color_t Color;
+
+                subroutine(color_t)
+                vec4 ColorRed()
+                {
+                  return vec4(1, 0, 0, 1);
+                }
+
+                subroutine(color_t)
+                vec4 ColorBlue()
+                {
+                  return vec4(0, 0, 1, 1);
+                }
+
+                void main()
+                {
+                    fragColor = Color();
+                }
+            "
+        },
+    ).unwrap();
+    let vb = glium::VertexBuffer::new(&display, &[
+        Vertex { position: [-1.0,  1.0] }, Vertex { position: [1.0,  1.0] },
+        Vertex { position: [-1.0, -1.0] }, Vertex { position: [1.0, -1.0] },
+    ]).unwrap();
+
+    let indices = glium::IndexBuffer::new(&display, PrimitiveType::TrianglesList,
+                                          &[0u16, 1, 2, 2, 1, 3]).unwrap();
+
+    let texture = support::build_renderable_texture(&display);
+
+    let uniforms = uniform!(
+        Color: ("ColorBlue", ShaderStage::Fragment),
+    );
+    texture.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
+    texture.as_surface().draw(&vb, &indices, &program, &uniforms,
+                              &Default::default()).unwrap();
+
+    let data: Vec<Vec<(u8, u8, u8, u8)>> = texture.read();
+
+    assert_eq!(data[0][0], (0, 0, 255, 255));
+    assert_eq!(data.last().unwrap().last().unwrap(), &(0, 0, 255, 255));
+
+    display.assert_no_error(None);
+
+    let uniforms = uniform!(
+        Color: ("ColorRed", ShaderStage::Fragment),
+    );
+    texture.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
+    texture.as_surface().draw(&vb, &indices, &program, &uniforms,
+                              &Default::default()).unwrap();
+
+    let data: Vec<Vec<(u8, u8, u8, u8)>> = texture.read();
+
+    assert_eq!(data[0][0], (255, 0, 0, 255));
+    assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0, 255));
+
+    display.assert_no_error(None);
+}
+
+// Start of more complex tests with multiple uniforms and such.
+// Unfortunately, mesa has a bug which produces a segfault when compiling this fragment shader.
+// https://bugs.freedesktop.org/show_bug.cgi?id=93722
+
+fn build_program_complex(display: &glium::Display) -> glium::Program {
+    let program = program!(display,
+        330 => {
+            vertex: "
+                #version 330
+
+                in vec2 position;
+
+                void main() {
+                    gl_Position = vec4(position, 0.0, 1.0);
+                }
+            ",
+
+            fragment: "
+                #version 330
+                #extension GL_ARB_shader_subroutine : require
+
+                out vec4 fragColor;
+                subroutine vec4 color_t();
+                subroutine vec4 modify_t(vec4 color);
+
+                subroutine uniform color_t Color;
+                subroutine uniform modify_t Modify;
+
+                subroutine(color_t)
+                vec4 ColorRed()
+                {
+                  return vec4(1, 0, 0, 1);
+                }
+
+                subroutine(color_t)
+                vec4 ColorBlue()
+                {
+                  return vec4(0, 0, 1, 1);
+                }
+
+                subroutine(modify_t)
+                vec4 SwapRB(vec4 color)
+                {
+                  return vec4(color.b, color.g, color.r, color.a);
+                }
+
+                subroutine(modify_t)
+                vec4 DeleteR(vec4 color)
+                {
+                  return vec4(0, color.g, color.b, color.a);
+                }
+
+                void main()
+                {
+                    vec4 color = Color();
+                    fragColor = Modify(color);
+                }
+            "
+        },
+    ).unwrap();
+    program
+}
+
+#[test]
+fn subroutine_bindings_multi() {
+    let display = support::build_display();
+    if !display.get_context().get_extensions().gl_arb_shader_subroutine {
+        println!("Backend does not support subroutines");
+        return
+    };
+
+    let program = build_program_complex(&display);
+    let vb = glium::VertexBuffer::new(&display, &[
+        Vertex { position: [-1.0,  1.0] }, Vertex { position: [1.0,  1.0] },
+        Vertex { position: [-1.0, -1.0] }, Vertex { position: [1.0, -1.0] },
+    ]).unwrap();
+
+    let indices = glium::IndexBuffer::new(&display, PrimitiveType::TrianglesList,
+                                          &[0u16, 1, 2, 2, 1, 3]).unwrap();
+
+    let texture = support::build_renderable_texture(&display);
+
+    let uniforms = uniform!(
+        Color: ("ColorBlue", ShaderStage::Fragment),
+        Modify: ("DeleteR", ShaderStage::Fragment),
+    );
+    texture.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
+    texture.as_surface().draw(&vb, &indices, &program, &uniforms,
+                              &Default::default()).unwrap();
+
+    let data: Vec<Vec<(u8, u8, u8, u8)>> = texture.read();
+
+    assert_eq!(data[0][0], (0, 0, 255, 255));
+    assert_eq!(data.last().unwrap().last().unwrap(), &(0, 0, 255, 255));
+
+    display.assert_no_error(None);
+
+    let uniforms = uniform!(
+        Color: ("ColorRed", ShaderStage::Fragment),
+        Modify: ("SwapRB", ShaderStage::Fragment),
+    );
+    texture.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
+    texture.as_surface().draw(&vb, &indices, &program, &uniforms,
+                              &Default::default()).unwrap();
+
+    let data: Vec<Vec<(u8, u8, u8, u8)>> = texture.read();
+
+    assert_eq!(data[0][0], (0, 0, 255, 255));
+    assert_eq!(data.last().unwrap().last().unwrap(), &(0, 0, 255, 255));
+
+    display.assert_no_error(None);
+}
+
+#[test]
+fn not_all_uniforms_set() {
+    let display = support::build_display();
+    if !display.get_context().get_extensions().gl_arb_shader_subroutine {
+        println!("Backend does not support subroutines");
+        return
+    };
+
+    let program = build_program_complex(&display);
+    let vb = glium::VertexBuffer::new(&display, &[
+        Vertex { position: [-1.0,  1.0] }, Vertex { position: [1.0,  1.0] },
+        Vertex { position: [-1.0, -1.0] }, Vertex { position: [1.0, -1.0] },
+    ]).unwrap();
+
+    let indices = glium::IndexBuffer::new(&display, PrimitiveType::TrianglesList,
+                                          &[0u16, 1, 2, 2, 1, 3]).unwrap();
+
+    let texture = support::build_renderable_texture(&display);
+
+    let uniforms = uniform!(
+        Color: ("ColorBlue", ShaderStage::Fragment),
+        // Not setting Modify on purpose
+    );
+    texture.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
+    match texture.as_surface().draw(&vb, &indices, &program, &uniforms,
+                              &Default::default()) {
+                                  Err(DrawError::SubroutineUniformMissing{ .. }) => (),
+                                  _ => panic!("Drawing should have errored")
+                              }
+
+    display.assert_no_error(None);
+}
+
+#[test]
+fn mismatched_subroutines() {
+    let display = support::build_display();
+    if !display.get_context().get_extensions().gl_arb_shader_subroutine {
+        println!("Backend does not support subroutines");
+        return
+    };
+
+    let program = build_program_complex(&display);
+    let vb = glium::VertexBuffer::new(&display, &[
+        Vertex { position: [-1.0,  1.0] }, Vertex { position: [1.0,  1.0] },
+        Vertex { position: [-1.0, -1.0] }, Vertex { position: [1.0, -1.0] },
+    ]).unwrap();
+
+    let indices = glium::IndexBuffer::new(&display, PrimitiveType::TrianglesList,
+                                          &[0u16, 1, 2, 2, 1, 3]).unwrap();
+
+    let texture = support::build_renderable_texture(&display);
+
+    let uniforms = uniform!(
+        Color: ("ColorBlue", ShaderStage::Fragment),
+        Modify: ("ColorBlue", ShaderStage::Fragment)
+    );
+    texture.as_surface().clear_color(0.0, 0.0, 0.0, 0.0);
+    match texture.as_surface().draw(&vb, &indices, &program, &uniforms,
+                              &Default::default()) {
+                                  Err(DrawError::SubroutineNotFound{ .. }) => (),
+                                  _ => panic!("Drawing should have errored")
+                              }
+
+    display.assert_no_error(None);
+}

--- a/tests/subroutines.rs
+++ b/tests/subroutines.rs
@@ -1,11 +1,10 @@
 #[macro_use]
 extern crate glium;
 
-use glium::{index, Surface};
+use glium::{Surface};
 use glium::index::PrimitiveType;
-use glium::program::ShaderStage;
+use glium::program::{ ShaderStage, is_subroutine_supported };
 use glium::backend::Facade;
-use glium::CapabilitiesSource;
 use glium::DrawError;
 
 mod support;
@@ -20,7 +19,7 @@ implement_vertex!(Vertex, position);
 #[test]
 fn subroutine_bindings_simple() {
     let display = support::build_display();
-    if !display.get_context().get_extensions().gl_arb_shader_subroutine {
+    if !is_subroutine_supported(display.get_context()) {
         println!("Backend does not support subroutines");
         return
     };
@@ -108,7 +107,7 @@ fn subroutine_bindings_simple() {
 #[ignore] // This seems to be buggy in almost every implementation, so ignore.
 fn subroutine_bindings_explicit_location() {
     let display = support::build_display();
-    if !display.get_context().get_extensions().gl_arb_shader_subroutine {
+    if !is_subroutine_supported(display.get_context()) {
         println!("Backend does not support subroutines");
         return
     };
@@ -261,7 +260,7 @@ fn build_program_complex(display: &glium::Display) -> glium::Program {
 #[ignore]
 fn subroutine_bindings_multi() {
     let display = support::build_display();
-    if !display.get_context().get_extensions().gl_arb_shader_subroutine {
+    if !is_subroutine_supported(display.get_context()) {
         println!("Backend does not support subroutines");
         return
     };
@@ -312,7 +311,7 @@ fn subroutine_bindings_multi() {
 #[ignore]
 fn not_all_uniforms_set() {
     let display = support::build_display();
-    if !display.get_context().get_extensions().gl_arb_shader_subroutine {
+    if !is_subroutine_supported(display.get_context()) {
         println!("Backend does not support subroutines");
         return
     };
@@ -346,7 +345,7 @@ fn not_all_uniforms_set() {
 #[ignore]
 fn mismatched_subroutines() {
     let display = support::build_display();
-    if !display.get_context().get_extensions().gl_arb_shader_subroutine {
+    if !is_subroutine_supported(display.get_context()) {
         println!("Backend does not support subroutines");
         return
     };

--- a/tests/subroutines.rs
+++ b/tests/subroutines.rs
@@ -105,6 +105,7 @@ fn subroutine_bindings_simple() {
 }
 
 #[test]
+#[ignore] // This seems to be buggy in almost every implementation, so ignore.
 fn subroutine_bindings_explicit_location() {
     let display = support::build_display();
     if !display.get_context().get_extensions().gl_arb_shader_subroutine {
@@ -194,7 +195,8 @@ fn subroutine_bindings_explicit_location() {
 
 // Start of more complex tests with multiple uniforms and such.
 // Unfortunately, mesa has a bug which produces a segfault when compiling this fragment shader.
-// https://bugs.freedesktop.org/show_bug.cgi?id=93722
+// See https://bugs.freedesktop.org/show_bug.cgi?id=93722
+// On non-mesa OpenGL implementations, the tests pass just fine.
 
 fn build_program_complex(display: &glium::Display) -> glium::Program {
     let program = program!(display,
@@ -256,6 +258,7 @@ fn build_program_complex(display: &glium::Display) -> glium::Program {
 }
 
 #[test]
+#[ignore]
 fn subroutine_bindings_multi() {
     let display = support::build_display();
     if !display.get_context().get_extensions().gl_arb_shader_subroutine {
@@ -306,6 +309,7 @@ fn subroutine_bindings_multi() {
 }
 
 #[test]
+#[ignore]
 fn not_all_uniforms_set() {
     let display = support::build_display();
     if !display.get_context().get_extensions().gl_arb_shader_subroutine {
@@ -339,6 +343,7 @@ fn not_all_uniforms_set() {
 }
 
 #[test]
+#[ignore]
 fn mismatched_subroutines() {
     let display = support::build_display();
     if !display.get_context().get_extensions().gl_arb_shader_subroutine {


### PR DESCRIPTION
*This is a WIP, do not merge yet!*

I needed subroutines for a personal project, so I started implementing them in glium.

If this feature is not desired, it's perfectly fine if you reject this.

So far, I have implemented reflection for subroutine data. This includes all subroutine uniforms and their corresponding candidate subroutines. This is turn means that the "data part" is done, which enables error checking etc. to avoid opengl errors.

The next step is the hard part where I need some pointers though, because I'm not so familiar with gliums internals: Actually drawing.
1. The user can potentially specify the subroutines in a format similar to this: `(ShaderType, "uniform_name") => "subroutine_name"`. How would these subroutine values be handled in the API? As an extra parameter to draw? Or maybe as draw_parameters? (I figured handling subroutine_uniforms the same as uniforms would be dumb, because they are definitely not the same thing)
2. Where do the current values get cached (context?) to avoid unnecessary opengl calls? (This could also be implemented lateron)
3. These caches need to be invalidated when i.e. after calling `glUseProgram()`, how is this handled in glium?

Of course I'm happy about feedback regarding my current implementation too.
Oh, I also added an example program which prints the queried SubroutineData. It gives a nice overview of the data structures.

Thanks in advance