### PR TITLE
Use arrays consistently to represent RGBA colors

### DIFF
--- a/src/framebuffer/default_fb.rs
+++ b/src/framebuffer/default_fb.rs
@@ -56,7 +56,7 @@ impl DefaultFramebuffer {
 
 impl Surface for DefaultFramebuffer {
     #[inline]
-    fn clear(&mut self, rect: Option<&Rect>, color: Option<(f32, f32, f32, f32)>, color_srgb: bool,
+    fn clear(&mut self, rect: Option<&Rect>, color: Option<[f32; 4]>, color_srgb: bool,
              depth: Option<f32>, stencil: Option<i32>)
     {
         // TODO: wrong attachment

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -267,7 +267,7 @@ impl<'a> SimpleFrameBuffer<'a> {
 
 impl<'a> Surface for SimpleFrameBuffer<'a> {
     #[inline]
-    fn clear(&mut self, rect: Option<&Rect>, color: Option<(f32, f32, f32, f32)>, color_srgb: bool,
+    fn clear(&mut self, rect: Option<&Rect>, color: Option<[f32; 4]>, color_srgb: bool,
              depth: Option<f32>, stencil: Option<i32>)
     {
         ops::clear(&self.context, Some(&self.attachments), rect, color, color_srgb, depth, stencil);
@@ -534,7 +534,7 @@ impl<'a> MultiOutputFrameBuffer<'a> {
 
 impl<'a> Surface for MultiOutputFrameBuffer<'a> {
     #[inline]
-    fn clear(&mut self, rect: Option<&Rect>, color: Option<(f32, f32, f32, f32)>, color_srgb: bool,
+    fn clear(&mut self, rect: Option<&Rect>, color: Option<[f32; 4]>, color_srgb: bool,
              depth: Option<f32>, stencil: Option<i32>)
     {
         ops::clear(&self.context, Some(&self.example_attachments), rect,
@@ -704,7 +704,7 @@ impl<'a> EmptyFrameBuffer {
 
 impl Surface for EmptyFrameBuffer {
     #[inline]
-    fn clear(&mut self, rect: Option<&Rect>, color: Option<(f32, f32, f32, f32)>, color_srgb: bool,
+    fn clear(&mut self, rect: Option<&Rect>, color: Option<[f32; 4]>, color_srgb: bool,
              depth: Option<f32>, stencil: Option<i32>)
     {
         ops::clear(&self.context, Some(&self.attachments), rect, color, color_srgb, depth, stencil);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -665,17 +665,17 @@ pub struct BlitTarget {
 ///
 pub trait Surface {
     /// Clears some attachments of the target.
-    fn clear(&mut self, rect: Option<&Rect>, color: Option<(f32, f32, f32, f32)>, color_srgb: bool,
+    fn clear(&mut self, rect: Option<&Rect>, color: Option<[f32; 4]>, color_srgb: bool,
              depth: Option<f32>, stencil: Option<i32>);
 
     /// Clears the color attachment of the target.
-    fn clear_color(&mut self, red: f32, green: f32, blue: f32, alpha: f32) {
-        self.clear(None, Some((red, green, blue, alpha)), false, None, None);
+    fn clear_color(&mut self, color: [f32; 4]) {
+        self.clear(None, Some(color), false, None, None);
     }
 
     /// Clears the color attachment of the target. The color is in sRGB format.
-    fn clear_color_srgb(&mut self, red: f32, green: f32, blue: f32, alpha: f32) {
-        self.clear(None, Some((red, green, blue, alpha)), true, None, None);
+    fn clear_color_srgb(&mut self, color: [f32; 4]) {
+        self.clear(None, Some(color), true, None, None);
     }
 
     /// Clears the depth attachment of the target.
@@ -689,22 +689,22 @@ pub trait Surface {
     }
 
     /// Clears the color and depth attachments of the target.
-    fn clear_color_and_depth(&mut self, color: (f32, f32, f32, f32), depth: f32) {
+    fn clear_color_and_depth(&mut self, color: [f32; 4], depth: f32) {
         self.clear(None, Some(color), false, Some(depth), None);
     }
 
     /// Clears the color and depth attachments of the target. The color is in sRGB format.
-    fn clear_color_srgb_and_depth(&mut self, color: (f32, f32, f32, f32), depth: f32) {
+    fn clear_color_srgb_and_depth(&mut self, color: [f32; 4], depth: f32) {
         self.clear(None, Some(color), true, Some(depth), None);
     }
 
     /// Clears the color and stencil attachments of the target.
-    fn clear_color_and_stencil(&mut self, color: (f32, f32, f32, f32), stencil: i32) {
+    fn clear_color_and_stencil(&mut self, color: [f32; 4], stencil: i32) {
         self.clear(None, Some(color), false, None, Some(stencil));
     }
 
     /// Clears the color and stencil attachments of the target. The color is in sRGB format.
-    fn clear_color_srgb_and_stencil(&mut self, color: (f32, f32, f32, f32), stencil: i32) {
+    fn clear_color_srgb_and_stencil(&mut self, color: [f32; 4], stencil: i32) {
         self.clear(None, Some(color), true, None, Some(stencil));
     }
 
@@ -714,12 +714,12 @@ pub trait Surface {
     }
 
     /// Clears the color, depth and stencil attachments of the target.
-    fn clear_all(&mut self, color: (f32, f32, f32, f32), depth: f32, stencil: i32) {
+    fn clear_all(&mut self, color: [f32; 4], depth: f32, stencil: i32) {
         self.clear(None, Some(color), false, Some(depth), Some(stencil));
     }
 
     /// Clears the color, depth and stencil attachments of the target. The color is in sRGB format.
-    fn clear_all_srgb(&mut self, color: (f32, f32, f32, f32), depth: f32, stencil: i32) {
+    fn clear_all_srgb(&mut self, color: [f32; 4], depth: f32, stencil: i32) {
         self.clear(None, Some(color), true, Some(depth), Some(stencil));
     }
 
@@ -1122,7 +1122,7 @@ impl Frame {
 
 impl Surface for Frame {
     #[inline]
-    fn clear(&mut self, rect: Option<&Rect>, color: Option<(f32, f32, f32, f32)>, color_srgb: bool,
+    fn clear(&mut self, rect: Option<&Rect>, color: Option<[f32; 4]>, color_srgb: bool,
              depth: Option<f32>, stencil: Option<i32>)
     {
         ops::clear(&self.context, None, None, color, color_srgb, depth, stencil);

--- a/src/ops/clear.rs
+++ b/src/ops/clear.rs
@@ -15,7 +15,7 @@ use gl;
 
 
 pub fn clear(context: &Context, framebuffer: Option<&ValidatedAttachments>,
-             rect: Option<&Rect>, color: Option<(f32, f32, f32, f32)>, color_srgb: bool,
+             rect: Option<&Rect>, color: Option<[f32; 4]>, color_srgb: bool,
              depth: Option<f32>, stencil: Option<i32>)
 {
     unsafe {
@@ -73,8 +73,8 @@ pub fn clear(context: &Context, framebuffer: Option<&ValidatedAttachments>,
         let mut flags = 0;
 
         if let Some(color) = color {
-            let color = (color.0 as gl::types::GLclampf, color.1 as gl::types::GLclampf,
-                         color.2 as gl::types::GLclampf, color.3 as gl::types::GLclampf);
+            let color = (color[0] as gl::types::GLclampf, color[1] as gl::types::GLclampf,
+                         color[2] as gl::types::GLclampf, color[3] as gl::types::GLclampf);
 
             flags |= gl::COLOR_BUFFER_BIT;
 


### PR DESCRIPTION
It seems overkill to have to write:
```rust
target.clear_color_srgb(BACKGROUND_COLOR[0], BACKGROUND_COLOR[1],
                        BACKGROUND_COLOR[2], BACKGROUND_COLOR[3]);
```