### PR TITLE
Unignore some tests that work now

### DIFF
--- a/tests/buffer.rs
+++ b/tests/buffer.rs
@@ -780,7 +780,6 @@ fn persistent_mapping_forget_then_remap() {
 }
 
 #[test]
-#[ignore]       // TODO: mystic rust-related bug
 fn persistent_mapping_forget_then_read() {
     let display = support::build_display();
 

--- a/tests/subroutines.rs
+++ b/tests/subroutines.rs
@@ -104,7 +104,6 @@ fn subroutine_bindings_simple() {
 }
 
 #[test]
-#[ignore] // This seems to be buggy in almost every implementation, so ignore.
 fn subroutine_bindings_explicit_location() {
     let display = support::build_display();
     if !is_subroutine_supported(display.get_context()) {
@@ -128,6 +127,7 @@ fn subroutine_bindings_explicit_location() {
                 #version 150
                 #extension GL_ARB_shader_subroutine : require
                 #extension GL_ARB_explicit_uniform_location : require
+                #extension GL_ARB_explicit_attrib_location : require
 
                 out vec4 fragColor;
                 subroutine vec4 color_t();
@@ -193,9 +193,6 @@ fn subroutine_bindings_explicit_location() {
 }
 
 // Start of more complex tests with multiple uniforms and such.
-// Unfortunately, mesa has a bug which produces a segfault when compiling this fragment shader.
-// See https://bugs.freedesktop.org/show_bug.cgi?id=93722
-// On non-mesa OpenGL implementations, the tests pass just fine.
 
 fn build_program_complex(display: &glium::Display) -> glium::Program {
     let program = program!(display,
@@ -257,7 +254,6 @@ fn build_program_complex(display: &glium::Display) -> glium::Program {
 }
 
 #[test]
-#[ignore]
 fn subroutine_bindings_multi() {
     let display = support::build_display();
     if !is_subroutine_supported(display.get_context()) {
@@ -308,8 +304,7 @@ fn subroutine_bindings_multi() {
 }
 
 #[test]
-#[ignore]
-fn not_all_uniforms_set() {
+fn not_all_subroutine_uniforms_set() {
     let display = support::build_display();
     if !is_subroutine_supported(display.get_context()) {
         println!("Backend does not support subroutines");
@@ -342,7 +337,6 @@ fn not_all_uniforms_set() {
 }
 
 #[test]
-#[ignore]
 fn mismatched_subroutines() {
     let display = support::build_display();
     if !is_subroutine_supported(display.get_context()) {


### PR DESCRIPTION
The subroutine tests were previously causing segfaults due to bugs in mesa, but they got fixed after I reported them some time ago.

The bug in `persistent_mapping_forget_then_read` I could no longer reproduce, and travis is not complaining either.