### PR TITLE
Added support for OpenGL primitive index restarting - fixes #180

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glium"
-version = "0.16.1"
+version = "0.16.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = """
 Elegant and safe OpenGL wrapper.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glium"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = """
 Elegant and safe OpenGL wrapper.

--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -5,7 +5,7 @@ extern crate image;
 
 use glium::glutin;
 use glium::index::PrimitiveType;
-use glium::Surface;
+use glium::{DisplayBuild, Surface};
 use std::io::Cursor;
 
 mod support;

--- a/examples/info.rs
+++ b/examples/info.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate glium;
 
 fn main() {

--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -45,6 +45,9 @@ pub struct GlState {
     /// Whether GL_POLYGON_OFFSET_FILL is enabled
     pub enabled_polygon_offset_fill: bool,
 
+    /// Whether GL_PRIMITIVE_RESTART_FIXED_INDEX is enabled
+    pub enabled_primitive_fixed_restart: bool,
+
     /// Whether GL_RASTERIZER_DISCARD is enabled
     pub enabled_rasterizer_discard: bool,
 
@@ -380,8 +383,9 @@ impl Default for GlState {
             enabled_stencil_test: false,
             enabled_line_smooth: false,
             enabled_polygon_smooth: false,
+            enabled_primitive_fixed_restart: false,
             enabled_program_point_size: false,
-
+            
             program: Handle::Id(0),
             vertex_array: 0,
             clear_color: (0.0, 0.0, 0.0, 0.0),

--- a/src/draw_parameters/mod.rs
+++ b/src/draw_parameters/mod.rs
@@ -496,6 +496,7 @@ pub fn sync(ctxt: &mut context::CommandContext, draw_parameters: &DrawParameters
     try!(sync_smooth(ctxt, draw_parameters.smooth, primitives_types));
     try!(sync_provoking_vertex(ctxt, draw_parameters.provoking_vertex));
     sync_primitive_bounding_box(ctxt, &draw_parameters.primitive_bounding_box);
+    try!(sync_primitive_restart_index(ctxt, draw_parameters.primitive_restart_index));
 
     Ok(())
 }

--- a/src/draw_parameters/mod.rs
+++ b/src/draw_parameters/mod.rs
@@ -381,9 +381,10 @@ pub struct DrawParameters<'a> {
     pub primitive_bounding_box: (Range<f32>, Range<f32>, Range<f32>, Range<f32>),
     
     /// If enabled, will split the index buffer (if any is used in the draw call) 
-    /// at the MAX value of the IndexType (u8::MAX, u16::MAX or u32::MAX) start a new primitive
-    /// of the same type ("primitive restarting"). Supported on > OpenGL 3.1 or OpenGL ES 3.0 - 
-    /// otherwise, enabling this has no effect.
+    /// at the MAX value of the IndexType (u8::MAX, u16::MAX or u32::MAX) and start a new primitive
+    /// of the same type ("primitive restarting"). Supported on > OpenGL 3.1 or OpenGL ES 3.0. 
+    /// If the backend does not support GL_PRIMITIVE_RESTART_FIXED_INDEX, an Error 
+    /// of type `FixedIndexRestartingNotSupported` will be returned.
     pub primitive_restart_index: bool,
 }
 
@@ -896,6 +897,8 @@ fn sync_primitive_restart_index(ctxt: &mut context::CommandContext,
                                 enabled: bool)
                                 -> Result<(), DrawError>
 {
+    // TODO: use GL_PRIMITIVE_RESTART (if possible) if 
+    // GL_PRIMITIVE_RESTART_FIXED_INDEX is not supported
     if ctxt.version >= &Version(Api::Gl, 3, 1)   || ctxt.version >= &Version(Api::GlEs, 3, 0) ||
        ctxt.extensions.gl_arb_es3_compatibility
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -931,6 +931,9 @@ pub enum DrawError {
 
     /// One of the blending parameters is not supported by the backend.
     BlendingParameterNotSupported,
+
+    /// Restarting indices (multiple objects per draw call) is not supported by the backend.
+    FixedIndexRestartingNotSupported,
 }
 
 impl Error for DrawError {
@@ -987,6 +990,8 @@ impl Error for DrawError {
                 "The depth clamp mode is not supported by the backend",
             BlendingParameterNotSupported =>
                 "One the blending parameters is not supported by the backend",
+            FixedIndexRestartingNotSupported =>
+                "Restarting indices (multiple objects per draw call) is not supported by the backend",
         }
     }
 

--- a/tests/draw_parameters.rs
+++ b/tests/draw_parameters.rs
@@ -1279,3 +1279,134 @@ fn primitive_bounding_box() {
 
     display.assert_no_error(None);
 }
+
+#[test]
+fn primitive_restart_index() {
+
+    let display = support::build_display();
+
+    // make two horizontal lines
+    // on failure, they will connect like a z
+    // on success, they will connect like a =
+
+    let vertex_buffer = {
+
+        #[derive(Copy, Clone)]
+        struct Vertex {
+            position: (f32, f32, f32),
+        }
+
+        implement_vertex!(Vertex, position);
+
+        glium::VertexBuffer::new(&display, &[
+            // lower line
+            Vertex { position: (-0.5, -0.5, 0.0) },
+            Vertex { position: ( 0.5, -0.5, 0.0) },
+            // upper line
+            Vertex { position: (-0.5,  0.5, 0.0) },
+            Vertex { position: ( 0.5,  0.5, 0.0) },
+        ]).unwrap()
+    };
+
+    let index_buffer = glium::IndexBuffer::<u8>::new(&display, glium::index::PrimitiveType::LineStrip, 
+                                                     &[0, 1, 255, 2, 3]).unwrap();
+    let program = program!(&display,
+        140 => {
+            vertex: "
+                #version 140
+
+                in vec3 position;
+
+                void main() {
+                    gl_Position = vec4(position, 1.0);
+                }
+            ",
+            fragment: "
+                #version 140
+
+                out vec4 color;
+                void main() {
+                    color = vec4(1.0, 0.0, 0.0, 1.0);
+                }
+            "
+        },
+        110 => {
+            vertex: "
+                #version 110
+
+                attribute vec3 position;
+
+                void main() {
+                    gl_Position = vec4(position, 1.0);
+                }
+            ",
+            fragment: "
+                #version 110
+
+                void main() {
+                    gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+                }
+            "
+        },
+        100 => {
+            vertex: "
+                #version 100
+
+                attribute lowp vec3 position;
+
+                void main() {
+                    gl_Position = vec4(position, 1.0);
+                }
+            ",
+            fragment: "
+                #version 100
+
+                void main() {
+                    gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+                }
+            "
+        },
+    ).unwrap();
+
+    let texture = support::build_renderable_texture(&display);
+    texture.as_surface().clear_color(1.0, 1.0, 1.0, 1.0);
+
+    let options = glium::DrawParameters {
+           primitive_restart_index: true,
+        .. Default::default()
+    };
+
+    let res = texture.as_surface().draw(&vertex_buffer,
+        &index_buffer, &program,
+        &glium::uniforms::EmptyUniforms,
+        &options);
+
+    match res {
+        Ok(_) => (),
+        Err(glium::DrawError::DepthClampNotSupported) => {
+            display.assert_no_error(None);
+            return;
+        },
+        e => e.unwrap(),
+    }
+
+    let data: Vec<Vec<(u8, u8, u8, u8)>> = texture.read();
+
+    let tex_w = texture.get_width() as usize;
+    let tex_h = texture.get_height().unwrap() as usize;
+
+    println!("{:?} x {:?}", tex_w, tex_h);
+
+    // midpoint of the texture should be white
+    let mid_x = tex_w / 2;
+    let mid_y = tex_h / 2;
+
+    // sometimes the sampling can be a few pixels off
+    for row in (mid_y - 2)..(mid_y + 2) {
+        for pixel in (mid_x - 2)..(mid_x + 2){
+            assert_eq!(data[row][pixel], (255, 255, 255, 255));
+        }
+    }
+
+    display.assert_no_error(None);
+}

--- a/tests/draw_parameters.rs
+++ b/tests/draw_parameters.rs
@@ -1395,8 +1395,6 @@ fn primitive_restart_index() {
     let tex_w = texture.get_width() as usize;
     let tex_h = texture.get_height().unwrap() as usize;
 
-    println!("{:?} x {:?}", tex_w, tex_h);
-
     // midpoint of the texture should be white
     let mid_x = tex_w / 2;
     let mid_y = tex_h / 2;


### PR DESCRIPTION
This PR adds the missing implementation for enabling GL_PRIMITIVE_RESTART_FIXED_INDEX. For compatibility with GL ES 3.0, only fixed restart index will be supported. The unit test works by drawing two lines and seeing if they are connected (in a successful test, they should not be connected, but rather be two seperate lines). Adds a public field to the draw parameters.

If there are stylistic issues / formatting errors or questions / code review, please notify me. I also fixed some missing / unused imports, otherwise the tests would not compile.