### PR TITLE
Fix a few warnings

### DIFF
--- a/src/backend/glutin_backend.rs
+++ b/src/backend/glutin_backend.rs
@@ -8,7 +8,7 @@ Backend implementation for the glutin library
 Only available if the 'glutin' feature is enabled.
 
 */
-extern crate glutin;
+pub extern crate glutin;
 
 use DisplayBuild;
 use Frame;

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -69,7 +69,6 @@ Not yet supported
 use std::rc::Rc;
 use smallvec::SmallVec;
 
-use texture::Texture2d;
 use texture::TextureAnyImage;
 use TextureExt;
 

--- a/src/index/buffer.rs
+++ b/src/index/buffer.rs
@@ -1,7 +1,6 @@
 use buffer::{Buffer, BufferSlice, BufferMutSlice, BufferAny, BufferType};
 use buffer::{BufferMode, BufferCreationError};
 use gl;
-use BufferExt;
 use GlObject;
 
 use backend::Facade;

--- a/src/program/compute.rs
+++ b/src/program/compute.rs
@@ -4,7 +4,6 @@ use context::CommandContext;
 use backend::Facade;
 
 use std::fmt;
-use std::error::Error;
 use std::collections::hash_map::{self, HashMap};
 use std::os::raw;
 

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -8,7 +8,6 @@ use backend::Facade;
 use CapabilitiesSource;
 
 use std::fmt;
-use std::error::Error;
 use std::collections::hash_map::{self, HashMap};
 
 use GlObject;

--- a/src/program/raw.rs
+++ b/src/program/raw.rs
@@ -10,7 +10,6 @@ use ContextExt;
 use UniformsExt;
 
 use std::{ffi, fmt, mem};
-use std::error::Error;
 use std::collections::hash_map::{self, HashMap};
 use std::rc::Rc;
 use std::cell::RefCell;

--- a/src/texture/any.rs
+++ b/src/texture/any.rs
@@ -35,7 +35,6 @@ use std::borrow::Cow;
 use std::cell::Cell;
 use std::rc::Rc;
 use std::ops::Range;
-use std::os::raw;
 
 use ops;
 use fbo;
@@ -474,7 +473,7 @@ pub unsafe fn from_id<F: Facade>(facade: &F,
     let should_generate_mipmaps = mipmaps.should_generate();
     if should_generate_mipmaps {
         let ctxt = facade.get_context().make_current();
-        unsafe { generate_mipmaps(&ctxt, get_bind_point(ty)); }
+        generate_mipmaps(&ctxt, get_bind_point(ty));
     }
     TextureAny {
         context: facade.get_context().clone(),

--- a/src/texture/pixel_buffer.rs
+++ b/src/texture/pixel_buffer.rs
@@ -11,7 +11,6 @@ use std::ops::{Deref, DerefMut};
 use backend::Facade;
 
 use GlObject;
-use BufferExt;
 use buffer::{ReadError, Buffer, BufferType, BufferMode};
 use gl;
 


### PR DESCRIPTION
There are still a few warnings left that I did not fix:

 * There are some unused results. Calling `unwrap()` would be a behavioural change and it might have a small performance impact.
 * Making types public to avoid the private type in public interface warning causes more warnings than it solves due to the missing documentation warning. It will have to be fixed at some point though, because it will become a hard error.