### PR TITLE
Add support for vertex normalization.

### DIFF
--- a/src/vertex/format.rs
+++ b/src/vertex/format.rs
@@ -405,9 +405,12 @@ impl AttributeType {
 
 /// Describes the layout of each vertex in a vertex buffer.
 ///
-/// The first element is the name of the binding, the second element is the offset
-/// from the start of each vertex to this element, and the third element is the type.
-pub type VertexFormat = Cow<'static, [(Cow<'static, str>, usize, AttributeType)]>;
+/// The first element is the name of the binding, the second element
+/// is the offset from the start of each vertex to this element, the
+/// third element is the type and the fourth element indicates whether
+/// or not the element should use fixed-point normalization when
+/// binding in a VAO.
+pub type VertexFormat = Cow<'static, [(Cow<'static, str>, usize, AttributeType, bool)]>;
 
 unsafe impl Attribute for i8 {
     #[inline]

--- a/src/vertex/mod.rs
+++ b/src/vertex/mod.rs
@@ -308,7 +308,7 @@ pub trait Vertex: Copy + Sized {
     fn is_supported<C: ?Sized>(caps: &C) -> bool where C: CapabilitiesSource {
         let format = Self::build_bindings();
 
-        for &(_, _, ref ty) in format.iter() {
+        for &(_, _, ref ty, _) in format.iter() {
             if !ty.is_supported(caps) {
                 return false;
             }


### PR DESCRIPTION
Normalization enables better packing of vertex data. This closes #1313.

This is probably not the cleanest way to do it, but it's the best I could think of.

My first approach was to have a wrapper struct that marked that the data should be used with normalization. The problem is rust doesn't guarantee the memory layout of 'newtype' style structs.

I also would have liked if this could have used the same "arm" as the old implement_vertex. But I couldn't figure out how to make that work.