### PR TITLE
Make examples run on Mac OS X

### DIFF
--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -6,14 +6,12 @@ extern crate image;
 use glium::glutin;
 use glium::index::PrimitiveType;
 use glium::Surface;
-use glium::DisplayBuild;
 use std::io::Cursor;
 
 mod support;
 
 fn main() {
     use cgmath::SquareMatrix;
-    use glium::DisplayBuild;
 
     // building the display, ie. the main object
     let display = glutin::WindowBuilder::new()

--- a/examples/screenshot-asynchronous.rs
+++ b/examples/screenshot-asynchronous.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 #[macro_use]
 extern crate glium;
 extern crate image;

--- a/examples/tutorial-08.rs
+++ b/examples/tutorial-08.rs
@@ -14,7 +14,7 @@ fn main() {
                                           &teapot::INDICES).unwrap();
 
     let vertex_shader_src = r#"
-        #version 140
+        #version 150
 
         in vec3 position;
         in vec3 normal;
@@ -30,7 +30,7 @@ fn main() {
     "#;
 
     let fragment_shader_src = r#"
-        #version 140
+        #version 150
 
         in vec3 v_normal;
         out vec4 color;

--- a/examples/tutorial-09.rs
+++ b/examples/tutorial-09.rs
@@ -16,7 +16,7 @@ fn main() {
                                           &teapot::INDICES).unwrap();
 
     let vertex_shader_src = r#"
-        #version 140
+        #version 150
 
         in vec3 position;
         in vec3 normal;
@@ -32,7 +32,7 @@ fn main() {
     "#;
 
     let fragment_shader_src = r#"
-        #version 140
+        #version 150
 
         in vec3 v_normal;
         out vec4 color;

--- a/examples/tutorial-10.rs
+++ b/examples/tutorial-10.rs
@@ -16,7 +16,7 @@ fn main() {
                                           &teapot::INDICES).unwrap();
 
     let vertex_shader_src = r#"
-        #version 140
+        #version 150
 
         in vec3 position;
         in vec3 normal;
@@ -33,7 +33,7 @@ fn main() {
     "#;
 
     let fragment_shader_src = r#"
-        #version 140
+        #version 150
 
         in vec3 v_normal;
         out vec4 color;

--- a/examples/tutorial-12.rs
+++ b/examples/tutorial-12.rs
@@ -16,7 +16,7 @@ fn main() {
                                           &teapot::INDICES).unwrap();
 
     let vertex_shader_src = r#"
-        #version 140
+        #version 150
 
         in vec3 position;
         in vec3 normal;
@@ -35,7 +35,7 @@ fn main() {
     "#;
 
     let fragment_shader_src = r#"
-        #version 140
+        #version 150
 
         in vec3 v_normal;
         out vec4 color;

--- a/examples/tutorial-13.rs
+++ b/examples/tutorial-13.rs
@@ -16,7 +16,7 @@ fn main() {
                                           &teapot::INDICES).unwrap();
 
     let vertex_shader_src = r#"
-        #version 140
+        #version 150
 
         in vec3 position;
         in vec3 normal;
@@ -37,7 +37,7 @@ fn main() {
     "#;
 
     let fragment_shader_src = r#"
-        #version 140
+        #version 150
 
         in vec3 v_normal;
         in vec3 v_position;

--- a/examples/tutorial-14.rs
+++ b/examples/tutorial-14.rs
@@ -42,7 +42,7 @@ fn main() {
 
 
     let vertex_shader_src = r#"
-        #version 140
+        #version 150
 
         in vec3 position;
         in vec3 normal;


### PR DESCRIPTION
Also remove some unused symbols.

With these changes all examples but the ones listed below run on my Mac OS X 10.11.5 Early 2013 MacBook Pro. I cannot say if they also output the correct visuals since I did not read all code.

The following do not work (properly?):
- gpgpu: Crashes with 'not yet implemented', in glutin-0.6.2/src/api/cocoa/headless.rs:60
- picking: runs, but only displays a black window.
- screenshot-asynchronous: runs, but does not create a screenshot. Crashes on
  window close with: 'The `Frame` object must be explicitly destroyed by
  calling `.finish()`', src/lib.rs:1221