### PR TITLE
Add ?Sized to all Facade generic parameters

### DIFF
--- a/build/textures.rs
+++ b/build/textures.rs
@@ -546,7 +546,7 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
                 ///
                 {gen_doc}
                 #[inline]
-                pub fn new<'a, F, T>(facade: &F, data: {param})
+                pub fn new<'a, F: ?Sized, T>(facade: &F, data: {param})
                               -> Result<{name}, TextureCreationError>
                               where T: {data_source_trait}<'a>, F: Facade
                 {{
@@ -571,7 +571,7 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
         (writeln!(dest, "
                 /// Builds a new texture by uploading data.
                 #[inline]
-                pub fn with_mipmaps<'a, F, T>(facade: &F, data: {param}, mipmaps: {mipmaps})
+                pub fn with_mipmaps<'a, F: ?Sized, T>(facade: &F, data: {param}, mipmaps: {mipmaps})
                                               -> Result<{name}, TextureCreationError>
                                               where T: {data_source_trait}<'a>, F: Facade
                 {{
@@ -597,7 +597,7 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
                 /// Builds a new texture with a specific format. The input data must also be of the
                 /// specified compressed format.
                 #[inline]
-                pub fn with_compressed_data<F>(facade: &F, data: {param}, {dim_params},
+                pub fn with_compressed_data<F: ?Sized>(facade: &F, data: {param}, {dim_params},
                                                       format: {format}, mipmaps: {mipmaps})
                                                       -> Result<{name}, TextureCreationError>
                                                        where F: Facade
@@ -628,7 +628,7 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
         (writeln!(dest, "
                 /// Builds a new texture with a specific format.
                 #[inline]
-                pub fn with_format<'a, F, T>(facade: &F, data: {param},
+                pub fn with_format<'a, F: ?Sized, T>(facade: &F, data: {param},
                                           format: {format}, mipmaps: {mipmaps})
                                           -> Result<{name}, TextureCreationError>
                                           where T: {data_source_trait}<'a>, F: Facade
@@ -654,7 +654,7 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
 
         (writeln!(dest, "
                 #[inline]
-                fn new_impl<'a, F, T>(facade: &F, data: {param},
+                fn new_impl<'a, F: ?Sized, T>(facade: &F, data: {param},
                                    format: Option<{relevant_format}>, mipmaps: {mipmaps})
                                    -> Result<{name}, TextureCreationError>
                                    where T: {data_source_trait}<'a>, F: Facade
@@ -718,7 +718,7 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
                 ///
                 /// The texture will contain undefined data.
                 #[inline]
-                pub fn empty<F>(facade: &F, {dim_params})
+                pub fn empty<F: ?Sized>(facade: &F, {dim_params})
                                 -> Result<{name}, TextureCreationError>
                                 where F: Facade
                 {{
@@ -742,7 +742,7 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
                 ///
                 /// The texture (and its mipmaps) will contain undefined data.
                 #[inline]
-                pub fn empty_with_format<F>(facade: &F, format: {format}, mipmaps: {mipmaps}, {dim_params}) -> Result<{name}, TextureCreationError> where F: Facade {{
+                pub fn empty_with_format<F: ?Sized>(facade: &F, format: {format}, mipmaps: {mipmaps}, {dim_params}) -> Result<{name}, TextureCreationError> where F: Facade {{
                     let format = format.to_texture_format();
                     let format = TextureFormatRequest::Specific(format);
             ", format = relevant_format, dim_params = dimensions_parameters_input, name = name,
@@ -765,7 +765,7 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
                 ///
                 /// The texture (and its mipmaps) will contain undefined data.
                 #[inline]
-                pub fn empty_with_mipmaps<F>(facade: &F, mipmaps: {mipmaps}, {dim_params}) -> Result<{name}, TextureCreationError> where F: Facade {{
+                pub fn empty_with_mipmaps<F: ?Sized>(facade: &F, mipmaps: {mipmaps}, {dim_params}) -> Result<{name}, TextureCreationError> where F: Facade {{
                     let format = {format};
             ", format = default_format, dim_params = dimensions_parameters_input, name = name,
                mipmaps = mipmaps_option_ty)).unwrap();
@@ -784,7 +784,7 @@ fn build_texture<W: Write>(mut dest: &mut W, ty: TextureType, dimensions: Textur
                 /// If `owned` is true, this reference will take ownership of the texture and be responsible
                 /// for cleaning it up. Otherwise, the texture must be cleaned up externally, but only
                 /// after this reference's lifetime has ended.
-                pub unsafe fn from_id<F: Facade>(facade: &F,
+                pub unsafe fn from_id<F: Facade + ?Sized>(facade: &F,
                                                  format: {format},
                                                  id: gl::types::GLuint,
                                                  owned: bool,

--- a/examples/fxaa.rs
+++ b/examples/fxaa.rs
@@ -33,7 +33,7 @@ mod fxaa {
     implement_vertex!(SpriteVertex, position, i_tex_coords);
 
     impl FxaaSystem {
-        pub fn new<F>(facade: &F) -> FxaaSystem where F: Facade + Clone {
+        pub fn new<F: ?Sized>(facade: &F) -> FxaaSystem where F: Facade + Clone {
             FxaaSystem {
                 context: facade.get_context().clone(),
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -80,7 +80,7 @@ pub trait Facade {
     fn get_context(&self) -> &Rc<Context>;
 }
 
-impl<T> CapabilitiesSource for T where T: Facade {
+impl<T: ?Sized> CapabilitiesSource for T where T: Facade {
     fn get_version(&self) -> &Version {
         self.get_context().deref().get_version()
     }

--- a/src/buffer/alloc.rs
+++ b/src/buffer/alloc.rs
@@ -106,7 +106,7 @@ pub struct Alloc {
 impl Alloc {
     /// Builds a new buffer containing the given data. The size of the buffer is equal to the
     /// size of the data.
-    pub fn new<D: ?Sized, F>(facade: &F, data: &D, ty: BufferType, mode: BufferMode)
+    pub fn new<D: ?Sized, F: ?Sized>(facade: &F, data: &D, ty: BufferType, mode: BufferMode)
                              -> Result<Alloc, BufferCreationError>
                              where D: Content, F: Facade
     {
@@ -133,7 +133,7 @@ impl Alloc {
     }
 
     /// Builds a new empty buffer of the given size.
-    pub fn empty<F>(facade: &F, ty: BufferType, size: usize, mode: BufferMode)
+    pub fn empty<F: ?Sized>(facade: &F, ty: BufferType, size: usize, mode: BufferMode)
                     -> Result<Alloc, BufferCreationError> where F: Facade
     {
         let mut ctxt = facade.get_context().make_current();
@@ -1085,7 +1085,7 @@ impl<'b, D> WriteMapping<'b, [D]> where [D]: Content, D: Copy {
 }
 
 /// Returns true if reading from a buffer is supported by the backend.
-pub fn is_buffer_read_supported<C>(ctxt: &C) -> bool where C: CapabilitiesSource {
+pub fn is_buffer_read_supported<C: ?Sized>(ctxt: &C) -> bool where C: CapabilitiesSource {
     if ctxt.get_version() >= &Version(Api::Gl, 4, 5) {
         true
 

--- a/src/buffer/view.rs
+++ b/src/buffer/view.rs
@@ -51,7 +51,7 @@ impl<T: ?Sized> GlObject for Buffer<T> where T: Content {
 impl<T: ?Sized> Buffer<T> where T: Content {
     /// Builds a new buffer containing the given data. The size of the buffer is equal to the size
     /// of the data.
-    pub fn new<F>(facade: &F, data: &T, ty: BufferType, mode: BufferMode)
+    pub fn new<F: ?Sized>(facade: &F, data: &T, ty: BufferType, mode: BufferMode)
                   -> Result<Buffer<T>, BufferCreationError>
                   where F: Facade
     {
@@ -66,7 +66,7 @@ impl<T: ?Sized> Buffer<T> where T: Content {
     }
 
     /// Builds a new buffer of the given size.
-    pub fn empty_unsized<F>(facade: &F, ty: BufferType, size: usize, mode: BufferMode)
+    pub fn empty_unsized<F: ?Sized>(facade: &F, ty: BufferType, size: usize, mode: BufferMode)
                             -> Result<Buffer<T>, BufferCreationError> where F: Facade
     {
         assert!(<T as Content>::is_size_suitable(size));
@@ -325,7 +325,7 @@ impl<T: ?Sized> Buffer<T> where T: Content {
 
 impl<T> Buffer<T> where T: Content + Copy {
     /// Builds a new buffer of the given size.
-    pub fn empty<F>(facade: &F, ty: BufferType, mode: BufferMode)
+    pub fn empty<F: ?Sized>(facade: &F, ty: BufferType, mode: BufferMode)
                     -> Result<Buffer<T>, BufferCreationError> where F: Facade
     {
         Alloc::empty(facade, ty, mem::size_of::<T>(), mode)
@@ -341,7 +341,7 @@ impl<T> Buffer<T> where T: Content + Copy {
 
 impl<T> Buffer<[T]> where [T]: Content, T: Copy {
     /// Builds a new buffer of the given size.
-    pub fn empty_array<F>(facade: &F, ty: BufferType, len: usize, mode: BufferMode)
+    pub fn empty_array<F: ?Sized>(facade: &F, ty: BufferType, len: usize, mode: BufferMode)
                           -> Result<Buffer<[T]>, BufferCreationError> where F: Facade
     {
         Alloc::empty(facade, ty, len * mem::size_of::<T>(), mode)

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -123,7 +123,7 @@ pub struct TimestampQuery {
 
 impl TimestampQuery {
     /// Creates a new `TimestampQuery`. Returns `None` if the backend doesn't support it.
-    pub fn new<F>(facade: &F) -> Option<TimestampQuery> where F: Facade {
+    pub fn new<F: ?Sized>(facade: &F) -> Option<TimestampQuery> where F: Facade {
         let ctxt = facade.get_context().make_current();
 
         let id = if ctxt.version >= &Version(Api::Gl, 3, 2) {    // TODO: extension

--- a/src/draw_parameters/query.rs
+++ b/src/draw_parameters/query.rs
@@ -105,7 +105,7 @@ impl Error for ToBufferError {
 
 impl RawQuery {
     /// Builds a new query. Returns `None` if the backend doesn't support this type.
-    pub fn new<F>(facade: &F, ty: QueryType) -> Result<RawQuery, QueryCreationError>
+    pub fn new<F: ?Sized>(facade: &F, ty: QueryType) -> Result<RawQuery, QueryCreationError>
                   where F: Facade
     {
         let context = facade.get_context().clone();
@@ -824,7 +824,7 @@ pub struct SamplesPassedQuery {
 impl SamplesPassedQuery {
     /// Builds a new query.
     #[inline]
-    pub fn new<F>(facade: &F) -> Result<SamplesPassedQuery, QueryCreationError> where F: Facade {
+    pub fn new<F: ?Sized>(facade: &F) -> Result<SamplesPassedQuery, QueryCreationError> where F: Facade {
         RawQuery::new(facade, QueryType::SamplesPassed).map(|q| SamplesPassedQuery { query: q })
     }
 }
@@ -843,7 +843,7 @@ pub struct TimeElapsedQuery {
 impl TimeElapsedQuery {
     /// Builds a new query.
     #[inline]
-    pub fn new<F>(facade: &F) -> Result<TimeElapsedQuery, QueryCreationError> where F: Facade {
+    pub fn new<F: ?Sized>(facade: &F) -> Result<TimeElapsedQuery, QueryCreationError> where F: Facade {
         RawQuery::new(facade, QueryType::TimeElapsed).map(|q| TimeElapsedQuery { query: q })
     }
 }
@@ -871,7 +871,7 @@ impl AnySamplesPassedQuery {
     ///
     /// If you pass `true` for `conservative`, then OpenGL may use a less accurate algorithm,
     /// leading to a faster result but with more false positives.
-    pub fn new<F>(facade: &F, conservative: bool)
+    pub fn new<F: ?Sized>(facade: &F, conservative: bool)
                   -> Result<AnySamplesPassedQuery, QueryCreationError>
                   where F: Facade
     {
@@ -903,7 +903,7 @@ pub struct PrimitivesGeneratedQuery {
 impl PrimitivesGeneratedQuery {
     /// Builds a new query.
     #[inline]
-    pub fn new<F>(facade: &F) -> Result<PrimitivesGeneratedQuery, QueryCreationError>
+    pub fn new<F: ?Sized>(facade: &F) -> Result<PrimitivesGeneratedQuery, QueryCreationError>
                   where F: Facade
     {
         RawQuery::new(facade, QueryType::PrimitivesGenerated)
@@ -922,7 +922,7 @@ pub struct TransformFeedbackPrimitivesWrittenQuery {
 impl TransformFeedbackPrimitivesWrittenQuery {
     /// Builds a new query.
     #[inline]
-    pub fn new<F>(facade: &F) -> Result<TransformFeedbackPrimitivesWrittenQuery, QueryCreationError>
+    pub fn new<F: ?Sized>(facade: &F) -> Result<TransformFeedbackPrimitivesWrittenQuery, QueryCreationError>
                   where F: Facade
     {
         RawQuery::new(facade, QueryType::TransformFeedbackPrimitivesWritten)

--- a/src/fbo.rs
+++ b/src/fbo.rs
@@ -78,7 +78,7 @@ use version::Api;
 /// If this function returns `true` and you pass attachments with different dimensions, the
 /// intersection between all the attachments will be used. If this function returns `false`, you'll
 /// get an error instead.
-pub fn is_dimensions_mismatch_supported<C>(context: &C) -> bool where C: CapabilitiesSource {
+pub fn is_dimensions_mismatch_supported<C: ?Sized>(context: &C) -> bool where C: CapabilitiesSource {
     context.get_version() >= &Version(Api::Gl, 3, 0) ||
     context.get_version() >= &Version(Api::GlEs, 2, 0) ||
     context.get_extensions().gl_arb_framebuffer_object
@@ -161,7 +161,7 @@ impl<'a> FramebufferAttachments<'a> {
     /// After building a `FramebufferAttachments` struct, you must use this function
     /// to "compile" the attachments and make sure that they are valid together.
     #[inline]
-    pub fn validate<C>(self, context: &C) -> Result<ValidatedAttachments<'a>, ValidationError>
+    pub fn validate<C: ?Sized>(self, context: &C) -> Result<ValidatedAttachments<'a>, ValidationError>
                        where C: CapabilitiesSource
     {
         match self {
@@ -214,7 +214,7 @@ impl<'a> FramebufferAttachments<'a> {
         }
     }
 
-    fn validate_layered<C>(context: &C, FramebufferSpecificAttachments { colors, depth_stencil }:
+    fn validate_layered<C: ?Sized>(context: &C, FramebufferSpecificAttachments { colors, depth_stencil }:
                            FramebufferSpecificAttachments<LayeredAttachment<'a>>)
                            -> Result<ValidatedAttachments<'a>, ValidationError>
                            where C: CapabilitiesSource
@@ -344,7 +344,7 @@ impl<'a> FramebufferAttachments<'a> {
         })
     }
 
-    fn validate_regular<C>(context: &C, FramebufferSpecificAttachments { colors, depth_stencil }:
+    fn validate_regular<C: ?Sized>(context: &C, FramebufferSpecificAttachments { colors, depth_stencil }:
                         FramebufferSpecificAttachments<RegularAttachment<'a>>)
                         -> Result<ValidatedAttachments<'a>, ValidationError>
                         where C: CapabilitiesSource

--- a/src/framebuffer/default_fb.rs
+++ b/src/framebuffer/default_fb.rs
@@ -46,7 +46,7 @@ pub struct DefaultFramebuffer {
 impl DefaultFramebuffer {
     /// Creates a `DefaultFramebuffer` with the back left buffer.
     #[inline]
-    pub fn back_left<F>(facade: &F) -> DefaultFramebuffer where F: Facade {
+    pub fn back_left<F: ?Sized>(facade: &F) -> DefaultFramebuffer where F: Facade {
         DefaultFramebuffer {
             context: facade.get_context().clone(),
             attachment: DefaultFramebufferAttachment::BackLeft,

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -111,7 +111,7 @@ impl<'a> SimpleFrameBuffer<'a> {
     /// Creates a `SimpleFrameBuffer` with a single color attachment and no depth
     /// nor stencil buffer.
     #[inline]
-    pub fn new<F, C>(facade: &F, color: C) -> Result<SimpleFrameBuffer<'a>, ValidationError>
+    pub fn new<F: ?Sized, C>(facade: &F, color: C) -> Result<SimpleFrameBuffer<'a>, ValidationError>
                      where C: ToColorAttachment<'a>, F: Facade
     {
         SimpleFrameBuffer::new_impl(facade, Some(color.to_color_attachment()), None, None, None)
@@ -120,7 +120,7 @@ impl<'a> SimpleFrameBuffer<'a> {
     /// Creates a `SimpleFrameBuffer` with a single color attachment and a depth
     /// buffer, but no stencil buffer.
     #[inline]
-    pub fn with_depth_buffer<F, C, D>(facade: &F, color: C, depth: D)
+    pub fn with_depth_buffer<F: ?Sized, C, D>(facade: &F, color: C, depth: D)
                                       -> Result<SimpleFrameBuffer<'a>, ValidationError>
                                       where C: ToColorAttachment<'a>,
                                             D: ToDepthAttachment<'a>, F: Facade
@@ -132,7 +132,7 @@ impl<'a> SimpleFrameBuffer<'a> {
     /// Creates a `SimpleFrameBuffer` with a single color attachment and no depth
     /// nor stencil buffer.
     #[inline]
-    pub fn depth_only<F, D>(facade: &F, depth: D)
+    pub fn depth_only<F: ?Sized, D>(facade: &F, depth: D)
                             -> Result<SimpleFrameBuffer<'a>, ValidationError>
         where D: ToDepthAttachment<'a>, F: Facade
     {
@@ -142,7 +142,7 @@ impl<'a> SimpleFrameBuffer<'a> {
     /// Creates a `SimpleFrameBuffer` with a single color attachment, a depth
     /// buffer, and a stencil buffer.
     #[inline]
-    pub fn with_depth_and_stencil_buffer<F, C, D, S>(facade: &F, color: C, depth: D,
+    pub fn with_depth_and_stencil_buffer<F: ?Sized, C, D, S>(facade: &F, color: C, depth: D,
                                                      stencil: S)
                                                      -> Result<SimpleFrameBuffer<'a>,
                                                                ValidationError>
@@ -158,7 +158,7 @@ impl<'a> SimpleFrameBuffer<'a> {
     /// Creates a `SimpleFrameBuffer` with a single color attachment and no depth
     /// nor stencil buffer.
     #[inline]
-    pub fn depth_and_stencil_only<F, D, S>(facade: &F, depth: D, stencil: S)
+    pub fn depth_and_stencil_only<F: ?Sized, D, S>(facade: &F, depth: D, stencil: S)
                                            -> Result<SimpleFrameBuffer<'a>, ValidationError>
         where D: ToDepthAttachment<'a>,
               S: ToStencilAttachment<'a>, F: Facade
@@ -170,7 +170,7 @@ impl<'a> SimpleFrameBuffer<'a> {
     /// Creates a `SimpleFrameBuffer` with a single color attachment and a stencil
     /// buffer, but no depth buffer.
     #[inline]
-    pub fn with_stencil_buffer<F, C, S>(facade: &F, color: C, stencil: S)
+    pub fn with_stencil_buffer<F: ?Sized, C, S>(facade: &F, color: C, stencil: S)
                                         -> Result<SimpleFrameBuffer<'a>, ValidationError>
                                         where C: ToColorAttachment<'a>, S: ToStencilAttachment<'a>,
                                               F: Facade
@@ -182,7 +182,7 @@ impl<'a> SimpleFrameBuffer<'a> {
     /// Creates a `SimpleFrameBuffer` with a single color attachment and a stencil
     /// buffer, but no depth buffer.
     #[inline]
-    pub fn stencil_only<F, S>(facade: &F, stencil: S)
+    pub fn stencil_only<F: ?Sized, S>(facade: &F, stencil: S)
                               -> Result<SimpleFrameBuffer<'a>, ValidationError>
         where S: ToStencilAttachment<'a>, F: Facade
     {
@@ -192,7 +192,7 @@ impl<'a> SimpleFrameBuffer<'a> {
 
     /// Creates a `SimpleFrameBuffer` with a single color attachment and a depth-stencil buffer.
     #[inline]
-    pub fn with_depth_stencil_buffer<F, C, D>(facade: &F, color: C, depthstencil: D)
+    pub fn with_depth_stencil_buffer<F: ?Sized, C, D>(facade: &F, color: C, depthstencil: D)
                                               -> Result<SimpleFrameBuffer<'a>, ValidationError>
                                               where C: ToColorAttachment<'a>,
                                                     D: ToDepthStencilAttachment<'a>, F: Facade
@@ -203,7 +203,7 @@ impl<'a> SimpleFrameBuffer<'a> {
 
     /// Creates a `SimpleFrameBuffer` with a single color attachment and a depth-stencil buffer.
     #[inline]
-    pub fn depth_stencil_only<F, D>(facade: &F, depthstencil: D)
+    pub fn depth_stencil_only<F: ?Sized, D>(facade: &F, depthstencil: D)
                                     -> Result<SimpleFrameBuffer<'a>, ValidationError>
         where D: ToDepthStencilAttachment<'a>, F: Facade
     {
@@ -212,7 +212,7 @@ impl<'a> SimpleFrameBuffer<'a> {
     }
 
 
-    fn new_impl<F>(facade: &F, color: Option<ColorAttachment<'a>>,
+    fn new_impl<F: ?Sized>(facade: &F, color: Option<ColorAttachment<'a>>,
                    depth: Option<DepthAttachment<'a>>, stencil: Option<StencilAttachment<'a>>,
                    depthstencil: Option<DepthStencilAttachment<'a>>)
                    -> Result<SimpleFrameBuffer<'a>, ValidationError> where F: Facade
@@ -372,7 +372,7 @@ impl<'a> MultiOutputFrameBuffer<'a> {
     ///
     /// Panics if all attachments don't have the same dimensions.
     #[inline]
-    pub fn new<F, I, A>(facade: &F, color_attachments: I)
+    pub fn new<F: ?Sized, I, A>(facade: &F, color_attachments: I)
                         -> Result<MultiOutputFrameBuffer<'a>, ValidationError>
         where F: Facade,
               I: IntoIterator<Item = (&'a str, A)>,
@@ -387,7 +387,7 @@ impl<'a> MultiOutputFrameBuffer<'a> {
     ///
     /// Panics if all attachments don't have the same dimensions.
     #[inline]
-    pub fn with_depth_buffer<F, D, I, A>(facade: &F, color_attachments: I, depth: D)
+    pub fn with_depth_buffer<F: ?Sized, D, I, A>(facade: &F, color_attachments: I, depth: D)
                                          -> Result<MultiOutputFrameBuffer<'a>, ValidationError>
         where F: Facade,
               D: ToDepthAttachment<'a>, 
@@ -404,7 +404,7 @@ impl<'a> MultiOutputFrameBuffer<'a> {
     ///
     /// Panics if all attachments don't have the same dimensions.
     #[inline]
-    pub fn with_depth_and_stencil_buffer<A, F, I, D, S>(facade: &F, color: I, depth: D, stencil: S)
+    pub fn with_depth_and_stencil_buffer<A, F: ?Sized, I, D, S>(facade: &F, color: I, depth: D, stencil: S)
                                                         -> Result<MultiOutputFrameBuffer<'a>,
                                                                   ValidationError>
         where D: ToDepthAttachment<'a>,
@@ -424,7 +424,7 @@ impl<'a> MultiOutputFrameBuffer<'a> {
     ///
     /// Panics if all attachments don't have the same dimensions.
     #[inline]
-    pub fn with_stencil_buffer<A, F, I, S>(facade: &F, color: I, stencil: S)
+    pub fn with_stencil_buffer<A, F: ?Sized, I, S>(facade: &F, color: I, stencil: S)
                                            -> Result<MultiOutputFrameBuffer<'a>, ValidationError>
         where S: ToStencilAttachment<'a>,
               F: Facade,
@@ -441,7 +441,7 @@ impl<'a> MultiOutputFrameBuffer<'a> {
     ///
     /// Panics if all attachments don't have the same dimensions.
     #[inline]
-    pub fn with_depth_stencil_buffer<A, F, I, D>(facade: &F, color: I, depthstencil: D)
+    pub fn with_depth_stencil_buffer<A, F: ?Sized, I, D>(facade: &F, color: I, depthstencil: D)
                                                  -> Result<MultiOutputFrameBuffer<'a>, ValidationError>
         where D: ToDepthStencilAttachment<'a>, F: Facade,
               I: IntoIterator<Item = (&'a str, A)>,
@@ -451,7 +451,7 @@ impl<'a> MultiOutputFrameBuffer<'a> {
                                     Some(depthstencil.to_depth_stencil_attachment()))
     }
 
-    fn new_impl<F, I, A>(facade: &F, color: I, depth: Option<DepthAttachment<'a>>,
+    fn new_impl<F: ?Sized, I, A>(facade: &F, color: I, depth: Option<DepthAttachment<'a>>,
                          stencil: Option<StencilAttachment<'a>>,
                          depthstencil: Option<DepthStencilAttachment<'a>>)
                          -> Result<MultiOutputFrameBuffer<'a>, ValidationError>
@@ -635,14 +635,14 @@ pub struct EmptyFrameBuffer {
 
 impl<'a> EmptyFrameBuffer {
     /// Returns true if empty framebuffers are supported by the backend.
-    pub fn is_supported<C>(context: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_supported<C: ?Sized>(context: &C) -> bool where C: CapabilitiesSource {
         context.get_version() >= &Version(Api::Gl, 4, 3) ||
         context.get_version() >= &Version(Api::GlEs, 3, 1) ||
         context.get_extensions().gl_arb_framebuffer_no_attachments
     }
 
     /// Returns true if layered empty framebuffers are supported by the backend.
-    pub fn is_layered_supported<C>(context: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_layered_supported<C: ?Sized>(context: &C) -> bool where C: CapabilitiesSource {
         context.get_version() >= &Version(Api::Gl, 4, 3) ||
         context.get_version() >= &Version(Api::GlEs, 3, 2) ||
         context.get_extensions().gl_arb_framebuffer_no_attachments
@@ -650,25 +650,25 @@ impl<'a> EmptyFrameBuffer {
 
     /// Returns the maximum width of empty framebuffers that the backend supports, or `None` if
     /// empty framebuffers are not supported.
-    pub fn get_max_supported_width<C>(context: &C) -> Option<u32> where C: CapabilitiesSource {
+    pub fn get_max_supported_width<C: ?Sized>(context: &C) -> Option<u32> where C: CapabilitiesSource {
         context.get_capabilities().max_framebuffer_width.map(|v| v as u32)
     }
 
     /// Returns the maximum height of empty framebuffers that the backend supports, or `None` if
     /// empty framebuffers are not supported.
-    pub fn get_max_supported_height<C>(context: &C) -> Option<u32> where C: CapabilitiesSource {
+    pub fn get_max_supported_height<C: ?Sized>(context: &C) -> Option<u32> where C: CapabilitiesSource {
         context.get_capabilities().max_framebuffer_height.map(|v| v as u32)
     }
 
     /// Returns the maximum number of samples of empty framebuffers that the backend supports,
     /// or `None` if empty framebuffers are not supported.
-    pub fn get_max_supported_samples<C>(context: &C) -> Option<u32> where C: CapabilitiesSource {
+    pub fn get_max_supported_samples<C: ?Sized>(context: &C) -> Option<u32> where C: CapabilitiesSource {
         context.get_capabilities().max_framebuffer_samples.map(|v| v as u32)
     }
 
     /// Returns the maximum number of layers of empty framebuffers that the backend supports,
     /// or `None` if layered empty framebuffers are not supported.
-    pub fn get_max_supported_layers<C>(context: &C) -> Option<u32> where C: CapabilitiesSource {
+    pub fn get_max_supported_layers<C: ?Sized>(context: &C) -> Option<u32> where C: CapabilitiesSource {
         context.get_capabilities().max_framebuffer_layers.map(|v| v as u32)
     }
 
@@ -679,7 +679,7 @@ impl<'a> EmptyFrameBuffer {
     /// Panicks if `layers` or `samples` is equal to `Some(0)`.
     ///
     #[inline]
-    pub fn new<F>(facade: &F, width: u32, height: u32, layers: Option<u32>,
+    pub fn new<F: ?Sized>(facade: &F, width: u32, height: u32, layers: Option<u32>,
                   samples: Option<u32>, fixed_samples: bool)
                   -> Result<EmptyFrameBuffer, ValidationError> where F: Facade
     {

--- a/src/framebuffer/render_buffer.rs
+++ b/src/framebuffer/render_buffer.rs
@@ -66,7 +66,7 @@ pub struct RenderBuffer {
 
 impl RenderBuffer {
     /// Builds a new render buffer.
-    pub fn new<F>(facade: &F, format: UncompressedFloatFormat, width: u32, height: u32)
+    pub fn new<F: ?Sized>(facade: &F, format: UncompressedFloatFormat, width: u32, height: u32)
                   -> Result<RenderBuffer, CreationError> where F: Facade
     {
         let format = image_format::TextureFormatRequest::Specific(image_format::TextureFormat::UncompressedFloat(format));
@@ -119,7 +119,7 @@ pub struct DepthRenderBuffer {
 
 impl DepthRenderBuffer {
     /// Builds a new render buffer.
-    pub fn new<F>(facade: &F, format: DepthFormat, width: u32, height: u32)
+    pub fn new<F: ?Sized>(facade: &F, format: DepthFormat, width: u32, height: u32)
                   -> Result<DepthRenderBuffer, CreationError> where F: Facade
     {
         let format = image_format::TextureFormatRequest::Specific(image_format::TextureFormat::DepthFormat(format));
@@ -171,7 +171,7 @@ pub struct StencilRenderBuffer {
 
 impl StencilRenderBuffer {
     /// Builds a new render buffer.
-    pub fn new<F>(facade: &F, format: StencilFormat, width: u32, height: u32)
+    pub fn new<F: ?Sized>(facade: &F, format: StencilFormat, width: u32, height: u32)
                   -> Result<StencilRenderBuffer, CreationError> where F: Facade
     {
         let format = image_format::TextureFormatRequest::Specific(image_format::TextureFormat::StencilFormat(format));
@@ -224,7 +224,7 @@ pub struct DepthStencilRenderBuffer {
 
 impl DepthStencilRenderBuffer {
     /// Builds a new render buffer.
-    pub fn new<F>(facade: &F, format: DepthStencilFormat, width: u32, height: u32)
+    pub fn new<F: ?Sized>(facade: &F, format: DepthStencilFormat, width: u32, height: u32)
                   -> Result<DepthStencilRenderBuffer, CreationError> where F: Facade
     {
         let format = image_format::TextureFormatRequest::Specific(image_format::TextureFormat::DepthStencilFormat(format));
@@ -280,7 +280,7 @@ pub struct RenderBufferAny {
 
 impl RenderBufferAny {
     /// Builds a new render buffer.
-    fn new<F>(facade: &F, format: gl::types::GLenum, kind: TextureKind, width: u32, height: u32,
+    fn new<F: ?Sized>(facade: &F, format: gl::types::GLenum, kind: TextureKind, width: u32, height: u32,
               samples: Option<u32>) -> RenderBufferAny
         where F: Facade
     {

--- a/src/image_format.rs
+++ b/src/image_format.rs
@@ -390,7 +390,7 @@ impl UncompressedFloatFormat {
     }
 
     /// Returns true if this format is supported by the backend.
-    pub fn is_supported<C>(&self, context: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_supported<C: ?Sized>(&self, context: &C) -> bool where C: CapabilitiesSource {
         let version = context.get_version();
         let extensions = context.get_extensions();
 
@@ -530,7 +530,7 @@ impl UncompressedFloatFormat {
 
     /// Returns true if a texture or renderbuffer with this format can be used as a framebuffer
     /// attachment.
-    pub fn is_color_renderable<C>(&self, context: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_color_renderable<C: ?Sized>(&self, context: &C) -> bool where C: CapabilitiesSource {
         // this is the only format that is never renderable
         if let &UncompressedFloatFormat::F9F9F9 = self {
             return false;
@@ -647,7 +647,7 @@ impl SrgbFormat {
     }
 
     /// Returns true if this format is supported by the backend.
-    pub fn is_supported<C>(&self, context: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_supported<C: ?Sized>(&self, context: &C) -> bool where C: CapabilitiesSource {
         let version = context.get_version();
         let extensions = context.get_extensions();
 
@@ -666,7 +666,7 @@ impl SrgbFormat {
 
     /// Returns true if a texture or renderbuffer with this format can be used as a framebuffer
     /// attachment.
-    pub fn is_color_renderable<C>(&self, context: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_color_renderable<C: ?Sized>(&self, context: &C) -> bool where C: CapabilitiesSource {
         // checking whether it's supported, so that we don't return `true` by accident
         if !self.is_supported(context) {
             return false;
@@ -738,7 +738,7 @@ impl UncompressedIntFormat {
     }
 
     /// Returns true if this format is supported by the backend.
-    pub fn is_supported<C>(&self, context: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_supported<C: ?Sized>(&self, context: &C) -> bool where C: CapabilitiesSource {
         let version = context.get_version();
         let extensions = context.get_extensions();
 
@@ -801,7 +801,7 @@ impl UncompressedIntFormat {
 
     /// Returns true if a texture or renderbuffer with this format can be used as a framebuffer
     /// attachment.
-    pub fn is_color_renderable<C>(&self, context: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_color_renderable<C: ?Sized>(&self, context: &C) -> bool where C: CapabilitiesSource {
         // checking whether it's supported, so that we don't return `true` by accident
         if !self.is_supported(context) {
             return false;
@@ -899,7 +899,7 @@ impl UncompressedUintFormat {
     }
 
     /// Returns true if this format is supported by the backend.
-    pub fn is_supported<C>(&self, context: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_supported<C: ?Sized>(&self, context: &C) -> bool where C: CapabilitiesSource {
         let version = context.get_version();
         let extensions = context.get_extensions();
 
@@ -966,7 +966,7 @@ impl UncompressedUintFormat {
 
     /// Returns true if a texture or renderbuffer with this format can be used as a framebuffer
     /// attachment.
-    pub fn is_color_renderable<C>(&self, context: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_color_renderable<C: ?Sized>(&self, context: &C) -> bool where C: CapabilitiesSource {
         // checking whether it's supported, so that we don't return `true` by accident
         if !self.is_supported(context) {
             return false;
@@ -1071,7 +1071,7 @@ impl CompressedFormat {
     }
 
     /// Returns true if this format is supported by the backend.
-    pub fn is_supported<C>(&self, context: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_supported<C: ?Sized>(&self, context: &C) -> bool where C: CapabilitiesSource {
         let version = context.get_version();
         let extensions = context.get_extensions();
 
@@ -1161,7 +1161,7 @@ impl CompressedSrgbFormat {
     }
 
     /// Returns true if this format is supported by the backend.
-    pub fn is_supported<C>(&self, context: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_supported<C: ?Sized>(&self, context: &C) -> bool where C: CapabilitiesSource {
         let version = context.get_version();
         let extensions = context.get_extensions();
 
@@ -1228,7 +1228,7 @@ impl DepthFormat {
     }
 
     /// Returns true if this format is supported by the backend.
-    pub fn is_supported<C>(&self, context: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_supported<C: ?Sized>(&self, context: &C) -> bool where C: CapabilitiesSource {
         let version = context.get_version();
         let extensions = context.get_extensions();
 
@@ -1288,7 +1288,7 @@ impl DepthStencilFormat {
     }
 
     /// Returns true if this format is supported by the backend.
-    pub fn is_supported<C>(&self, context: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_supported<C: ?Sized>(&self, context: &C) -> bool where C: CapabilitiesSource {
         let version = context.get_version();
         let extensions = context.get_extensions();
 
@@ -1346,7 +1346,7 @@ impl StencilFormat {
     }
 
     /// Returns true if this format is supported by the backend for textures.
-    pub fn is_supported_for_textures<C>(&self, context: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_supported_for_textures<C: ?Sized>(&self, context: &C) -> bool where C: CapabilitiesSource {
         let version = context.get_version();
         let extensions = context.get_extensions();
 
@@ -1361,7 +1361,7 @@ impl StencilFormat {
     }
 
     /// Returns true if this format is supported by the backend for renderbuffers.
-    pub fn is_supported_for_renderbuffers<C>(&self, context: &C) -> bool
+    pub fn is_supported_for_renderbuffers<C: ?Sized>(&self, context: &C) -> bool
                                              where C: CapabilitiesSource
     {
         let version = context.get_version();
@@ -1434,7 +1434,7 @@ impl TextureFormat {
 
     /// Returns true if this format is supported by the backend for textures.
     #[inline]
-    pub fn is_supported_for_textures<C>(&self, c: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_supported_for_textures<C: ?Sized>(&self, c: &C) -> bool where C: CapabilitiesSource {
         match self {
             &TextureFormat::UncompressedFloat(format) => format.is_supported(c),
             &TextureFormat::UncompressedIntegral(format) => format.is_supported(c),
@@ -1450,7 +1450,7 @@ impl TextureFormat {
 
     /// Returns true if this format is supported by the backend for renderbuffers.
     #[inline]
-    pub fn is_supported_for_renderbuffers<C>(&self, c: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_supported_for_renderbuffers<C: ?Sized>(&self, c: &C) -> bool where C: CapabilitiesSource {
         match self {
             &TextureFormat::UncompressedFloat(format) => format.is_supported(c),
             &TextureFormat::UncompressedIntegral(format) => format.is_supported(c),
@@ -1467,7 +1467,7 @@ impl TextureFormat {
     /// Returns true if the format is color-renderable, depth-renderable, depth-stencil-renderable
     /// or stencil-renderable.
     #[inline]
-    pub fn is_renderable<C>(&self, c: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_renderable<C: ?Sized>(&self, c: &C) -> bool where C: CapabilitiesSource {
         match self {
             &TextureFormat::UncompressedFloat(format) => format.is_color_renderable(c),
             &TextureFormat::UncompressedIntegral(format) => format.is_color_renderable(c),

--- a/src/index/buffer.rs
+++ b/src/index/buffer.rs
@@ -73,7 +73,7 @@ pub struct IndexBuffer<T> where T: Index {
 impl<T> IndexBuffer<T> where T: Index {
     /// Builds a new index buffer from a list of indices and a primitive type.
     #[inline]
-    pub fn new<F>(facade: &F, prim: PrimitiveType, data: &[T])
+    pub fn new<F: ?Sized>(facade: &F, prim: PrimitiveType, data: &[T])
                   -> Result<IndexBuffer<T>, CreationError>
                   where F: Facade
     {
@@ -82,7 +82,7 @@ impl<T> IndexBuffer<T> where T: Index {
 
     /// Builds a new index buffer from a list of indices and a primitive type.
     #[inline]
-    pub fn dynamic<F>(facade: &F, prim: PrimitiveType, data: &[T])
+    pub fn dynamic<F: ?Sized>(facade: &F, prim: PrimitiveType, data: &[T])
                       -> Result<IndexBuffer<T>, CreationError>
                       where F: Facade
     {
@@ -91,7 +91,7 @@ impl<T> IndexBuffer<T> where T: Index {
 
     /// Builds a new index buffer from a list of indices and a primitive type.
     #[inline]
-    pub fn persistent<F>(facade: &F, prim: PrimitiveType, data: &[T])
+    pub fn persistent<F: ?Sized>(facade: &F, prim: PrimitiveType, data: &[T])
                          -> Result<IndexBuffer<T>, CreationError>
                          where F: Facade
     {
@@ -100,7 +100,7 @@ impl<T> IndexBuffer<T> where T: Index {
 
     /// Builds a new index buffer from a list of indices and a primitive type.
     #[inline]
-    pub fn immutable<F>(facade: &F, prim: PrimitiveType, data: &[T])
+    pub fn immutable<F: ?Sized>(facade: &F, prim: PrimitiveType, data: &[T])
                         -> Result<IndexBuffer<T>, CreationError>
                         where F: Facade
     {
@@ -108,7 +108,7 @@ impl<T> IndexBuffer<T> where T: Index {
     }
 
     #[inline]
-    fn new_impl<F>(facade: &F, prim: PrimitiveType, data: &[T], mode: BufferMode)
+    fn new_impl<F: ?Sized>(facade: &F, prim: PrimitiveType, data: &[T], mode: BufferMode)
                    -> Result<IndexBuffer<T>, CreationError>
                    where F: Facade
     {
@@ -128,7 +128,7 @@ impl<T> IndexBuffer<T> where T: Index {
 
     /// Builds a new empty index buffer.
     #[inline]
-    pub fn empty<F>(facade: &F, prim: PrimitiveType, len: usize)
+    pub fn empty<F: ?Sized>(facade: &F, prim: PrimitiveType, len: usize)
                     -> Result<IndexBuffer<T>, CreationError>
                     where F: Facade
     {
@@ -137,7 +137,7 @@ impl<T> IndexBuffer<T> where T: Index {
 
     /// Builds a new empty index buffer.
     #[inline]
-    pub fn empty_dynamic<F>(facade: &F, prim: PrimitiveType, len: usize)
+    pub fn empty_dynamic<F: ?Sized>(facade: &F, prim: PrimitiveType, len: usize)
                             -> Result<IndexBuffer<T>, CreationError>
                             where F: Facade
     {
@@ -146,7 +146,7 @@ impl<T> IndexBuffer<T> where T: Index {
 
     /// Builds a new empty index buffer.
     #[inline]
-    pub fn empty_persistent<F>(facade: &F, prim: PrimitiveType, len: usize)
+    pub fn empty_persistent<F: ?Sized>(facade: &F, prim: PrimitiveType, len: usize)
                                -> Result<IndexBuffer<T>, CreationError>
                                where F: Facade
     {
@@ -155,7 +155,7 @@ impl<T> IndexBuffer<T> where T: Index {
 
     /// Builds a new empty index buffer.
     #[inline]
-    pub fn empty_immutable<F>(facade: &F, prim: PrimitiveType, len: usize)
+    pub fn empty_immutable<F: ?Sized>(facade: &F, prim: PrimitiveType, len: usize)
                               -> Result<IndexBuffer<T>, CreationError>
                               where F: Facade
     {
@@ -163,7 +163,7 @@ impl<T> IndexBuffer<T> where T: Index {
     }
 
     #[inline]
-    fn empty_impl<F>(facade: &F, prim: PrimitiveType, len: usize, mode: BufferMode)
+    fn empty_impl<F: ?Sized>(facade: &F, prim: PrimitiveType, len: usize, mode: BufferMode)
                      -> Result<IndexBuffer<T>, CreationError>
                      where F: Facade
     {

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -194,7 +194,7 @@ pub enum PrimitiveType {
 
 impl PrimitiveType {
     /// Returns true if the backend supports this type of primitives.
-    pub fn is_supported<C>(&self, caps: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_supported<C: ?Sized>(&self, caps: &C) -> bool where C: CapabilitiesSource {
         match self {
             &PrimitiveType::Points | &PrimitiveType::LinesList | &PrimitiveType::LineStrip |
             &PrimitiveType::LineLoop | &PrimitiveType::TrianglesList |
@@ -286,7 +286,7 @@ impl IndexType {
 
     /// Returns true if the backend supports this type of index.
     #[inline]
-    pub fn is_supported<C>(&self, caps: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_supported<C: ?Sized>(&self, caps: &C) -> bool where C: CapabilitiesSource {
         match self {
             &IndexType::U8 => true,
             &IndexType::U16 => true,
@@ -312,7 +312,7 @@ pub unsafe trait Index: Copy + Send + 'static {
     fn get_type() -> IndexType;
 
     /// Returns true if this type of index is supported by the backend.
-    fn is_supported<C>(caps: &C) -> bool where C: CapabilitiesSource {
+    fn is_supported<C: ?Sized>(caps: &C) -> bool where C: CapabilitiesSource {
         Self::get_type().is_supported(caps)
     }
 }

--- a/src/index/multidraw.rs
+++ b/src/index/multidraw.rs
@@ -55,7 +55,7 @@ impl DrawCommandsNoIndicesBuffer {
     ///
     /// The parameter indicates the number of elements.
     #[inline]
-    pub fn empty<F>(facade: &F, elements: usize)
+    pub fn empty<F: ?Sized>(facade: &F, elements: usize)
                     -> Result<DrawCommandsNoIndicesBuffer, BufferCreationError>
                     where F: Facade
     {
@@ -68,7 +68,7 @@ impl DrawCommandsNoIndicesBuffer {
     ///
     /// The parameter indicates the number of elements.
     #[inline]
-    pub fn empty_dynamic<F>(facade: &F, elements: usize)
+    pub fn empty_dynamic<F: ?Sized>(facade: &F, elements: usize)
                             -> Result<DrawCommandsNoIndicesBuffer, BufferCreationError>
                             where F: Facade
     {
@@ -81,7 +81,7 @@ impl DrawCommandsNoIndicesBuffer {
     ///
     /// The parameter indicates the number of elements.
     #[inline]
-    pub fn empty_persistent<F>(facade: &F, elements: usize)
+    pub fn empty_persistent<F: ?Sized>(facade: &F, elements: usize)
                                -> Result<DrawCommandsNoIndicesBuffer, BufferCreationError>
                                where F: Facade
     {
@@ -94,7 +94,7 @@ impl DrawCommandsNoIndicesBuffer {
     ///
     /// The parameter indicates the number of elements.
     #[inline]
-    pub fn empty_immutable<F>(facade: &F, elements: usize)
+    pub fn empty_immutable<F: ?Sized>(facade: &F, elements: usize)
                               -> Result<DrawCommandsNoIndicesBuffer, BufferCreationError>
                               where F: Facade
     {
@@ -156,7 +156,7 @@ impl DrawCommandsIndicesBuffer {
     ///
     /// The parameter indicates the number of elements.
     #[inline]
-    pub fn empty<F>(facade: &F, elements: usize)
+    pub fn empty<F: ?Sized>(facade: &F, elements: usize)
                     -> Result<DrawCommandsIndicesBuffer, BufferCreationError>
                     where F: Facade
     {
@@ -169,7 +169,7 @@ impl DrawCommandsIndicesBuffer {
     ///
     /// The parameter indicates the number of elements.
     #[inline]
-    pub fn empty_dynamic<F>(facade: &F, elements: usize)
+    pub fn empty_dynamic<F: ?Sized>(facade: &F, elements: usize)
                             -> Result<DrawCommandsIndicesBuffer, BufferCreationError>
                             where F: Facade
     {
@@ -182,7 +182,7 @@ impl DrawCommandsIndicesBuffer {
     ///
     /// The parameter indicates the number of elements.
     #[inline]
-    pub fn empty_persistent<F>(facade: &F, elements: usize)
+    pub fn empty_persistent<F: ?Sized>(facade: &F, elements: usize)
                                -> Result<DrawCommandsIndicesBuffer, BufferCreationError>
                                where F: Facade
     {
@@ -195,7 +195,7 @@ impl DrawCommandsIndicesBuffer {
     ///
     /// The parameter indicates the number of elements.
     #[inline]
-    pub fn empty_immutable<F>(facade: &F, elements: usize)
+    pub fn empty_immutable<F: ?Sized>(facade: &F, elements: usize)
                               -> Result<DrawCommandsIndicesBuffer, BufferCreationError>
                               where F: Facade
     {

--- a/src/program/compute.rs
+++ b/src/program/compute.rs
@@ -32,13 +32,13 @@ pub struct ComputeShader {
 impl ComputeShader {
     /// Returns true if the backend supports compute shaders.
     #[inline]
-    pub fn is_supported<C>(ctxt: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_supported<C: ?Sized>(ctxt: &C) -> bool where C: CapabilitiesSource {
         check_shader_type_compatibility(ctxt, gl::COMPUTE_SHADER)
     }
 
     /// Builds a new compute shader from some source code.
     #[inline]
-    pub fn from_source<F>(facade: &F, src: &str) -> Result<ComputeShader, ProgramCreationError>
+    pub fn from_source<F: ?Sized>(facade: &F, src: &str) -> Result<ComputeShader, ProgramCreationError>
                           where F: Facade
     {
         let _lock = COMPILER_GLOBAL_LOCK.lock();
@@ -52,7 +52,7 @@ impl ComputeShader {
 
     /// Builds a new compute shader from some binary.
     #[inline]
-    pub fn from_binary<F>(facade: &F, data: Binary) -> Result<ComputeShader, ProgramCreationError>
+    pub fn from_binary<F: ?Sized>(facade: &F, data: Binary) -> Result<ComputeShader, ProgramCreationError>
                           where F: Facade
     {
         let _lock = COMPILER_GLOBAL_LOCK.lock();

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -23,26 +23,26 @@ mod binary_header;
 
 /// Returns true if the backend supports geometry shaders.
 #[inline]
-pub fn is_geometry_shader_supported<C>(ctxt: &C) -> bool where C: CapabilitiesSource {
+pub fn is_geometry_shader_supported<C: ?Sized>(ctxt: &C) -> bool where C: CapabilitiesSource {
     shader::check_shader_type_compatibility(ctxt, gl::GEOMETRY_SHADER)
 }
 
 /// Returns true if the backend supports tessellation shaders.
 #[inline]
-pub fn is_tessellation_shader_supported<C>(ctxt: &C) -> bool where C: CapabilitiesSource {
+pub fn is_tessellation_shader_supported<C: ?Sized>(ctxt: &C) -> bool where C: CapabilitiesSource {
     shader::check_shader_type_compatibility(ctxt, gl::TESS_CONTROL_SHADER)
 }
 
 /// Returns true if the backend supports creating and retreiving binary format.
 #[inline]
-pub fn is_binary_supported<C>(ctxt: &C) -> bool where C: CapabilitiesSource {
+pub fn is_binary_supported<C: ?Sized>(ctxt: &C) -> bool where C: CapabilitiesSource {
     ctxt.get_version() >= &Version(Api::Gl, 4, 1) || ctxt.get_version() >= &Version(Api::GlEs, 2, 0)
         || ctxt.get_extensions().gl_arb_get_programy_binary
 }
 
 /// Returns true if the backend supports shader subroutines.
 #[inline]
-pub fn is_subroutine_supported<C>(ctxt: &C) -> bool where C: CapabilitiesSource {
+pub fn is_subroutine_supported<C: ?Sized>(ctxt: &C) -> bool where C: CapabilitiesSource {
     // WORKAROUND: Windows only; NVIDIA doesn't actually return a valid function pointer for
     //              GetProgramStageiv despite supporting ARB_shader_subroutine; see #1439
     if cfg!(target_os = "windows")

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -36,7 +36,7 @@ pub struct Program {
 
 impl Program {
     /// Builds a new program.
-    pub fn new<'a, F, I>(facade: &F, input: I) -> Result<Program, ProgramCreationError>
+    pub fn new<'a, F: ?Sized, I>(facade: &F, input: I) -> Result<Program, ProgramCreationError>
                          where I: Into<ProgramCreationInput<'a>>, F: Facade
     {
         let input = input.into();
@@ -134,7 +134,7 @@ impl Program {
     /// ```
     ///
     #[inline]
-    pub fn from_source<'a, F>(facade: &F, vertex_shader: &'a str, fragment_shader: &'a str,
+    pub fn from_source<'a, F: ?Sized>(facade: &F, vertex_shader: &'a str, fragment_shader: &'a str,
                               geometry_shader: Option<&'a str>)
                               -> Result<Program, ProgramCreationError> where F: Facade
     {

--- a/src/program/raw.rs
+++ b/src/program/raw.rs
@@ -68,7 +68,7 @@ pub struct RawProgram {
 impl RawProgram {
     /// Builds a new program from a list of shaders.
     // TODO: the "has_*" parameters are bad
-    pub fn from_shaders<'a, F, I>(facade: &'a F, shaders: I, has_geometry_shader: bool,
+    pub fn from_shaders<'a, F: ?Sized, I>(facade: &'a F, shaders: I, has_geometry_shader: bool,
                                   has_tessellation_control_shader: bool,
                                   has_tessellation_evaluation_shader: bool,
                                   transform_feedback: Option<(Vec<String>, TransformFeedbackMode)>)
@@ -198,7 +198,7 @@ impl RawProgram {
     }
 
     /// Creates a program from binary.
-    pub fn from_binary<F>(facade: &F, binary: Binary)
+    pub fn from_binary<F: ?Sized>(facade: &F, binary: Binary)
                           -> Result<RawProgram, ProgramCreationError> where F: Facade
     {
         let (has_geometry_shader, has_tessellation_control_shader, has_tessellation_evaluation_shader) = {

--- a/src/program/shader.rs
+++ b/src/program/shader.rs
@@ -51,7 +51,7 @@ impl Drop for Shader {
 }
 
 /// Builds an individual shader.
-pub fn build_shader<F>(facade: &F, shader_type: gl::types::GLenum, source_code: &str)
+pub fn build_shader<F: ?Sized>(facade: &F, shader_type: gl::types::GLenum, source_code: &str)
                        -> Result<Shader, ProgramCreationError> where F: Facade
 {
     unsafe {
@@ -182,7 +182,7 @@ pub fn build_shader<F>(facade: &F, shader_type: gl::types::GLenum, source_code: 
     }
 }
 
-pub fn check_shader_type_compatibility<C>(ctxt: &C, shader_type: gl::types::GLenum)
+pub fn check_shader_type_compatibility<C: ?Sized>(ctxt: &C, shader_type: gl::types::GLenum)
                                           -> bool where C: CapabilitiesSource
 {
     match shader_type {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -36,7 +36,7 @@ pub struct SyncFence {
 impl SyncFence {
     /// Builds a new `SyncFence` that is injected in the server.
     #[inline]
-    pub fn new<F>(facade: &F) -> Result<SyncFence, SyncNotSupportedError> where F: Facade {
+    pub fn new<F: ?Sized>(facade: &F) -> Result<SyncFence, SyncNotSupportedError> where F: Facade {
         let mut ctxt = facade.get_context().make_current();
         unsafe { new_linear_sync_fence(&mut ctxt) }.map(|f| f.into_sync_fence(facade))
     }
@@ -83,7 +83,7 @@ unsafe impl Send for LinearSyncFence {}
 impl LinearSyncFence {
     /// Turns the prototype into a real fence.
     #[inline]
-    pub fn into_sync_fence<F>(mut self, facade: &F) -> SyncFence where F: Facade {
+    pub fn into_sync_fence<F: ?Sized>(mut self, facade: &F) -> SyncFence where F: Facade {
         SyncFence {
             context: facade.get_context().clone(),
             id: self.id.take()

--- a/src/texture/any.rs
+++ b/src/texture/any.rs
@@ -125,7 +125,7 @@ unsafe fn generate_mipmaps(ctxt: &CommandContext,
 /// # Panic
 ///
 /// Panicks if the size of the data doesn't match the texture dimensions.
-pub fn new_texture<'a, F, P>(facade: &F, format: TextureFormatRequest,
+pub fn new_texture<'a, F: ?Sized, P>(facade: &F, format: TextureFormatRequest,
                              data: Option<(ClientFormatAny, Cow<'a, [P]>)>,
                              mipmaps: MipmapsOption, ty: Dimensions)
                              -> Result<TextureAny, TextureCreationError>
@@ -461,7 +461,7 @@ pub fn new_texture<'a, F, P>(facade: &F, format: TextureFormatRequest,
 /// If `owned` is true, this reference will take ownership of the texture and be responsible
 /// for cleaning it up. Otherwise, the texture must be cleaned up externally, but only
 /// after this reference's lifetime has ended.
-pub unsafe fn from_id<F: Facade>(facade: &F,
+pub unsafe fn from_id<F: Facade + ?Sized>(facade: &F,
                                  format: TextureFormatRequest,
                                  id: gl::types::GLuint,
                                  owned: bool,

--- a/src/texture/buffer_texture.rs
+++ b/src/texture/buffer_texture.rs
@@ -192,7 +192,7 @@ pub struct BufferTexture<T> where [T]: BufferContent {
 impl<T> BufferTexture<T> where [T]: BufferContent, T: TextureBufferContent + Copy {
     /// Builds a new texture buffer from data.
     #[inline]
-    pub fn new<F>(facade: &F, data: &[T], ty: BufferTextureType)
+    pub fn new<F: ?Sized>(facade: &F, data: &[T], ty: BufferTextureType)
                   -> Result<BufferTexture<T>, CreationError>
                   where F: Facade
     {
@@ -201,7 +201,7 @@ impl<T> BufferTexture<T> where [T]: BufferContent, T: TextureBufferContent + Cop
 
     /// Builds a new texture buffer from data.
     #[inline]
-    pub fn dynamic<F>(facade: &F, data: &[T], ty: BufferTextureType)
+    pub fn dynamic<F: ?Sized>(facade: &F, data: &[T], ty: BufferTextureType)
                   -> Result<BufferTexture<T>, CreationError>
                       where F: Facade
     {
@@ -210,7 +210,7 @@ impl<T> BufferTexture<T> where [T]: BufferContent, T: TextureBufferContent + Cop
 
     /// Builds a new texture buffer from data.
     #[inline]
-    pub fn persistent<F>(facade: &F, data: &[T], ty: BufferTextureType)
+    pub fn persistent<F: ?Sized>(facade: &F, data: &[T], ty: BufferTextureType)
                   -> Result<BufferTexture<T>, CreationError>
                          where F: Facade
     {
@@ -219,7 +219,7 @@ impl<T> BufferTexture<T> where [T]: BufferContent, T: TextureBufferContent + Cop
 
     /// Builds a new texture buffer from data.
     #[inline]
-    pub fn immutable<F>(facade: &F, data: &[T], ty: BufferTextureType)
+    pub fn immutable<F: ?Sized>(facade: &F, data: &[T], ty: BufferTextureType)
                         -> Result<BufferTexture<T>, CreationError>
                         where F: Facade
     {
@@ -227,7 +227,7 @@ impl<T> BufferTexture<T> where [T]: BufferContent, T: TextureBufferContent + Cop
     }
 
     #[inline]
-    fn new_impl<F>(facade: &F, data: &[T], mode: BufferMode, ty: BufferTextureType)
+    fn new_impl<F: ?Sized>(facade: &F, data: &[T], mode: BufferMode, ty: BufferTextureType)
                    -> Result<BufferTexture<T>, CreationError>
                    where F: Facade
     {
@@ -237,7 +237,7 @@ impl<T> BufferTexture<T> where [T]: BufferContent, T: TextureBufferContent + Cop
 
     /// Builds a new empty buffer buffer.
     #[inline]
-    pub fn empty<F>(facade: &F, len: usize, ty: BufferTextureType)
+    pub fn empty<F: ?Sized>(facade: &F, len: usize, ty: BufferTextureType)
                     -> Result<BufferTexture<T>, CreationError>
                     where F: Facade
     {
@@ -246,7 +246,7 @@ impl<T> BufferTexture<T> where [T]: BufferContent, T: TextureBufferContent + Cop
 
     /// Builds a new empty buffer buffer.
     #[inline]
-    pub fn empty_dynamic<F>(facade: &F, len: usize, ty: BufferTextureType)
+    pub fn empty_dynamic<F: ?Sized>(facade: &F, len: usize, ty: BufferTextureType)
                             -> Result<BufferTexture<T>, CreationError>
                             where F: Facade
     {
@@ -255,7 +255,7 @@ impl<T> BufferTexture<T> where [T]: BufferContent, T: TextureBufferContent + Cop
 
     /// Builds a new empty buffer buffer.
     #[inline]
-    pub fn empty_persistent<F>(facade: &F, len: usize, ty: BufferTextureType)
+    pub fn empty_persistent<F: ?Sized>(facade: &F, len: usize, ty: BufferTextureType)
                                -> Result<BufferTexture<T>, CreationError>
                                where F: Facade
     {
@@ -264,7 +264,7 @@ impl<T> BufferTexture<T> where [T]: BufferContent, T: TextureBufferContent + Cop
 
     /// Builds a new empty buffer buffer.
     #[inline]
-    pub fn empty_immutable<F>(facade: &F, len: usize, ty: BufferTextureType)
+    pub fn empty_immutable<F: ?Sized>(facade: &F, len: usize, ty: BufferTextureType)
                               -> Result<BufferTexture<T>, CreationError>
                               where F: Facade
     {
@@ -272,7 +272,7 @@ impl<T> BufferTexture<T> where [T]: BufferContent, T: TextureBufferContent + Cop
     }
 
     #[inline]
-    fn empty_impl<F>(facade: &F, len: usize, ty: BufferTextureType, mode: BufferMode)
+    fn empty_impl<F: ?Sized>(facade: &F, len: usize, ty: BufferTextureType, mode: BufferMode)
                      -> Result<BufferTexture<T>, CreationError>
                      where F: Facade
     {
@@ -281,7 +281,7 @@ impl<T> BufferTexture<T> where [T]: BufferContent, T: TextureBufferContent + Cop
     }
 
     /// Builds a new buffer texture by taking ownership of a buffer.
-    pub fn from_buffer<F>(context: &F, buffer: Buffer<[T]>, ty: BufferTextureType)
+    pub fn from_buffer<F: ?Sized>(context: &F, buffer: Buffer<[T]>, ty: BufferTextureType)
                           -> Result<BufferTexture<T>, (TextureCreationError, Buffer<[T]>)>
                           where F: Facade
     {

--- a/src/texture/pixel_buffer.rs
+++ b/src/texture/pixel_buffer.rs
@@ -28,7 +28,7 @@ pub struct PixelBuffer<T> where T: PixelValue {
 impl<T> PixelBuffer<T> where T: PixelValue {
     /// Builds a new buffer with an uninitialized content.
     #[inline]
-    pub fn new_empty<F>(facade: &F, capacity: usize) -> PixelBuffer<T> where F: Facade {
+    pub fn new_empty<F: ?Sized>(facade: &F, capacity: usize) -> PixelBuffer<T> where F: Facade {
         PixelBuffer {
             buffer: Buffer::empty_array(facade, BufferType::PixelPackBuffer, capacity,
                                             BufferMode::Default).unwrap(),

--- a/src/texture/ty_support.rs
+++ b/src/texture/ty_support.rs
@@ -6,7 +6,7 @@ use version::Version;
 
 /// Returns true is one-dimensional textures are supported.
 #[inline]
-pub fn is_texture_1d_supported<C>(context: &C) -> bool where C: CapabilitiesSource {
+pub fn is_texture_1d_supported<C: ?Sized>(context: &C) -> bool where C: CapabilitiesSource {
     context.get_version() >= &Version(Api::Gl, 1, 1)
 }
 
@@ -15,13 +15,13 @@ pub fn is_texture_1d_supported<C>(context: &C) -> bool where C: CapabilitiesSour
 /// This is a dummy function that always returns true, as 2d textures are always supported. This
 /// function is just here for completeness.
 #[inline]
-pub fn is_texture_2d_supported<C>(_: &C) -> bool where C: CapabilitiesSource {
+pub fn is_texture_2d_supported<C: ?Sized>(_: &C) -> bool where C: CapabilitiesSource {
     true
 }
 
 /// Returns true is three-dimensional textures are supported.
 #[inline]
-pub fn is_texture_3d_supported<C>(context: &C) -> bool where C: CapabilitiesSource {
+pub fn is_texture_3d_supported<C: ?Sized>(context: &C) -> bool where C: CapabilitiesSource {
     context.get_version() >= &Version(Api::Gl, 1, 2) ||
     context.get_version() >= &Version(Api::GlEs, 3, 0) ||
     context.get_extensions().gl_ext_texture3d ||        // FIXME: functions have an EXT suffix, this isn't handled by glium
@@ -30,14 +30,14 @@ pub fn is_texture_3d_supported<C>(context: &C) -> bool where C: CapabilitiesSour
 
 /// Returns true is one-dimensional texture arrays are supported.
 #[inline]
-pub fn is_texture_1d_array_supported<C>(context: &C) -> bool where C: CapabilitiesSource {
+pub fn is_texture_1d_array_supported<C: ?Sized>(context: &C) -> bool where C: CapabilitiesSource {
     context.get_version() >= &Version(Api::Gl, 3, 0) ||
     context.get_extensions().gl_ext_texture_array
 }
 
 /// Returns true is two-dimensional texture arrays are supported.
 #[inline]
-pub fn is_texture_2d_array_supported<C>(context: &C) -> bool where C: CapabilitiesSource {
+pub fn is_texture_2d_array_supported<C: ?Sized>(context: &C) -> bool where C: CapabilitiesSource {
     context.get_version() >= &Version(Api::Gl, 3, 0) ||
     context.get_version() >= &Version(Api::GlEs, 3, 0) ||
     context.get_extensions().gl_ext_texture_array ||
@@ -46,7 +46,7 @@ pub fn is_texture_2d_array_supported<C>(context: &C) -> bool where C: Capabiliti
 
 /// Returns true is two-dimensional multisample textures are supported.
 #[inline]
-pub fn is_texture_2d_multisample_supported<C>(context: &C) -> bool where C: CapabilitiesSource {
+pub fn is_texture_2d_multisample_supported<C: ?Sized>(context: &C) -> bool where C: CapabilitiesSource {
     context.get_version() >= &Version(Api::Gl, 3, 2) ||
     context.get_version() >= &Version(Api::GlEs, 3, 1) ||
     context.get_extensions().gl_arb_texture_multisample
@@ -55,7 +55,7 @@ pub fn is_texture_2d_multisample_supported<C>(context: &C) -> bool where C: Capa
 
 /// Returns true is two-dimensional multisample texture arrays are supported.
 #[inline]
-pub fn is_texture_2d_multisample_array_supported<C>(context: &C) -> bool
+pub fn is_texture_2d_multisample_array_supported<C: ?Sized>(context: &C) -> bool
                                                     where C: CapabilitiesSource
 {
     context.get_version() >= &Version(Api::Gl, 3, 2) ||
@@ -65,7 +65,7 @@ pub fn is_texture_2d_multisample_array_supported<C>(context: &C) -> bool
 
 /// Returns true is cubemaps are supported.
 #[inline]
-pub fn is_cubemaps_supported<C>(context: &C) -> bool where C: CapabilitiesSource {
+pub fn is_cubemaps_supported<C: ?Sized>(context: &C) -> bool where C: CapabilitiesSource {
     context.get_version() >= &Version(Api::Gl, 1, 3) ||
     context.get_version() >= &Version(Api::GlEs, 2, 0) ||
     context.get_extensions().gl_ext_texture_cube_map ||
@@ -74,7 +74,7 @@ pub fn is_cubemaps_supported<C>(context: &C) -> bool where C: CapabilitiesSource
 
 /// Returns true is cubemap arrays are supported.
 #[inline]
-pub fn is_cubemap_arrays_supported<C>(context: &C) -> bool where C: CapabilitiesSource {
+pub fn is_cubemap_arrays_supported<C: ?Sized>(context: &C) -> bool where C: CapabilitiesSource {
     context.get_version() >= &Version(Api::Gl, 4, 0) ||
     context.get_extensions().gl_arb_texture_cube_map_array ||
     context.get_extensions().gl_ext_texture_cube_map_array ||

--- a/src/uniforms/buffer.rs
+++ b/src/uniforms/buffer.rs
@@ -34,7 +34,7 @@ impl<T: ?Sized + Content> GlObject for UniformBuffer<T> {
 impl<T> UniformBuffer<T> where T: Copy {
     /// Uploads data in the uniforms buffer.
     #[inline]
-    pub fn new<F>(facade: &F, data: T) -> Result<UniformBuffer<T>, BufferCreationError>
+    pub fn new<F: ?Sized>(facade: &F, data: T) -> Result<UniformBuffer<T>, BufferCreationError>
                   where F: Facade
     {
         UniformBuffer::new_impl(facade, data, BufferMode::Default)
@@ -42,7 +42,7 @@ impl<T> UniformBuffer<T> where T: Copy {
 
     /// Uploads data in the uniforms buffer.
     #[inline]
-    pub fn dynamic<F>(facade: &F, data: T) -> Result<UniformBuffer<T>, BufferCreationError>
+    pub fn dynamic<F: ?Sized>(facade: &F, data: T) -> Result<UniformBuffer<T>, BufferCreationError>
                       where F: Facade
     {
         UniformBuffer::new_impl(facade, data, BufferMode::Dynamic)
@@ -50,7 +50,7 @@ impl<T> UniformBuffer<T> where T: Copy {
 
     /// Uploads data in the uniforms buffer.
     #[inline]
-    pub fn persistent<F>(facade: &F, data: T) -> Result<UniformBuffer<T>, BufferCreationError>
+    pub fn persistent<F: ?Sized>(facade: &F, data: T) -> Result<UniformBuffer<T>, BufferCreationError>
                   where F: Facade
     {
         UniformBuffer::new_impl(facade, data, BufferMode::Persistent)
@@ -58,14 +58,14 @@ impl<T> UniformBuffer<T> where T: Copy {
 
     /// Uploads data in the uniforms buffer.
     #[inline]
-    pub fn immutable<F>(facade: &F, data: T) -> Result<UniformBuffer<T>, BufferCreationError>
+    pub fn immutable<F: ?Sized>(facade: &F, data: T) -> Result<UniformBuffer<T>, BufferCreationError>
                         where F: Facade
     {
         UniformBuffer::new_impl(facade, data, BufferMode::Immutable)
     }
 
     #[inline]
-    fn new_impl<F>(facade: &F, data: T, mode: BufferMode)
+    fn new_impl<F: ?Sized>(facade: &F, data: T, mode: BufferMode)
                    -> Result<UniformBuffer<T>, BufferCreationError>
                    where F: Facade
     {
@@ -78,13 +78,13 @@ impl<T> UniformBuffer<T> where T: Copy {
 
     /// Creates an empty buffer.
     #[inline]
-    pub fn empty<F>(facade: &F) -> Result<UniformBuffer<T>, BufferCreationError> where F: Facade {
+    pub fn empty<F: ?Sized>(facade: &F) -> Result<UniformBuffer<T>, BufferCreationError> where F: Facade {
         UniformBuffer::empty_impl(facade, BufferMode::Default)
     }
 
     /// Creates an empty buffer.
     #[inline]
-    pub fn empty_dynamic<F>(facade: &F) -> Result<UniformBuffer<T>, BufferCreationError>
+    pub fn empty_dynamic<F: ?Sized>(facade: &F) -> Result<UniformBuffer<T>, BufferCreationError>
                             where F: Facade
     {
         UniformBuffer::empty_impl(facade, BufferMode::Dynamic)
@@ -92,7 +92,7 @@ impl<T> UniformBuffer<T> where T: Copy {
 
     /// Creates an empty buffer.
     #[inline]
-    pub fn empty_persistent<F>(facade: &F) -> Result<UniformBuffer<T>, BufferCreationError>
+    pub fn empty_persistent<F: ?Sized>(facade: &F) -> Result<UniformBuffer<T>, BufferCreationError>
                                where F: Facade
     {
         UniformBuffer::empty_impl(facade, BufferMode::Persistent)
@@ -100,14 +100,14 @@ impl<T> UniformBuffer<T> where T: Copy {
 
     /// Creates an empty buffer.
     #[inline]
-    pub fn empty_immutable<F>(facade: &F) -> Result<UniformBuffer<T>, BufferCreationError>
+    pub fn empty_immutable<F: ?Sized>(facade: &F) -> Result<UniformBuffer<T>, BufferCreationError>
                               where F: Facade
     {
         UniformBuffer::empty_impl(facade, BufferMode::Immutable)
     }
 
     #[inline]
-    fn empty_impl<F>(facade: &F, mode: BufferMode) -> Result<UniformBuffer<T>, BufferCreationError>
+    fn empty_impl<F: ?Sized>(facade: &F, mode: BufferMode) -> Result<UniformBuffer<T>, BufferCreationError>
                      where F: Facade
     {
         let buffer = try!(Buffer::empty(facade, BufferType::UniformBuffer, mode));
@@ -126,7 +126,7 @@ impl<T: ?Sized> UniformBuffer<T> where T: Content {
     /// Panicks if the size passed as parameter is not suitable for the type of data.
     ///
     #[inline]
-    pub fn empty_unsized<F>(facade: &F, size: usize)
+    pub fn empty_unsized<F: ?Sized>(facade: &F, size: usize)
                             -> Result<UniformBuffer<T>, BufferCreationError>
                             where F: Facade
     {
@@ -140,7 +140,7 @@ impl<T: ?Sized> UniformBuffer<T> where T: Content {
     /// Panicks if the size passed as parameter is not suitable for the type of data.
     ///
     #[inline]
-    pub fn empty_unsized_dynamic<F>(facade: &F, size: usize)
+    pub fn empty_unsized_dynamic<F: ?Sized>(facade: &F, size: usize)
                                     -> Result<UniformBuffer<T>, BufferCreationError>
                                     where F: Facade
     {
@@ -154,7 +154,7 @@ impl<T: ?Sized> UniformBuffer<T> where T: Content {
     /// Panicks if the size passed as parameter is not suitable for the type of data.
     ///
     #[inline]
-    pub fn empty_unsized_persistent<F>(facade: &F, size: usize)
+    pub fn empty_unsized_persistent<F: ?Sized>(facade: &F, size: usize)
                                        -> Result<UniformBuffer<T>, BufferCreationError>
                                        where F: Facade
     {
@@ -168,7 +168,7 @@ impl<T: ?Sized> UniformBuffer<T> where T: Content {
     /// Panicks if the size passed as parameter is not suitable for the type of data.
     ///
     #[inline]
-    pub fn empty_unsized_immutable<F>(facade: &F, size: usize)
+    pub fn empty_unsized_immutable<F: ?Sized>(facade: &F, size: usize)
                                       -> Result<UniformBuffer<T>, BufferCreationError>
                                       where F: Facade
     {
@@ -176,7 +176,7 @@ impl<T: ?Sized> UniformBuffer<T> where T: Content {
     }
 
     #[inline]
-    fn empty_unsized_impl<F>(facade: &F, size: usize, mode: BufferMode)
+    fn empty_unsized_impl<F: ?Sized>(facade: &F, size: usize, mode: BufferMode)
                              -> Result<UniformBuffer<T>, BufferCreationError>
                              where F: Facade
     {

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -131,7 +131,7 @@ impl<T> VertexBuffer<T> where T: Vertex {
     /// ```
     ///
     #[inline]
-    pub fn new<F>(facade: &F, data: &[T]) -> Result<VertexBuffer<T>, CreationError>
+    pub fn new<F: ?Sized>(facade: &F, data: &[T]) -> Result<VertexBuffer<T>, CreationError>
                   where F: Facade
     {
         VertexBuffer::new_impl(facade, data, BufferMode::Default)
@@ -141,7 +141,7 @@ impl<T> VertexBuffer<T> where T: Vertex {
     ///
     /// This function will create a buffer that is intended to be modified frequently.
     #[inline]
-    pub fn dynamic<F>(facade: &F, data: &[T]) -> Result<VertexBuffer<T>, CreationError>
+    pub fn dynamic<F: ?Sized>(facade: &F, data: &[T]) -> Result<VertexBuffer<T>, CreationError>
                       where F: Facade
     {
         VertexBuffer::new_impl(facade, data, BufferMode::Dynamic)
@@ -149,7 +149,7 @@ impl<T> VertexBuffer<T> where T: Vertex {
 
     /// Builds a new vertex buffer.
     #[inline]
-    pub fn persistent<F>(facade: &F, data: &[T]) -> Result<VertexBuffer<T>, CreationError>
+    pub fn persistent<F: ?Sized>(facade: &F, data: &[T]) -> Result<VertexBuffer<T>, CreationError>
                          where F: Facade
     {
         VertexBuffer::new_impl(facade, data, BufferMode::Persistent)
@@ -157,14 +157,14 @@ impl<T> VertexBuffer<T> where T: Vertex {
 
     /// Builds a new vertex buffer.
     #[inline]
-    pub fn immutable<F>(facade: &F, data: &[T]) -> Result<VertexBuffer<T>, CreationError>
+    pub fn immutable<F: ?Sized>(facade: &F, data: &[T]) -> Result<VertexBuffer<T>, CreationError>
                         where F: Facade
     {
         VertexBuffer::new_impl(facade, data, BufferMode::Immutable)
     }
 
     #[inline]
-    fn new_impl<F>(facade: &F, data: &[T], mode: BufferMode)
+    fn new_impl<F: ?Sized>(facade: &F, data: &[T], mode: BufferMode)
                    -> Result<VertexBuffer<T>, CreationError>
                    where F: Facade
     {
@@ -180,7 +180,7 @@ impl<T> VertexBuffer<T> where T: Vertex {
     ///
     /// The parameter indicates the number of elements.
     #[inline]
-    pub fn empty<F>(facade: &F, elements: usize) -> Result<VertexBuffer<T>, CreationError>
+    pub fn empty<F: ?Sized>(facade: &F, elements: usize) -> Result<VertexBuffer<T>, CreationError>
                     where F: Facade
     {
         VertexBuffer::empty_impl(facade, elements, BufferMode::Default)
@@ -190,7 +190,7 @@ impl<T> VertexBuffer<T> where T: Vertex {
     ///
     /// The parameter indicates the number of elements.
     #[inline]
-    pub fn empty_dynamic<F>(facade: &F, elements: usize) -> Result<VertexBuffer<T>, CreationError>
+    pub fn empty_dynamic<F: ?Sized>(facade: &F, elements: usize) -> Result<VertexBuffer<T>, CreationError>
                             where F: Facade
     {
         VertexBuffer::empty_impl(facade, elements, BufferMode::Dynamic)
@@ -200,7 +200,7 @@ impl<T> VertexBuffer<T> where T: Vertex {
     ///
     /// The parameter indicates the number of elements.
     #[inline]
-    pub fn empty_persistent<F>(facade: &F, elements: usize)
+    pub fn empty_persistent<F: ?Sized>(facade: &F, elements: usize)
                                -> Result<VertexBuffer<T>, CreationError>
                                where F: Facade
     {
@@ -211,14 +211,14 @@ impl<T> VertexBuffer<T> where T: Vertex {
     ///
     /// The parameter indicates the number of elements.
     #[inline]
-    pub fn empty_immutable<F>(facade: &F, elements: usize) -> Result<VertexBuffer<T>, CreationError>
+    pub fn empty_immutable<F: ?Sized>(facade: &F, elements: usize) -> Result<VertexBuffer<T>, CreationError>
                               where F: Facade
     {
         VertexBuffer::empty_impl(facade, elements, BufferMode::Immutable)
     }
 
     #[inline]
-    fn empty_impl<F>(facade: &F, elements: usize, mode: BufferMode)
+    fn empty_impl<F: ?Sized>(facade: &F, elements: usize, mode: BufferMode)
                      -> Result<VertexBuffer<T>, CreationError>
                      where F: Facade
     {
@@ -264,7 +264,7 @@ impl<T> VertexBuffer<T> where T: Copy {
     /// ```
     ///
     #[inline]
-    pub unsafe fn new_raw<F>(facade: &F, data: &[T],
+    pub unsafe fn new_raw<F: ?Sized>(facade: &F, data: &[T],
                              bindings: VertexFormat, elements_size: usize)
                              -> Result<VertexBuffer<T>, CreationError>
                              where F: Facade
@@ -280,7 +280,7 @@ impl<T> VertexBuffer<T> where T: Copy {
 
     /// Dynamic version of `new_raw`.
     #[inline]
-    pub unsafe fn new_raw_dynamic<F>(facade: &F, data: &[T],
+    pub unsafe fn new_raw_dynamic<F: ?Sized>(facade: &F, data: &[T],
                                      bindings: VertexFormat, elements_size: usize)
                                      -> Result<VertexBuffer<T>, CreationError>
                                      where F: Facade

--- a/src/vertex/format.rs
+++ b/src/vertex/format.rs
@@ -151,7 +151,7 @@ pub enum AttributeType {
 
 impl AttributeType {
     /// Returns true if the backend supports this type of attribute.
-    pub fn is_supported<C>(&self, caps: &C) -> bool where C: CapabilitiesSource {
+    pub fn is_supported<C: ?Sized>(&self, caps: &C) -> bool where C: CapabilitiesSource {
         match self {    
             &AttributeType::I8 | &AttributeType::I8I8 | &AttributeType::I8I8I8 |
             &AttributeType::I8I8I8I8 | &AttributeType::U8 | &AttributeType::U8U8 |

--- a/src/vertex/mod.rs
+++ b/src/vertex/mod.rs
@@ -305,7 +305,7 @@ pub trait Vertex: Copy + Sized {
     fn build_bindings() -> VertexFormat;
 
     /// Returns true if the backend supports this vertex format.
-    fn is_supported<C>(caps: &C) -> bool where C: CapabilitiesSource {
+    fn is_supported<C: ?Sized>(caps: &C) -> bool where C: CapabilitiesSource {
         let format = Self::build_bindings();
 
         for &(_, _, ref ty) in format.iter() {
@@ -325,7 +325,7 @@ pub unsafe trait Attribute: Sized {
 
     /// Returns true if the backend supports this type of attribute.
     #[inline]
-    fn is_supported<C>(caps: &C) -> bool where C: CapabilitiesSource {
+    fn is_supported<C: ?Sized>(caps: &C) -> bool where C: CapabilitiesSource {
         Self::get_type().is_supported(caps)
     }
 }

--- a/src/vertex/transform_feedback.rs
+++ b/src/vertex/transform_feedback.rs
@@ -126,7 +126,7 @@ impl Error for TransformFeedbackSessionCreationError {
 
 /// Returns true if transform feedback is supported by the OpenGL implementation.
 #[inline]
-pub fn is_transform_feedback_supported<F>(facade: &F) -> bool where F: Facade {
+pub fn is_transform_feedback_supported<F: ?Sized>(facade: &F) -> bool where F: Facade {
     let context = facade.get_context();
 
     context.get_version() >= &Version(Api::Gl, 3, 0) ||
@@ -139,7 +139,7 @@ impl<'a> TransformFeedbackSession<'a> {
     ///
     /// TODO: this constructor should ultimately support passing multiple buffers of different
     ///       types
-    pub fn new<F, V>(facade: &F, program: &'a Program, buffer: &'a mut Buffer<[V]>)
+    pub fn new<F: ?Sized, V>(facade: &F, program: &'a Program, buffer: &'a mut Buffer<[V]>)
                      -> Result<TransformFeedbackSession<'a>, TransformFeedbackSessionCreationError>
                      where F: Facade, V: Vertex + Copy + Send + 'static
     {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -75,7 +75,7 @@ fn parse_version() -> glutin::GlRequest {
 }
 
 /// Builds a 2x2 unicolor texture.
-pub fn build_unicolor_texture2d<F>(facade: &F, red: f32, green: f32, blue: f32)
+pub fn build_unicolor_texture2d<F: ?Sized>(facade: &F, red: f32, green: f32, blue: f32)
     -> glium::Texture2d where F: Facade
 {
     let color = ((red * 255.0) as u8, (green * 255.0) as u8, (blue * 255.0) as u8);
@@ -87,7 +87,7 @@ pub fn build_unicolor_texture2d<F>(facade: &F, red: f32, green: f32, blue: f32)
 }
 
 /// Builds a vertex buffer, index buffer, and program, to draw red `(1.0, 0.0, 0.0, 1.0)` to the whole screen.
-pub fn build_fullscreen_red_pipeline<F>(facade: &F) -> (glium::vertex::VertexBufferAny,
+pub fn build_fullscreen_red_pipeline<F: ?Sized>(facade: &F) -> (glium::vertex::VertexBufferAny,
     glium::index::IndexBufferAny, glium::Program) where F: Facade
 {
     #[derive(Copy, Clone)]
@@ -149,7 +149,7 @@ pub fn build_fullscreen_red_pipeline<F>(facade: &F) -> (glium::vertex::VertexBuf
 /// Builds a vertex buffer and an index buffer corresponding to a rectangle.
 ///
 /// The vertex buffer has the "position" attribute of type "vec2".
-pub fn build_rectangle_vb_ib<F>(facade: &F)
+pub fn build_rectangle_vb_ib<F: ?Sized>(facade: &F)
     -> (glium::vertex::VertexBufferAny, glium::index::IndexBufferAny) where F: Facade
 {
     #[derive(Copy, Clone)]
@@ -170,6 +170,6 @@ pub fn build_rectangle_vb_ib<F>(facade: &F)
 }
 
 /// Builds a texture suitable for rendering.
-pub fn build_renderable_texture<F>(facade: &F) -> glium::Texture2d where F: Facade {
+pub fn build_renderable_texture<F: ?Sized>(facade: &F) -> glium::Texture2d where F: Facade {
     glium::Texture2d::empty(facade, 1024, 1024).unwrap()
 }


### PR DESCRIPTION
Add ?Sized to all Facade generic parameters in order to enable dynamic
dispatch as well as static dispatch. (Allows passing a &Facade trait
object to the relevant functions.)