### PR TITLE
Adjust compute shader example

### DIFF
--- a/examples/gpgpu.rs
+++ b/examples/gpgpu.rs
@@ -13,10 +13,9 @@ fn main() {
     let program = glium::program::ComputeShader::from_source(&display, r#"\
 
             #version 430
-            buffer layout(std140);
             layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
-            buffer MyBlock {
+            layout(std140) buffer MyBlock {
                 float power;
                 float values[256];
             };


### PR DESCRIPTION
This addresses issue #1310 where the compute shader example,
gpgpus.rs, does not run on certain setups.  With the most
recent up to date nVidia driver the example would have no issues
but on an older driver, capable of running OpenGL 4.5 and over a
year old, the example would panic due to a compilation error of
the shader.