### PR TITLE
book: Fix various typos and minor wording mistakes.

### DIFF
--- a/book/tuto-01-getting-started.md
+++ b/book/tuto-01-getting-started.md
@@ -32,7 +32,7 @@ It is now time to start filling the `main` function!
 
 The first step when creating a graphical application is to create a window. If you have ever worked with OpenGL before, you know how hard it is to do this correctly. Both window creation and context creation are platform-specific, and they are sometimes weird and tedious. Fortunately, this is where the **glutin** library shines.
 
-Initializing a window with glutin can be done by calling `glium::glutin::WindowBuilder()::new().build().unwrap()`. However we don't just want to create a *glutin* window, but a window with an OpenGL context handled by glium. Instead of calling `build()` we going to call `build_glium()`, which is defined in the `glium::DisplayBuild` trait.
+Initializing a window with glutin can be done by calling `glium::glutin::WindowBuilder()::new().build().unwrap()`. However we don't just want to create a *glutin* window, but a window with an OpenGL context handled by glium. Instead of calling `build()` we are going to call `build_glium()`, which is defined in the `glium::DisplayBuild` trait.
 
 ```rust
 fn main() {
@@ -55,7 +55,7 @@ loop {
 }
 ```
 
-Right now this code will consume 100% of our CPU, but that will do for now. In a real application you should either use vertical synchronization or sleep for a few milliseconds at the end of the loop, but this is a more advanced topic.
+Right now this code will consume 100% of our CPU, but that will do for now. In a real application you should either use vertical synchronization or sleep for a few milliseconds at the end of the loop, but that is a more advanced topic.
 
 You can now execute `cargo run`. After a few minutes during which Cargo downloads and compiles glium and its dependencies, you should see a nice little window.
 
@@ -63,7 +63,7 @@ You can now execute `cargo run`. After a few minutes during which Cargo download
 
 The content of the window, however, is not not very appealing. Depending on your system, it can appear black, show a random image, or just some snow. We are expected to draw on the window, so the system doesn't bother initializing its color to a specific value.
 
-Glium and the OpenGL API work similarly to a drawing software like Window's Paint or The GIMP. We start with an empty image, then draw an object on it, then another object, then another object, etc. until we are satisfied with the result. But contrary to a drawing software, you don't want your users to see the intermediate steps. Only the final result should be shown.
+Glium and the OpenGL API work similarly to drawing software like Windows' Paint or The GIMP. We start with an empty image, then draw an object on it, then another object, then another object, etc. until we are satisfied with the result. But contrary to drawing software, you don't want your users to see the intermediate steps. Only the final result should be shown.
 
 To handle this, OpenGL uses what is called *double buffering*. Instead of drawing directly to the window, we are drawing to an image stored in memory. Once we have finished drawing, this image is copied to the window.
 This is represented in glium by the `Frame` object. When you want to start drawing something on your window, you must first call `display.draw()` in order to produce a `Frame`:

--- a/book/tuto-02-triangle.md
+++ b/book/tuto-02-triangle.md
@@ -81,7 +81,7 @@ let vertex_shader_src = r#"
 "#;
 ```
 
-First of all, the `#version 140` line is here to tell OpenGL what version of GLSL this source code corresponds to. Some hardware don't support the latest versions of GLSL, so we are trying to stick to earlier versions if possible.
+First of all, the `#version 140` line is here to tell OpenGL what version of GLSL this source code corresponds to. Some hardware doesn't support the latest versions of GLSL, so we are trying to stick to earlier versions if possible.
 
 When we defined the `Vertex` struct in our shape, we created a field named `position` which contains the position of our vertex. But contrary to what I let you think, this struct doesn't contain the actual position of the vertex but only a attribute whose value is passed to the vertex shader. OpenGL doesn't care about the name of the attribute, all it does is passing its value to the vertex shader. The `in vec2 position;` line of our shader is here to declare that we are expected to be passed an attribute named `position` whose type is `vec2` (which corresponds to `[f32; 2]` in Rust).
 

--- a/book/tuto-04-matrices.md
+++ b/book/tuto-04-matrices.md
@@ -29,7 +29,7 @@ let vertex_shader_src = r#"
 "#;
 ```
 
-Note that it is important to write `matrix * vertex` and not `vertex * matrix`. Matrix operations produce different result depending on the order.
+Note that it is important to write `matrix * vertex` and not `vertex * matrix`. Matrix operations produce different results depending on the order.
 
 We also need to pass the matrix when calling the `draw` function:
 

--- a/book/tuto-09-depth.md
+++ b/book/tuto-09-depth.md
@@ -5,7 +5,7 @@ What's wrong with the teapot of the previous section?
 ![The teapot](tuto-08-result.png)
 
 The problem is that faces that are in the back of the model are displayed *above* faces that are
-in the back of the model.
+in the front of the model.
 
 ![The problem](tuto-09-problem.png)
 

--- a/book/tuto-10-perspective.md
+++ b/book/tuto-10-perspective.md
@@ -55,7 +55,7 @@ dimensions they get back to their original aspect.
 
 ## Introducing the perspective matrix
 
-The reason why these two problems are in the same tutorial is because graphics engine usually
+The reason why these two problems are in the same tutorial is because graphics engines usually
 solve both with one matrix: the **perspective matrix**.
 
 ```rust


### PR DESCRIPTION
These changes are meant to be very minimal: no "style" issues or rephrasings, just wrong or missing words.

- In `tuto-01-getting-started.md`:
    - a missing word "are"
    - "this" should be "that"
    - "Window's Paint" should be "Windows' Paint".
    - Extra "a".
- In `tuto-02-triangle.md`:
    - "don't" should be "doesn't".
- In `tuto-04-matrices.md`:
    - "result" should be "results"
- In `tuto-09-depth.md`:
    - "back" should be "front"
- In `tuto-10-perspective.md`:
    - "engine" should be "engines"

