### PR TITLE
Take reference instead of Vec in RawImage2d::from_raw_rgb(a)_reversed() to avoid extra copy

### DIFF
--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -465,7 +465,7 @@ impl<'a, T: Clone + 'a> RawImage2d<'a, T> {
     /// Builds a raw image from a vector of interleaved RGB values, flipping it vertically.
     ///
     /// The first pixel is at (0, 1), the last pixel is at (1, 0).
-    pub fn from_raw_rgb_reversed(data: Vec<T>, dimensions: (u32, u32)) -> RawImage2d<'a, T>
+    pub fn from_raw_rgb_reversed(data: &[T], dimensions: (u32, u32)) -> RawImage2d<'a, T>
         where T: ToClientFormat {
         let data = data
             .chunks(dimensions.0 as usize * 3)
@@ -480,7 +480,7 @@ impl<'a, T: Clone + 'a> RawImage2d<'a, T> {
     /// Builds a raw image from a vector of interleaved RGBA values, flipping it vertically.
     ///
     /// The first pixel is at (0, 1), the last pixel is at (1, 0).
-    pub fn from_raw_rgba_reversed(data: Vec<T>, dimensions: (u32, u32)) -> RawImage2d<'a, T>
+    pub fn from_raw_rgba_reversed(data: &[T], dimensions: (u32, u32)) -> RawImage2d<'a, T>
         where T: ToClientFormat {
         let data = data
             .chunks(dimensions.0 as usize * 4)


### PR DESCRIPTION
The from_raw_rgb(a)_reversed() functions do a copy but take a Vec<T> and thus may require copying if the calling code needs the original data back. Change them to a &[T] which works fine and avoids the issue.