### PR TITLE
fixed warnings that were going to be made into errors next release

### DIFF
--- a/src/backend/glutin_backend.rs
+++ b/src/backend/glutin_backend.rs
@@ -8,7 +8,7 @@ Backend implementation for the glutin library
 Only available if the 'glutin' feature is enabled.
 
 */
-pub extern crate glutin;
+extern crate glutin;
 
 use DisplayBuild;
 use Frame;

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -517,7 +517,7 @@ impl Context {
 
         let mut data = Vec::with_capacity(0);
         ops::read(&mut ctxt, ops::Source::DefaultFramebuffer(gl::FRONT_LEFT), &rect, &mut data,
-                  false);
+                  false).ok().unwrap();
         T::from_raw(Cow::Owned(data), dimensions.0, dimensions.1)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,7 +382,7 @@ trait UniformsExt {
 ///
 /// Blocks and subroutines are not included.
 #[derive(Copy, Clone, Debug)]
-enum RawUniformValue {
+pub enum RawUniformValue {
     SignedInt(gl::types::GLint),
     UnsignedInt(gl::types::GLuint),
     Float(gl::types::GLfloat),

--- a/src/texture/any.rs
+++ b/src/texture/any.rs
@@ -1380,7 +1380,7 @@ impl<'a> TextureAnyImage<'a> {
     ///
     /// # Panic
     ///
-    /// Panicks if the rect is out of range.
+    /// Panics if the rect is out of range.
     ///
     pub fn raw_read<T, P>(&self, rect: &Rect) -> T where T: Texture2dDataSink<P>, P: PixelValue {
         assert!(rect.left + rect.width <= self.width);
@@ -1389,7 +1389,7 @@ impl<'a> TextureAnyImage<'a> {
         let mut ctxt = self.texture.context.make_current();
 
         let mut data = Vec::new();
-        ops::read(&mut ctxt, &fbo::RegularAttachment::Texture(*self), &rect, &mut data, false);
+        ops::read(&mut ctxt, &fbo::RegularAttachment::Texture(*self), &rect, &mut data, false).ok().unwrap();
         T::from_raw(Cow::Owned(data), self.width, self.height.unwrap_or(1))
     }
 
@@ -1409,7 +1409,7 @@ impl<'a> TextureAnyImage<'a> {
 
         let size = rect.width as usize * rect.height as usize * 4;
         let mut ctxt = self.texture.context.make_current();
-        ops::read(&mut ctxt, &fbo::RegularAttachment::Texture(*self), &rect, dest, false);
+        ops::read(&mut ctxt, &fbo::RegularAttachment::Texture(*self), &rect, dest, false).ok().unwrap();
     }
 
     /// Clears the content of the texture to a specific value.


### PR DESCRIPTION
If for some reason panic on failure to copy a rect was not desired, I can modify the PR with a more appropriate solution (such as ignoring an error). This is primarily to eliminate the annoying warnings that will turn into errors.