### PR TITLE
Fix SAMPLES query for gles

### DIFF
--- a/src/context/capabilities.rs
+++ b/src/context/capabilities.rs
@@ -720,7 +720,7 @@ pub fn get_internal_format(gl: &gl::Gl, version: &Version, extensions: &Extensio
         let target = if renderbuffer { gl::RENDERBUFFER } else { gl::TEXTURE_2D_MULTISAMPLE };
 
         let samples = if format.is_renderable(&dummy) &&
-                         (version >= &Version(Api::GlEs, 3, 0) ||
+                         ((version >= &Version(Api::GlEs, 3, 0) && renderbuffer) ||
                           version >= &Version(Api::Gl, 4, 2) ||
                           extensions.gl_arb_internalformat_query)
         {


### PR DESCRIPTION
The [OpenGL ES 3.0 Specification](https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf) states that:

> An `INVALID_ENUM` error is generated if *internalformat* is not color-, depth- or
stencil-renderable; if *target* is not `RENDERBUFFER`; or if *pname* is not `SAMPLES` or
`NUM_SAMPLE_COUNTS`.

(Note that this is different from what the OpenGL or ARB Extension Specification say).