### PR TITLE
clamp light attenuation to avoid negative outputs

### DIFF
--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -170,6 +170,7 @@ fn main() {
                         (light_attenuation.z * light_distance * light_distance)
                     );
                     attenuation_factor *= (1.0 - pow((light_distance / light_radius), 2.0));
+		    attenuation_factor = max(attenuation_factor, 0.0);
                     diffuse *= attenuation_factor;
 
                 }


### PR DESCRIPTION
while working my way through the enjoyable glium examples i noticed that the lights in the deferred test were not adding together as i'd expect.  turns out the attenuation was going negative, causing the yellow light to subtract from the red and green ones.  a minor thing but easy to fix...

before:
<img width="912" alt="before" src="https://cloud.githubusercontent.com/assets/43400/24532375/de0a7af2-1574-11e7-83fd-069c73ab4424.png">

with fix:
<img width="912" alt="with_fix" src="https://cloud.githubusercontent.com/assets/43400/24532380/e4d81e8e-1574-11e7-9985-9c2c8faa2302.png">

thanks for glium!