### PR TITLE
Fix image orientation in screenshot example

### DIFF
--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -118,7 +118,7 @@ fn main() {
     // reading the front buffer into an image
     let image: glium::texture::RawImage2d<u8> = display.read_front_buffer();
     let image = image::ImageBuffer::from_raw(image.width, image.height, image.data.into_owned()).unwrap();
-    let image = image::DynamicImage::ImageRgba8(image);
+    let image = image::DynamicImage::ImageRgba8(image).flipv();
     let mut output = std::fs::File::create(&Path::new("glium-example-screenshot.png")).unwrap();
     image.save(&mut output, image::ImageFormat::PNG).unwrap();
 }


### PR DESCRIPTION
The triangle should point upward given its coordinates.

But glReadPixels returns pixels starting from the bottom left corner, so we need to flip vertically in order to get a correct image.