### PR TITLE
Provide current project state in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Glium is no longer maintained, for more information visit the [post-mortem](https://users.rust-lang.org/t/glium-post-mortem/7063).
 
+##
+
 Elegant and safe OpenGL wrapper.
 
 Glium is an intermediate layer between OpenGL and your application. You still need to manually handle

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 [![](http://meritbadge.herokuapp.com/glium)](https://crates.io/crates/glium)
 
+## Note to current and future Glium users: 
+
+Glium is no longer maintained, for more information visit the [post-mortem](https://users.rust-lang.org/t/glium-post-mortem/7063).
+
 Elegant and safe OpenGL wrapper.
 
 Glium is an intermediate layer between OpenGL and your application. You still need to manually handle


### PR DESCRIPTION
Since the project is no-longer maintained, it'd be beneficial to have that be the first thing people see when deciding to use Glium. 