### PR TITLE
examples/picking: trivial fix for MouseMoved API

### DIFF
--- a/examples/picking.rs
+++ b/examples/picking.rs
@@ -233,7 +233,7 @@ fn main() {
         for event in display.poll_events() {
             match event {
                 glutin::Event::Closed => return support::Action::Stop,
-                glutin::Event::MouseMoved(m) => cursor_position = Some(m),
+                glutin::Event::MouseMoved(x,y) => cursor_position = Some((x,y)),
                 ev => camera.process_input(&ev),
             }
         }


### PR DESCRIPTION
Travis and CircleCI tests have been failing for glium because (as far as I can tell) of a small change in the glutin MouseMoved API.
This trivial commit fixes the problem.