### PR TITLE
Allow OpenGL ES 3.0+ to use Sampler Objects

### DIFF
--- a/src/sampler_object.rs
+++ b/src/sampler_object.rs
@@ -20,6 +20,7 @@ impl SamplerObject {
     pub fn new(ctxt: &mut CommandContext, behavior: &SamplerBehavior) -> SamplerObject {
         // making sure that the backend supports samplers
         assert!(ctxt.version >= &Version(Api::Gl, 3, 2) ||
+                ctxt.version >= &Version(Api::GlEs, 3, 0) ||
                 ctxt.extensions.gl_arb_sampler_objects);
 
         let sampler = unsafe {
@@ -58,7 +59,7 @@ impl SamplerObject {
         }
     }
 
-    /// 
+    ///
     #[inline]
     pub fn destroy(mut self, ctxt: &mut CommandContext) {
         self.destroyed = true;

--- a/src/uniforms/bind.rs
+++ b/src/uniforms/bind.rs
@@ -647,6 +647,7 @@ fn bind_texture_uniform<P, T>(mut ctxt: &mut context::CommandContext,
 
         if ctxt.state.texture_units[texture_unit as usize].sampler != sampler {
             assert!(ctxt.version >= &Version(Api::Gl, 3, 3) ||
+                    ctxt.version >= &Version(Api::GlEs, 3, 0) ||
                     ctxt.extensions.gl_arb_sampler_objects);
 
             unsafe { ctxt.gl.BindSampler(texture_unit as gl::types::GLenum, sampler); }


### PR DESCRIPTION
Fixes #1497.